### PR TITLE
Add prefix to names that get formatted into kernel cmd

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -166,7 +166,9 @@ class KernelManager(ConnectionFileMixin):
         else:
             cmd = self.kernel_spec.argv + extra_arguments
 
-        ns = dict(connection_file=self.connection_file)
+        ns = dict(connection_file=self.connection_file,
+                  prefix=sys.prefix,
+                 )
         ns.update(self._launch_args)
 
         pat = re.compile(r'\{([A-Za-z0-9_]+)\}')


### PR DESCRIPTION
This makes it easier to make a portable Jupyter+kernels setup, because you can specify executable paths for kernels relative to the parent process' prefix, e.g. `argv: ['{prefix}/bin/R', ...]`

Closes jupyter/jupyter_notebook#53