### PR TITLE
Don't allow PYTHONEXECUTABLE env to be inherited by kernel process

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -225,13 +225,15 @@ class KernelManager(ConnectionFileMixin):
         # build the Popen cmd
         extra_arguments = kw.pop('extra_arguments', [])
         kernel_cmd = self.format_kernel_cmd(extra_arguments=extra_arguments)
-        if self.kernel_cmd:
+        env = os.environ.copy()
+        # Don't allow PYTHONEXECUTABLE to be passed to kernel process.
+        # If set, it can bork all the things.
+        env.pop('PYTHONEXECUTABLE', None)
+        if not self.kernel_cmd:
             # If kernel_cmd has been set manually, don't refer to a kernel spec
-            env = os.environ
-        else:
             # Environment variables from kernel spec are added to os.environ
-            env = os.environ.copy()
             env.update(self.kernel_spec.env or {})
+        
         # launch the kernel subprocess
         self.kernel = self._launch_kernel(kernel_cmd, env=env,
                                     **kw)


### PR DESCRIPTION
it can break Python.

Server in one conda env with kernel in another illustrates this problem.

Symptomatic kernel output:

```
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
ImportError: No module named site
```