### PR TITLE
Clean up some naming left behinds from migration

### DIFF
--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -52,7 +52,7 @@ class InstallKernelSpec(JupyterApp):
     replace = Bool(False, config=True,
         help="Replace any existing kernel spec with this name."
     )
-    
+
     aliases = {'name': 'InstallKernelSpec.kernel_name'}
     aliases.update(base_aliases)
 
@@ -119,8 +119,8 @@ class InstallNativeKernelSpec(JupyterApp):
             self.exit(e)
 
 class KernelSpecApp(Application):
-    name = "ipython kernelspec"
-    description = """Manage IPython kernel specifications."""
+    name = "jupyter kernelspec"
+    description = """Manage Jupyter kernel specifications."""
 
     subcommands = Dict({
         'list': (ListKernelSpecs, ListKernelSpecs.description.splitlines()[0]),

--- a/jupyter_client/tests/test_adapter.py
+++ b/jupyter_client/tests/test_adapter.py
@@ -1,4 +1,4 @@
-"""Tests for adapting IPython msg spec versions"""
+"""Tests for adapting Jupyter msg spec versions"""
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.


### PR DESCRIPTION
Noticed this when running `jupyter kernelspec`.

```
$ jupyter kernelspec
No subcommand specified. Must specify one of: ['install-self', 'install', 'list']

Manage IPython kernel specifications.

Subcommands
-----------

Subcommands are launched as `ipython kernelspec cmd [args]`. For information on
using subcommand 'cmd', do: `ipython kernelspec cmd -h`.

install-self
    [DEPRECATED] Install the IPython kernel spec directory for this Python.
install
    Install a kernel specification directory.
list
    List installed kernel specifications.
```

Now it reads:

```
$ jupyter kernelspec
No subcommand specified. Must specify one of: ['list', 'install', 'install-self']

Manage Jupyter kernel specifications.

Subcommands
-----------

Subcommands are launched as `jupyter kernelspec cmd [args]`. For information on
using subcommand 'cmd', do: `jupyter kernelspec cmd -h`.

list
    List installed kernel specifications.
install
    Install a kernel specification directory.
install-self
    [DEPRECATED] Install the IPython kernel spec directory for this Python.
```
