### PR TITLE
add `jupyter kernelspec remove`

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -182,6 +182,25 @@ class KernelSpecManager(LoggingConfigurable):
                 "spec": self._get_kernel_spec_by_name(kname, d[kname]).to_dict()
                 } for kname in d}
 
+    def remove_kernel_spec(self, name):
+        """Remove a kernel spec directory by name.
+        
+        Returns the path that was deleted.
+        """
+        save_native = self.ensure_native_kernel
+        try:
+            self.ensure_native_kernel = False
+            specs = self.find_kernel_specs()
+        finally:
+            self.ensure_native_kernel = save_native
+        spec_dir = specs[name]
+        self.log.debug("Removing %s", spec_dir)
+        if os.path.islink(spec_dir):
+            os.remove(spec_dir)
+        else:
+            shutil.rmtree(spec_dir)
+        return spec_dir
+
     def _get_destination_dir(self, kernel_name, user=False, prefix=None):
         if user:
             return os.path.join(self.user_kernel_dir, kernel_name)

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -12,7 +12,7 @@ import warnings
 pjoin = os.path.join
 
 from ipython_genutils.py3compat import PY3
-from traitlets import HasTraits, List, Unicode, Dict, Set, Type
+from traitlets import HasTraits, List, Unicode, Dict, Set, Bool, Type
 from traitlets.config import LoggingConfigurable
 
 from jupyter_core.paths import jupyter_data_dir, jupyter_path, SYSTEM_JUPYTER_PATH
@@ -80,6 +80,12 @@ class KernelSpecManager(LoggingConfigurable):
         """
     )
 
+    ensure_native_kernel = Bool(True, config=True,
+        help="""If there is no Python kernelspec registered and the IPython
+        kernel is available, ensure it is added to the spec list.
+        """
+    )
+
     data_dir = Unicode()
     def _data_dir_default(self):
         return jupyter_data_dir()
@@ -123,7 +129,7 @@ class KernelSpecManager(LoggingConfigurable):
                     self.log.debug("Found kernel %s in %s", kname, kernel_dir)
                     d[kname] = spec
 
-        if NATIVE_KERNEL_NAME not in d:
+        if self.ensure_native_kernel and NATIVE_KERNEL_NAME not in d:
             try:
                 from ipykernel.kernelspec import RESOURCES
                 self.log.debug("Native kernel (%s) available from %s",


### PR DESCRIPTION
for removing kernelspecs

and `jupyter kernelspec uninstall` alias, for good measure.

In order to avoid removing data from the ipykernel source directory, I also added KernelSpecManager.ensure_native_kernel configurable, so that the native kernel can be excluded. This is generally useful for people who want to simply turn off that behavior (@damianavila).

closes jupyter/jupyter_core#63