### PR TITLE
Stop flashing console windows on Windows

### DIFF
--- a/jupyter_client/localinterfaces.py
+++ b/jupyter_client/localinterfaces.py
@@ -30,7 +30,11 @@ def _uniq_stable(elems):
 
 def _get_output(cmd):
     """Get output of a command, raising IOError if it fails"""
-    p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+    startupinfo = None
+    if os.name == 'nt':
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    p = Popen(cmd, stdout=PIPE, stderr=PIPE, startupinfo=startupinfo)
     stdout, stderr = p.communicate()
     if p.returncode:
         raise IOError("Failed to run %s: %s" % (cmd, stderr.decode('utf8', 'replace')))


### PR DESCRIPTION
This patch makes sure that processes spawned by the Jupyter-client will have their windows hidden. This solves jupyter/jupyter#57.