### PR TITLE
name isn't part of inspect_reply

### DIFF
--- a/jupyter_client/adapter.py
+++ b/jupyter_client/adapter.py
@@ -319,7 +319,6 @@ class V4toV5(Adapter):
         content = msg['content']
         new_content = msg['content'] = {'status' : 'ok'}
         found = new_content['found'] = content['found']
-        new_content['name'] = content['oname']
         new_content['data'] = data = {}
         new_content['metadata'] = {}
         if found:

--- a/jupyter_client/tests/test_adapter.py
+++ b/jupyter_client/tests/test_adapter.py
@@ -155,7 +155,7 @@ class V4toV5TestCase(AdapterTest):
 
     def test_object_info_reply(self):
         msg = self.msg("object_info_reply", {
-            'oname' : 'foo',
+            'name' : 'foo',
             'found' : True,
             'status' : 'ok',
             'definition' : 'foo(a=5)',
@@ -165,9 +165,25 @@ class V4toV5TestCase(AdapterTest):
         self.assertEqual(v5['header']['msg_type'], 'inspect_reply')
         v4c = v4['content']
         v5c = v5['content']
-        self.assertEqual(sorted(v5c), [ 'data', 'found', 'metadata', 'name', 'status'])
+        self.assertEqual(sorted(v5c), [ 'data', 'found', 'metadata', 'status'])
         text = v5c['data']['text/plain']
         self.assertEqual(text, '\n'.join([v4c['definition'], v4c['docstring']]))
+
+    def test_object_info_reply_not_found(self):
+        msg = self.msg("object_info_reply", {
+            'name' : 'foo',
+            'found' : False,
+        })
+        v4, v5 = self.adapt(msg)
+        self.assertEqual(v5['header']['msg_type'], 'inspect_reply')
+        v4c = v4['content']
+        v5c = v5['content']
+        self.assertEqual(v5c, {
+            'status': 'ok',
+            'found': False,
+            'data': {},
+            'metadata': {},
+        })
 
     def test_kernel_info_reply(self):
         msg = self.msg("kernel_info_reply", {


### PR DESCRIPTION
we were adapting `oname` to `name`, which was wrong for two reasons:

1. it's actually `name` in practice, not `oname`, despite what the spec doc claimed. This caused an error during adaptation.
2. name isn't actually part of inspect_reply.