### PR TITLE
find connection files in runtime_dir

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -27,7 +27,7 @@ from ipython_genutils.py3compat import (str_to_bytes, bytes_to_str, cast_bytes_p
 from traitlets import (
     Bool, Integer, Unicode, CaselessStrEnum, Instance,
 )
-from jupyter_core.paths import jupyter_data_dir
+from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir
 
 
 def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0,
@@ -159,7 +159,7 @@ def find_connection_file(filename='kernel-*.json', path=None):
     str : The absolute path of the connection file.
     """
     if path is None:
-        path = ['.']
+        path = ['.', jupyter_runtime_dir()]
     if isinstance(path, string_types):
         path = [path]
     

--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -153,7 +153,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
         """
         if self.existing:
             try:
-                cf = find_connection_file(self.existing)
+                cf = find_connection_file(self.existing, [self.runtime_dir])
             except Exception:
                 self.log.critical("Could not find existing kernel connection file %s", self.existing)
                 self.exit(1)
@@ -163,7 +163,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
             # not existing, check if we are going to write the file
             # and ensure that self.connection_file is a full path, not just the shortname
             try:
-                cf = find_connection_file(self.connection_file)
+                cf = find_connection_file(self.connection_file, [self.runtime_dir])
             except Exception:
                 # file might not exist
                 if self.connection_file == os.path.basename(self.connection_file):


### PR DESCRIPTION
since that's where they go

fixes `qtconsole --existing`

cc @rgbkrk