### PR TITLE
Make print function python2-compatible by importing from __future__

### DIFF
--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -2,6 +2,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from __future__ import print_function
+
 import errno
 import os.path
 


### PR DESCRIPTION
Without this, we get a syntax error on python2 in the print around line 111.