### PR TITLE
start new session instead of setpgrp for detaching kernel

### DIFF
--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -27,20 +27,23 @@ class SignalTestKernel(Kernel):
     def do_execute(self, code, silent, store_history=True, user_expressions=None,
                    allow_stdin=False):
         code = code.strip()
-        reply = {'status': 'ok'}
+        reply = {
+            'status': 'ok',
+            'user_expressions': {},
+        }
         if code == 'start':
             child = Popen(['bash', '-i', '-c', 'sleep 30'], stderr=PIPE)
             self.children.append(child)
-            reply['pid'] = self.children[-1].pid
+            reply['user_expressions']['pid'] = self.children[-1].pid
         elif code == 'check':
-            reply['poll'] = [ child.poll() for child in self.children ]
+            reply['user_expressions']['poll'] = [ child.poll() for child in self.children ]
         elif code == 'sleep':
             try:
                 time.sleep(10)
             except KeyboardInterrupt:
-                reply['interrupted'] = True
+                reply['user_expressions']['interrupted'] = True
             else:
-                reply['interrupted'] = False
+                reply['user_expressions']['interrupted'] = False
         else:
             reply['status'] = 'error'
             reply['ename'] = 'Error'

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -1,0 +1,57 @@
+"""Test kernel for signalling subprocesses"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import print_function
+
+from subprocess import Popen, PIPE
+import sys
+import time
+
+from ipykernel.kernelbase import Kernel
+from ipykernel.kernelapp import IPKernelApp
+
+
+class SignalTestKernel(Kernel):
+    """Kernel for testing subprocess signaling"""
+    implementation = 'signaltest'
+    implementation_version = '0.0'
+    banner = ''
+    
+    def __init__(self, **kwargs):
+        super(SignalTestKernel, self).__init__(**kwargs)
+        self.children = []
+        
+
+    def do_execute(self, code, silent, store_history=True, user_expressions=None,
+                   allow_stdin=False):
+        code = code.strip()
+        reply = {'status': 'ok'}
+        if code == 'start':
+            child = Popen(['bash', '-i', '-c', 'sleep 30'], stderr=PIPE)
+            self.children.append(child)
+            reply['pid'] = self.children[-1].pid
+        elif code == 'check':
+            reply['poll'] = [ child.poll() for child in self.children ]
+        elif code == 'sleep':
+            try:
+                time.sleep(10)
+            except KeyboardInterrupt:
+                reply['interrupted'] = True
+            else:
+                reply['interrupted'] = False
+        else:
+            reply['status'] = 'error'
+            reply['ename'] = 'Error'
+            reply['evalue'] = code
+            reply['traceback'] = ['no such command: %s' % code]
+        return reply
+
+class SignalTestApp(IPKernelApp):
+    kernel_class = SignalTestKernel
+    def init_io(self):
+        pass # disable stdout/stderr capture
+    
+if __name__ == '__main__':
+    SignalTestApp.launch_instance()

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -101,7 +101,7 @@ class TestKernelManager(TestCase):
             execute("start")
         time.sleep(1) # make sure subprocs stay up
         reply = execute('check')
-        self.assertEqual(reply['poll'], [None] * N)
+        self.assertEqual(reply['user_expressions']['poll'], [None] * N)
         
         # start a job on the kernel to be interrupted
         kc.execute('sleep')
@@ -110,13 +110,13 @@ class TestKernelManager(TestCase):
         reply = kc.get_shell_msg(TIMEOUT)
         content = reply['content']
         self.assertEqual(content['status'], 'ok')
-        self.assertEqual(content['interrupted'], True)
+        self.assertEqual(content['user_expressions']['interrupted'], True)
         # wait up to 5s for subprocesses to handle signal
         for i in range(50):
             reply = execute('check')
-            if reply['poll'] != [-signal.SIGINT] * N:
+            if reply['user_expressions']['poll'] != [-signal.SIGINT] * N:
                 time.sleep(0.1)
             else:
                 break
         # verify that subprocesses were interrupted
-        self.assertEqual(reply['poll'], [-signal.SIGINT] * N)
+        self.assertEqual(reply['user_expressions']['poll'], [-signal.SIGINT] * N)

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -1,3 +1,8 @@
+"""Tests for the KernelSpecManager"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import io
 import json
 from logging import StreamHandler
@@ -7,11 +12,6 @@ from subprocess import Popen, PIPE, STDOUT
 import sys
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 if str is bytes: # py2
     StringIO = io.BytesIO
 else:
@@ -20,6 +20,8 @@ else:
 from ipython_genutils.testing.decorators import onlyif
 from ipython_genutils.tempdir import TemporaryDirectory
 from jupyter_client import kernelspec
+from jupyter_core import paths
+from .utils import test_env
 
 sample_kernel_json = {'argv':['cat', '{connection_file}'],
                       'display_name':'Test kernel',
@@ -37,17 +39,10 @@ class KernelSpecTests(unittest.TestCase):
         return sample_kernel_dir
     
     def setUp(self):
-        td = TemporaryDirectory()
-        self.env_patch = patch.dict(os.environ, {
-            'JUPYTER_CONFIG_DIR': pjoin(td.name, 'jupyter'),
-            'JUPYTER_DATA_DIR': pjoin(td.name, 'jupyter_data'),
-            'JUPYTER_RUNTIME_DIR': pjoin(td.name, 'jupyter_runtime'),
-            'IPYTHONDIR': pjoin(td.name, 'ipython'),
-        })
+        self.env_patch = test_env()
         self.env_patch.start()
-        self.addCleanup(td.cleanup)
         self.sample_kernel_dir = self._install_sample_kernel(
-            pjoin(td.name, 'jupyter_data', 'kernels'))
+            pjoin(paths.jupyter_data_dir(), 'kernels'))
 
         self.ksm = kernelspec.KernelSpecManager()
 

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -1,0 +1,56 @@
+"""Testing utils for jupyter_client tests
+
+"""
+import os
+pjoin = os.path.join
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from ipython_genutils.tempdir import TemporaryDirectory
+
+class test_env(object):
+    """Set Jupyter path variables to a temporary directory
+    
+    Useful as a context manager or with explicit start/stop
+    """
+    def start(self):
+        self.test_dir = td = TemporaryDirectory()
+        self.env_patch = patch.dict(os.environ, {
+            'JUPYTER_CONFIG_DIR': pjoin(td.name, 'jupyter'),
+            'JUPYTER_DATA_DIR': pjoin(td.name, 'jupyter_data'),
+            'JUPYTER_RUNTIME_DIR': pjoin(td.name, 'jupyter_runtime'),
+            'IPYTHONDIR': pjoin(td.name, 'ipython'),
+        })
+        self.env_patch.start()
+    
+    def stop(self):
+        self.env_patch.stop()
+        self.test_dir.cleanup()
+    
+    def __enter__(self):
+        self.start()
+        return self.test_dir.name
+    
+    def __exit__(self, *exc_info):
+        self.stop()
+
+def execute(code='', kc=None, **kwargs):
+    """wrapper for doing common steps for validating an execution request"""
+    from .test_message_spec import validate_message
+    if kc is None:
+        kc = KC
+    msg_id = kc.execute(code=code, **kwargs)
+    reply = kc.get_shell_msg(timeout=TIMEOUT)
+    validate_message(reply, 'execute_reply', msg_id)
+    busy = kc.get_iopub_msg(timeout=TIMEOUT)
+    validate_message(busy, 'status', msg_id)
+    nt.assert_equal(busy['content']['execution_state'], 'busy')
+
+    if not kwargs.get('silent'):
+        execute_input = kc.get_iopub_msg(timeout=TIMEOUT)
+        validate_message(execute_input, 'execute_input', msg_id)
+        nt.assert_equal(execute_input['content']['code'], code)
+
+    return msg_id, reply['content']


### PR DESCRIPTION
setpgrp seems to cause problems with children spawning subprocesses. setsid doesn't cause the same problems, but has its own issues.

This is WIP because I need to at least add some tests to exercise various subprocesses-of-subprocesses cases.

cc @takluyver who knows more about terminals and process groups than I do.