### PR TITLE
add session flag to KernelManager.get_connection_info

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -323,9 +323,22 @@ class ConnectionFileMixin(LoggingConfigurable):
     # Connection and ipc file management
     #--------------------------------------------------------------------------
 
-    def get_connection_info(self):
-        """return the connection info as a dict"""
-        return dict(
+    def get_connection_info(self, session=False):
+        """Return the connection info as a dict
+
+        Parameters
+        ----------
+        session : bool [default: False]
+            If True, return our session object will be included in the connection info.
+            If False (default), the configuration parameters of our session object will be included,
+            rather than the session object itself.
+
+        Returns
+        -------
+        connect_info : dict
+            dictionary of connection information.
+        """
+        info = dict(
             transport=self.transport,
             ip=self.ip,
             shell_port=self.shell_port,
@@ -333,9 +346,17 @@ class ConnectionFileMixin(LoggingConfigurable):
             stdin_port=self.stdin_port,
             hb_port=self.hb_port,
             control_port=self.control_port,
-            signature_scheme=self.session.signature_scheme,
-            key=self.session.key,
         )
+        if session:
+            # add session
+            info['session'] = self.session
+        else:
+            # add session info
+            info.update(dict(
+                signature_scheme=self.session.signature_scheme,
+                key=self.session.key,
+            ))
+        return info
 
     # factory for blocking clients
     blocking_class = Type(klass=object, default_value='jupyter_client.BlockingKernelClient')

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -147,10 +147,9 @@ class KernelManager(ConnectionFileMixin):
     def client(self, **kwargs):
         """Create a client configured to connect to our kernel"""
         kw = {}
-        kw.update(self.get_connection_info())
+        kw.update(self.get_connection_info(session=True))
         kw.update(dict(
             connection_file=self.connection_file,
-            session=self.session,
             parent=self,
         ))
 


### PR DESCRIPTION
- `session=True`: include session object itself
- `session=False`: include session info only (key, signature scheme)

We were passing ignored arguments to the constructor, revealed by a recent warning added to traitlets.

related to #128