### PR TITLE
Interrupt the kernel and its child processes

### DIFF
--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -114,6 +114,10 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None, env=None,
         if independent:
             kwargs['preexec_fn'] = lambda: os.setsid()
         else:
+            # Create a new process group. This makes it easier to
+            # interrupt the kernel, because we want to interrupt the
+            # children of the kernel process also.
+            kwargs['preexec_fn'] = lambda: os.setpgrp()
             env['JPY_PARENT_PID'] = str(os.getpid())
 
         proc = Popen(cmd, **kwargs)

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -398,11 +398,14 @@ class KernelManager(ConnectionFileMixin):
         only useful on Unix systems.
         """
         if self.has_kernel:
-            try:
-                pgid = os.getpgid(self.kernel.pid)
-                os.killpg(pgid, signum)
-            except Exception:
-                self.kernel.send_signal(signum)
+            if hasattr(os, "getpgid") and hasattr(os, "killpg"):
+                try:
+                    pgid = os.getpgid(self.kernel.pid)
+                    os.killpg(pgid, signum)
+                    return
+                except OSError:
+                    pass
+            self.kernel.send_signal(signum)
         else:
             raise RuntimeError("Cannot signal kernel. No kernel is running!")
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -400,8 +400,8 @@ class KernelManager(ConnectionFileMixin):
         if self.has_kernel:
             try:
                 pgid = os.getpgid(self.kernel.pid)
-                os.killpg(pgid, signal.SIGINT)
-            except OSError:
+                os.killpg(pgid, signum)
+            except Exception:
                 self.kernel.send_signal(signum)
         else:
             raise RuntimeError("Cannot signal kernel. No kernel is running!")


### PR DESCRIPTION
When interrupting the kernel, you usually want to interrupt the kernel process and its children also. To implement this, we run the kernel in a new process group.