### PR TITLE
Add ability to specify the env dict for launching the kernel

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -228,7 +228,7 @@ class KernelManager(ConnectionFileMixin):
         # build the Popen cmd
         extra_arguments = kw.pop('extra_arguments', [])
         kernel_cmd = self.format_kernel_cmd(extra_arguments=extra_arguments)
-        env = os.environ.copy()
+        env = kw.pop('env', os.environ).copy()
         # Don't allow PYTHONEXECUTABLE to be passed to kernel process.
         # If set, it can bork all the things.
         env.pop('PYTHONEXECUTABLE', None)


### PR DESCRIPTION
This adds ability to use different dict other than os.environ
as the environment for launching the kernel

Fixes #117 