### PR TITLE
fix warn exception when get local ip

### DIFF
--- a/jupyter_client/localinterfaces.py
+++ b/jupyter_client/localinterfaces.py
@@ -225,11 +225,11 @@ def _load_ips(suppress_exceptions=True):
         else:
             try:
                 return _load_ips_ip()
-            except (IOError, NoIPAddresses):
+            except (IOError, OSError, NoIPAddresses):
                 pass
             try:
                 return _load_ips_ifconfig()
-            except (IOError, NoIPAddresses):
+            except (IOError, OSError, NoIPAddresses):
                 pass
         
         # lowest priority, use gethostbyname


### PR DESCRIPTION
when i turn on debug i found this:

```python
[D 21:40:41.543 NotebookApp] Connecting to: tcp://127.0.0.1:60504
/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/localinterfaces.py:242: UserWarning: Unexpected error discovering local network interfaces: [Errno 2] No such file or directory
  warn("Unexpected error discovering local network interfaces: %s" % e)
```

```python
    Traceback (most recent call last):
      File "/Users/dongweiming/notebook/jupyter_notebook/base/handlers.py", line 369, in wrapper
        result = yield gen.maybe_future(method(self, *args, **kwargs))
      File "/Users/dongweiming/notebook/jupyter_notebook/services/sessions/handlers.py", line 53, in post
        model = sm.create_session(path=path, kernel_name=kernel_name)
      File "/Users/dongweiming/notebook/jupyter_notebook/services/sessions/sessionmanager.py", line 66, in create_session
        kernel_name=kernel_name)
      File "/Users/dongweiming/notebook/jupyter_notebook/services/kernels/kernelmanager.py", line 84, in start_kernel
        **kwargs)
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/multikernelmanager.py", line 109, in start_kernel
        km.start_kernel(**kwargs)
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/manager.py", line 213, in start_kernel
        if self.transport == 'tcp' and not is_local_ip(self.ip):
      File "/Users/dongweiming/.virtualenvs/notebook/src/traitlets/traitlets/traitlets.py", line 449, in __get__
        value = method()
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/connect.py", line 291, in _ip_default
        return localhost()
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/localinterfaces.py", line 53, in ips_loaded
        _load_ips()
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/localinterfaces.py", line 45, in wrapped
        ret = f(**kwargs)
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/localinterfaces.py", line 227, in _load_ips
        return _load_ips_ip()
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/localinterfaces.py", line 108, in _load_ips_ip
        out = _get_output(['ip', '-f', 'inet', 'addr'])
      File "/Users/dongweiming/.virtualenvs/notebook/src/jupyter-client/jupyter_client/localinterfaces.py", line 33, in _get_output
        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
      File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 711, in __init__
        errread, errwrite)
      File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1308, in _execute_child
        raise child_exception
    OSError: [Errno 2] No such file or directory
```

When i use osx. the system has not command named `ip` and raise a `OSError` exception