### PR TITLE
test for random ports on the interface the kernel will bind to

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -93,7 +93,7 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
             sock = socket.socket()
             # struct.pack('ii', (0,0)) is 8 null bytes
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, b'\0' * 8)
-            sock.bind(('', 0))
+            sock.bind((ip, 0))
             ports.append(sock)
         for i, sock in enumerate(ports):
             port = sock.getsockname()[1]


### PR DESCRIPTION
There is no need to bind to all interfaces if the kernel is only going to use a specific one anyway.