### PR TITLE
import sys because it is used.

### DIFF
--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import errno
 import os.path
+import sys
 
 from traitlets.config.application import Application
 from jupyter_core.application import (


### PR DESCRIPTION
The foloowing line for example:

> print("ipython_kernel not available, can't install its spec.", file=sys.stderr)