### PR TITLE
Making the NoSuchKernel error produce a more useful error message

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -72,6 +72,9 @@ class NoSuchKernel(KeyError):
     def __init__(self, name):
         self.name = name
 
+    def __str__(self):
+        return "No such kernel named {}".format(self.name)
+
 class KernelSpecManager(LoggingConfigurable):
 
     kernel_spec_class = Type(KernelSpec, config=True,


### PR DESCRIPTION
Before if this error is raied, it just prints `NoSuchKernel`, and you need to use a debugger to see which kernel it's complaining about. Now the error message printed along with the exception will include the name of the kernel:

```
Exception occurred:
    raise NoSuchKernel(kernel_name)
NoSuchKernel: No such kernel named python3
```