### PR TITLE
allow installing kernelspecs with a prefix

### DIFF
--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -49,11 +49,19 @@ class InstallKernelSpec(JupyterApp):
         the system or environment directory.
         """
     )
+    prefix = Unicode('', config=True,
+        help="""Specify a prefix to install to, e.g. an env.
+        The kernelspec will be installed in PREFIX/share/jupyter/kernels/
+        """
+    )
     replace = Bool(False, config=True,
         help="Replace any existing kernel spec with this name."
     )
 
-    aliases = {'name': 'InstallKernelSpec.kernel_name'}
+    aliases = {
+        'name': 'InstallKernelSpec.kernel_name',
+        'prefix': 'InstallKernelSpec.prefix',
+    }
     aliases.update(base_aliases)
 
     flags = {'user': ({'InstallKernelSpec': {'user': True}},
@@ -73,10 +81,13 @@ class InstallKernelSpec(JupyterApp):
             self.exit(1)
 
     def start(self):
+        if self.user and self.prefix:
+            self.exit("Can't specify both user and prefix. Please choose one or the other.")
         try:
             self.kernel_spec_manager.install_kernel_spec(self.sourcedir,
                                                  kernel_name=self.kernel_name,
                                                  user=self.user,
+                                                 prefix=self.prefix,
                                                  replace=self.replace,
                                                 )
         except OSError as e:

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -9,7 +9,12 @@ try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
-    
+
+if str is bytes: # py2
+    StringIO = io.BytesIO
+else:
+    StringIO = io.StringIO
+
 from ipython_genutils.testing.decorators import onlyif
 from ipython_genutils.tempdir import TemporaryDirectory
 from jupyter_client import kernelspec
@@ -88,7 +93,7 @@ class KernelSpecTests(unittest.TestCase):
     def test_install_kernel_spec_prefix(self):
         td = TemporaryDirectory()
         self.addCleanup(td.cleanup)
-        capture = io.StringIO()
+        capture = StringIO()
         handler = StreamHandler(capture)
         self.ksm.log.addHandler(handler)
         self.ksm.install_kernel_spec(self.installable_kernel,
@@ -104,7 +109,7 @@ class KernelSpecTests(unittest.TestCase):
         self.assertIn('tstinstalled', self.ksm.find_kernel_specs())
     
         # Run it again, no warning this time because we've added it to the path
-        capture = io.StringIO()
+        capture = StringIO()
         handler = StreamHandler(capture)
         self.ksm.log.addHandler(handler)
         self.ksm.install_kernel_spec(self.installable_kernel,

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -1,4 +1,6 @@
+import io
 import json
+from logging import StreamHandler
 import os
 from os.path import join as pjoin
 import unittest
@@ -82,6 +84,35 @@ class KernelSpecTests(unittest.TestCase):
         self.ksm.install_kernel_spec(self.installable_kernel,
                                      kernel_name='tstinstalled',
                                      user=True)
+
+    def test_install_kernel_spec_prefix(self):
+        td = TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        capture = io.StringIO()
+        handler = StreamHandler(capture)
+        self.ksm.log.addHandler(handler)
+        self.ksm.install_kernel_spec(self.installable_kernel,
+                                     kernel_name='tstinstalled',
+                                     prefix=td.name)
+        captured = capture.getvalue()
+        self.ksm.log.removeHandler(handler)
+        self.assertIn("may not be found", captured)
+        self.assertNotIn('tstinstalled', self.ksm.find_kernel_specs())
+
+        # add prefix to path, so we find the spec
+        self.ksm.kernel_dirs.append(pjoin(td.name, 'share', 'jupyter', 'kernels'))
+        self.assertIn('tstinstalled', self.ksm.find_kernel_specs())
+    
+        # Run it again, no warning this time because we've added it to the path
+        capture = io.StringIO()
+        handler = StreamHandler(capture)
+        self.ksm.log.addHandler(handler)
+        self.ksm.install_kernel_spec(self.installable_kernel,
+                                     kernel_name='tstinstalled',
+                                     prefix=td.name)
+        captured = capture.getvalue()
+        self.ksm.log.removeHandler(handler)
+        self.assertNotIn("may not be found", captured)
 
     @onlyif(os.name != 'nt' and not os.access('/usr/local/share', os.W_OK), "needs Unix system without root privileges")
     def test_cant_install_kernel_spec(self):


### PR DESCRIPTION
Makes it a little easier to put kernelspecs in virtualenvs or conda envs, and build packages for kernels.