### PR TITLE
require netifaces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'traitlets',
     'jupyter_core',
+    'netifaces',
     'pyzmq>=13',
 ]
 


### PR DESCRIPTION
Has always been preferred when available, but I think it's safe to require it now.

This removes the need to fallback on shelling out to subprocesses.

closes #87