### PR TITLE
Ditch requirements.txt, upgrade setuptools on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     
 install:
-    - pip install -f travis-wheels/wheelhouse -e . coveralls -r requirements.txt
-    - pip install  -f travis-wheels/wheelhouse jupyter_client[test]
+    - pip install -U setuptools
+    - pip install -f travis-wheels/wheelhouse -e .[test] coveralls
     - python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 script:
     - nosetests --with-coverage --cover-package jupyter_client jupyter_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
--e git+https://github.com/ipython/ipython.git#egg=ipython
--e git+https://github.com/ipython/ipykernel.git#egg=ipykernel


### PR DESCRIPTION
We no longer need a development version of IPython to test against.

The check for setuptools 18.5 seems to be breaking more stuff than I had expected.