### PR TITLE
Prepare docs for 4.2

### DIFF
--- a/docs/api/kernelspec.rst
+++ b/docs/api/kernelspec.rst
@@ -35,6 +35,8 @@ kernelspec - discovering kernels
 
    .. automethod:: find_kernel_specs
 
+   .. automethod:: get_all_specs
+
    .. automethod:: get_kernel_spec
 
    .. automethod:: install_kernel_spec

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,21 @@
 Changes in Jupyter Client
 =========================
 
+4.2
+===
+
+4.2.0
+-----
+
+`4.2.0 on GitHub <https://github.com/jupyter/jupyter_client/milestones/4.2>`__
+
+- added :command:`jupyter kernelspec remove` for removing kernelspecs
+- allow specifying the environment for kernel processes via the ``env`` argument
+- added ``name`` field to connection files identifying the kernelspec name,
+  so that consumers of connection files (alternate frontends) can identify the kernelspec in use
+- added :meth:`KernelSpecManager.get_all_specs` for getting all kernelspecs more efficiently
+- various improvements to error messages and documentation
+
 4.1
 ===
 

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -177,7 +177,17 @@ class KernelSpecManager(LoggingConfigurable):
         return self._get_kernel_spec_by_name(kernel_name, resource_dir)
 
     def get_all_specs(self):
-        """Returns a dict mapping kernel names and resource directories.
+        """Returns a dict mapping kernel names to kernelspecs.
+
+        Returns a dict of the form::
+
+            {
+              'kernel_name': {
+                'resource_dir': '/path/to/kernel_name',
+                'spec': {"the spec itself": ...}
+              },
+              ...
+            }
         """
         d = self.find_kernel_specs()
         return {kname: {


### PR DESCRIPTION
- changelog highlights
- document get_all_specs

We should be ready to ship 4.2 after this, unless there's something anyone else would like to make sure to get in.