### PR TITLE
Strip trailing path separators off kernelspec source directory

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -228,6 +228,7 @@ class KernelSpecManager(LoggingConfigurable):
         PREFIX/share/jupyter/kernels/KERNEL_NAME. This can be sys.prefix
         for installation inside virtual or conda envs.
         """
+        source_dir = source_dir.rstrip('/\\')
         if not kernel_name:
             kernel_name = os.path.basename(source_dir)
         kernel_name = kernel_name.lower()


### PR DESCRIPTION
I just discovered that if you do `jupyter kernelspec install blah/`, with the trailing slash, it replaces your entire .../kernels/ directory rather than creating a subdirectory. This is because when it finds the kernel name, it gets the empty string rather than the directory name.

This fixes that.