### PR TITLE
Add notebook path to environment variable if present in start_kernel argument list

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -228,7 +228,7 @@ class KernelManager(ConnectionFileMixin):
         # build the Popen cmd
         extra_arguments = kw.pop('extra_arguments', [])
         kernel_cmd = self.format_kernel_cmd(extra_arguments=extra_arguments)
-        notebook_name = kw.pop('notebook_name', None)
+        notebook_path = kw.pop('notebook_path', None)
         env = kw.pop('env', os.environ).copy()
         # Don't allow PYTHONEXECUTABLE to be passed to kernel process.
         # If set, it can bork all the things.
@@ -237,8 +237,8 @@ class KernelManager(ConnectionFileMixin):
             # If kernel_cmd has been set manually, don't refer to a kernel spec
             # Environment variables from kernel spec are added to os.environ
             env.update(self.kernel_spec.env or {})
-        if notebook_name is not None:
-            env['JPY_NOTEBOOK_NAME'] = notebook_name
+        if notebook_path is not None:
+            env['JPY_NOTEBOOK_PATH'] = notebook_path
         
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -228,6 +228,7 @@ class KernelManager(ConnectionFileMixin):
         # build the Popen cmd
         extra_arguments = kw.pop('extra_arguments', [])
         kernel_cmd = self.format_kernel_cmd(extra_arguments=extra_arguments)
+        notebook_name = kw.pop('notebook_name', None)
         env = kw.pop('env', os.environ).copy()
         # Don't allow PYTHONEXECUTABLE to be passed to kernel process.
         # If set, it can bork all the things.
@@ -236,11 +237,12 @@ class KernelManager(ConnectionFileMixin):
             # If kernel_cmd has been set manually, don't refer to a kernel spec
             # Environment variables from kernel spec are added to os.environ
             env.update(self.kernel_spec.env or {})
+        if notebook_name is not None:
+            env['JPY_NOTEBOOK_NAME'] = notebook_name
         
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)
-        self.kernel = self._launch_kernel(kernel_cmd, env=env,
-                                    **kw)
+        self.kernel = self._launch_kernel(kernel_cmd, env=env, **kw)
         self.start_restarter()
         self._connect_control_socket()
 


### PR DESCRIPTION
This change checks if there is a `notebook_path` keyword argument to the `KernelManager.start_kernel` method and puts it in the kernel's environment if present.  This is the first of a 2-part change (the second of which will go against `jupyter/notebook`) to make the path of the notebook you're working on generally available inside the kernel.

This is a backwards-compatible change that does not break any components that may be starting Jupyter kernels for which a "notebook path" would be either unknown or not applicable.

(Obviously the environment variable will not change when the notebook is renamed; the environment variable effectively means "the path the notebook was at when the kernel was started".)