### PR TITLE
language_info name doc fixes

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -778,7 +778,7 @@ Message type: ``kernel_info_reply``::
 
         # Information about the language of code for the kernel
         'language_info': {
-            # Name of the programming language in which kernel is implemented.
+            # Name of the programming language that the kernel implements.
             # Kernel included in IPython returns 'python'.
             'name': str,
 

--- a/docs/wrapperkernels.rst
+++ b/docs/wrapperkernels.rst
@@ -36,7 +36,8 @@ following methods and attributes:
 
      Language information for :ref:`msging_kernel_info` replies, in a dictionary.
      This should contain the key ``mimetype`` with the mimetype of code in the
-     target language (e.g. ``'text/x-python'``), and ``file_extension`` (e.g.
+     target language (e.g. ``'text/x-python'``), the ``name`` of the language
+     being implemented (e.g. ``'python'``), and ``file_extension`` (e.g.
      ``'py'``).
      It may also contain keys ``codemirror_mode`` and ``pygments_lexer`` if they
      need to differ from :attr:`language`.


### PR DESCRIPTION
This PR solves two issues with the docs related to the `language_info` field of `kernel_info_message`:

The messaging docs suggest that `name` should be the language that implements the kernel (e.g. a python kernel written in C should use `'C'`). Is this correct?

Wrapper kernels also need to provide this field, otherwise I see an error message when trying to save files. In principle this could be provided from the `Kernel.language` field but it's not being done currently.