### PR TITLE
Modify existing kwargs dict instead of creating a new one

### DIFF
--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -102,7 +102,6 @@ class MultiKernelManager(LoggingConfigurable):
         # kernel_manager_factory is the constructor for the KernelManager
         # subclass we are using. It can be configured as any Configurable,
         # including things like its transport and ip.
-        kwargs = {}
         if self.kernel_spec_manager:
             kwargs['kernel_spec_manager'] = self.kernel_spec_manager
         km = self.kernel_manager_factory(connection_file=os.path.join(


### PR DESCRIPTION
Creating a new dict throws away any kwargs passed into the function.  For example, the working directory for the kernel is passed in, and then is ignored if we create a new kwargs dict.  The end result is that we can't set the current working directory for a kernel.