### PR TITLE
Timeout in start_new_kernel if kernel fails to respond

### DIFF
--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -21,7 +21,7 @@ class BlockingKernelClient(KernelClient):
         if timeout is None:
             abs_timeout = float('inf')
         else:
-            abs_timeout = time.time()
+            abs_timeout = time.time() + timeout
         # Wait for kernel info reply on shell channel
         while True:
             try:

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -430,7 +430,12 @@ def start_new_kernel(startup_timeout=60, kernel_name='python', **kwargs):
     km.start_kernel(**kwargs)
     kc = km.client()
     kc.start_channels()
-    kc.wait_for_ready()
+    try:
+        kc.wait_for_ready(timeout=startup_timeout)
+    except RuntimeError:
+        kc.stop_channels()
+        km.shutdown_kernel()
+        raise
 
     return km, kc
 


### PR DESCRIPTION
Closes jupyter/nbconvert#217

`start_new_kernel()` has a `startup_timeout` parameter, but it wasn't being used anywhere. I pass it through to `KernelClient.wait_for_ready()`, and raise RuntimeError if it times out. (Maybe should raise something else? TimeoutError? But this is for OS level operations with errno ETIMEDOUT - not sure if we should use it for arbitrary timeouts).

It also checks whether the kernel is still alive, so if the kernel has already died, we don't need to wait 60 seconds before giving up. It will still wait one second trying to get the message from the kernel.

Ping @minrk 