### PR TITLE
Avoid passing down unexpected kwargs

### DIFF
--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -104,7 +104,6 @@ class MultiKernelManager(LoggingConfigurable):
         km = self.kernel_manager_factory(connection_file=os.path.join(
                     self.connection_dir, "kernel-%s.json" % kernel_id),
                     parent=self, log=self.log, kernel_name=kernel_name,
-                    **kwargs
         )
         km.start_kernel(**kwargs)
         self._kernels[kernel_id] = km

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -99,11 +99,13 @@ class MultiKernelManager(LoggingConfigurable):
         # kernel_manager_factory is the constructor for the KernelManager
         # subclass we are using. It can be configured as any Configurable,
         # including things like its transport and ip.
+        constructor_kwargs = {}
         if self.kernel_spec_manager:
-            kwargs['kernel_spec_manager'] = self.kernel_spec_manager
+            constructor_kwargs['kernel_spec_manager'] = self.kernel_spec_manager
         km = self.kernel_manager_factory(connection_file=os.path.join(
                     self.connection_dir, "kernel-%s.json" % kernel_id),
                     parent=self, log=self.log, kernel_name=kernel_name,
+                    **constructor_kwargs
         )
         km.start_kernel(**kwargs)
         self._kernels[kernel_id] = km

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -20,6 +20,7 @@ class SignalTestKernel(Kernel):
     banner = ''
     
     def __init__(self, **kwargs):
+        kwargs.pop('user_ns', None)
         super(SignalTestKernel, self).__init__(**kwargs)
         self.children = []
         


### PR DESCRIPTION
Squashes some warnings from recent traitlets changes.

There's still another issue with KernelClient - it's passed parameters from the connection info which it doesn't use (key and signature_scheme), because it's also passed a reference to a Session object which already has those things. I'm not sure of the neatest way to resolve that.