### PR TITLE
fix can"t found executable when executable changed

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -6,6 +6,7 @@
 import io
 import json
 import os
+import sys
 import shutil
 import warnings
 
@@ -37,7 +38,24 @@ class KernelSpec(HasTraits):
         kernel_file = pjoin(resource_dir, 'kernel.json')
         with io.open(kernel_file, 'r', encoding='utf-8') as f:
             kernel_dict = json.load(f)
+        kernel_dict = cls.update_newest_kernel(kernel_file, kernel_dict)
         return cls(resource_dir=resource_dir, **kernel_dict)
+
+    @classmethod
+    def update_newest_kernel(cls, kernel_file, kernel_dict):
+        """Update to the newest kernel.json when kernel"s language is python
+        """
+        if 'language' in kernel_dict and \
+           kernel_dict['language'] == 'python' and \
+           kernel_dict['argv'][0] != sys.executable:
+            kernel_dict['argv'][0] = sys.executable
+            if PY3:
+                f = io.open(kernel_file, 'w', encoding='utf-8')
+            else:
+                f = open(kernel_file, 'wb')
+            with f:
+                json.dump(kernel_dict, f)
+        return kernel_dict
 
     def to_dict(self):
         d = dict(argv=self.argv,


### PR DESCRIPTION
I updated to lastest version notebook. but can't start it. the error like this:

```python
[E 11:59:48.124 NotebookApp] Unhandled error in API request
    Traceback (most recent call last):
      File "/Users/dongweiming/notebook/jupyter_notebook/base/handlers.py", line 369, in wrapper
        result = yield gen.maybe_future(method(self, *args, **kwargs))
      File "/Users/dongweiming/notebook/jupyter_notebook/services/sessions/handlers.py", line 53, in post
        model = sm.create_session(path=path, kernel_name=kernel_name)
      File "/Users/dongweiming/notebook/jupyter_notebook/services/sessions/sessionmanager.py", line 66, in create_session
        kernel_name=kernel_name)
      File "/Users/dongweiming/notebook/jupyter_notebook/services/kernels/kernelmanager.py", line 84, in start_kernel
        **kwargs)
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/multikernelmanager.py", line 109, in start_kernel
        km.start_kernel(**kwargs)
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/manager.py", line 237, in start_kernel
        **kw)
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/manager.py", line 186, in _launch_kernel
        return launch_kernel(kernel_cmd, **kw)
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/launcher.py", line 119, in launch_kernel
        proc = Popen(cmd, **kwargs)
      File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 711, in __init__
        errread, errwrite)
      File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1308, in _execute_child
        raise child_exception
    OSError: [Errno 2] No such file or directory
```

because now my virtualenvs's executable is `~/.virtualenvs/notebook/bin/python`. but my kernel.json used the old executable `~/.virtualenvs/jupyter_notebook/bin/python`. it not update to the current executable

```python
python -c "import IPython; print(IPython.sys_info())"

{'commit_hash': u'e51e50d',
 'commit_source': 'repository',
 'default_encoding': 'UTF-8',
 'ipython_path': '/Users/dongweiming/.virtualenvs/notebook/src/ipython/IPython',
 'ipython_version': '4.0.0-dev',
 'os_name': 'posix',
 'platform': 'Darwin-13.4.0-x86_64-i386-64bit',
 'sys_executable': '/Users/dongweiming/.virtualenvs/notebook/bin/python',
 'sys_platform': 'darwin',
 'sys_version': '2.7.5 (default, Mar  9 2014, 22:15:05) \n[GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)]'}
```