### PR TITLE
always replace existing installations with `kernelspec.install`

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -162,6 +162,8 @@ class KernelSpecManager(LoggingConfigurable):
             shutil.rmtree(destination)
 
         shutil.copytree(source_dir, destination)
+        self.log.info('Installed kernelspec %s in %s', kernel_name, destination)
+        return destination
 
     def install_native_kernel_spec(self, user=False):
         """DEPRECATED: Use ipykernel.kenelspec.install"""

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -152,6 +152,7 @@ class KernelSpecManager(LoggingConfigurable):
             warnings.warn(
                 "replace is ignored. Installing a kernelspec always replaces an existing installation",
                 DeprecationWarning,
+                stacklevel=2,
             )
         
         destination = self._get_destination_dir(kernel_name, user=user)

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -134,7 +134,7 @@ class KernelSpecManager(LoggingConfigurable):
 
 
     def install_kernel_spec(self, source_dir, kernel_name=None, user=False,
-                            replace=False):
+                            replace=None):
         """Install a kernel spec by copying its directory.
 
         If ``kernel_name`` is not given, the basename of ``source_dir`` will
@@ -143,19 +143,22 @@ class KernelSpecManager(LoggingConfigurable):
         If ``user`` is False, it will attempt to install into the systemwide
         kernel registry. If the process does not have appropriate permissions,
         an :exc:`OSError` will be raised.
-
-        If ``replace`` is True, this will replace an existing kernel of the same
-        name. Otherwise, if the destination already exists, an :exc:`OSError`
-        will be raised.
         """
         if not kernel_name:
             kernel_name = os.path.basename(source_dir)
         kernel_name = kernel_name.lower()
-
+        
+        if replace is not None:
+            warnings.warn(
+                "replace is ignored. Installing a kernelspec always replaces an existing installation",
+                DeprecationWarning,
+            )
+        
         destination = self._get_destination_dir(kernel_name, user=user)
-        self.log.debug('Installing kernelspec in %s'%destination)
+        self.log.debug('Installing kernelspec in %s', destination)
 
-        if replace and os.path.isdir(destination):
+        if os.path.isdir(destination):
+            self.log.info('Removing existing kernelspec in %s', destination)
             shutil.rmtree(destination)
 
         shutil.copytree(source_dir, destination)

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -77,16 +77,11 @@ class KernelSpecTests(unittest.TestCase):
                                      kernel_name='tstinstalled',
                                      user=True)
         self.assertIn('tstinstalled', self.ksm.find_kernel_specs())
-
-        with self.assertRaises(OSError):
-            self.ksm.install_kernel_spec(self.installable_kernel,
-                                         kernel_name='tstinstalled',
-                                         user=True)
-
-        # Smoketest that this succeeds
+        
+        # install again works
         self.ksm.install_kernel_spec(self.installable_kernel,
                                      kernel_name='tstinstalled',
-                                     replace=True, user=True)
+                                     user=True)
 
     @onlyif(os.name != 'nt' and not os.access('/usr/local/share', os.W_OK), "needs Unix system without root privileges")
     def test_cant_install_kernel_spec(self):


### PR DESCRIPTION
deprecate replace arg with a DeprecationWarning that nobody will ever see...

Also return the install destination for use by callers.