### PR TITLE
don't store signature if just peeking at headers

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -845,7 +845,9 @@ class Session(Configurable):
                 raise ValueError("Unsigned Message")
             if signature in self.digest_history:
                 raise ValueError("Duplicate Signature: %r" % signature)
-            self._add_digest(signature)
+            if content:
+                # Only store signature if we are unpacking content, don't store if just peeking.
+                self._add_digest(signature)
             check = self.sign(msg_list[1:5])
             if not compare_digest(signature, check):
                 raise ValueError("Invalid Signature: %r" % signature)


### PR DESCRIPTION
avoids duplicate signature errors if one bit of code peeks at headers, but another bit actually handles the message later.