### PR TITLE
Fix for: malformed message - 'datetime' not defined error

### DIFF
--- a/jupyter_client/adapter.py
+++ b/jupyter_client/adapter.py
@@ -6,6 +6,8 @@
 import re
 import json
 
+from datetime import datetime
+
 from jupyter_client import protocol_version_info
 
 


### PR DESCRIPTION
Running jupyter notebook with ijulia I got a non working system after the last update. 
The incriminating series of errors was of the form:
```
[C 11:24:59.636 NotebookApp] Malformed message: [b'status', b'<IDS|MSG>', b'f3523709959441960f28345269661ef64ae62f171d15b6803a356a88fb460998', b'{"msg_id":"2960fe5c-a66d-4a7a-a6dc-2f812f76ddab","msg_type":"status","username":"jlkernel","version":"5.0","session":"????"}', b'{"msg_id":"4386FCC4226042EBAF16A1D3E3911179","msg_type":"kernel_info_request","username":"username","version":"5.0","session":"85D1DBF1CC844A80888619E04D55EC30"}', b'{}', b'{"execution_state":"idle"}']
    Traceback (most recent call last):
      File "/usr/local/lib/python3.5/site-packages/notebook/base/zmqhandlers.py", line 184, in _on_zmq_reply
        msg = self._reserialize_reply(msg_list, channel=channel)
      File "/usr/local/lib/python3.5/site-packages/notebook/base/zmqhandlers.py", line 165, in _reserialize_reply
        msg = self.session.deserialize(msg_list)
      File "/usr/local/lib/python3.5/site-packages/jupyter_client/session.py", line 870, in deserialize
        return adapt(message)
      File "/usr/local/lib/python3.5/site-packages/jupyter_client/adapter.py", line 386, in adapt
        header['date'] = datetime.now().isoformat()
    NameError: name 'datetime' is not defined
```

This commit fixes the error by appropriately importing datetime