### PR TITLE
[WIP] Travis errors when a kernel client blocks and prematurely times out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ install:
     - pip install -f travis-wheels/wheelhouse -e .[test] coveralls
     - python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
 script:
-    - nosetests --with-coverage --cover-package jupyter_client jupyter_client
+    - nosetests --verbosity=3 --with-coverage --cover-package jupyter_client jupyter_client
 after_success:
     - coveralls

--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -16,8 +16,19 @@ from jupyter_client.channels import HBChannel
 from jupyter_client.client import KernelClient
 from .channels import ZMQSocketChannel
 
+
 class BlockingKernelClient(KernelClient):
+    """A BlockingKernelClient """
+    
     def wait_for_ready(self, timeout=None):
+        """Waits for a response when a client is blocked
+        
+        - Sets future time for timeout
+        - Blocks on shell channel until a message is received
+        - Exit if the kernel has died
+        - If client times out before receiving a message from the kernel, send RuntimeError
+        - Flush the IOPub channel
+        """
         if timeout is None:
             abs_timeout = float('inf')
         else:
@@ -35,14 +46,12 @@ class BlockingKernelClient(KernelClient):
                     break
 
             if not self.is_alive():
-                print("self.is_alive: ", self.is_alive())
                 raise RuntimeError('Kernel died before replying to kernel_info')
 
             # Check if current time is ready check time plus timeout
-            time_now = time.time()
-            if now > abs_timeout:
+            if time.time() > abs_timeout:
                 print("now:")
-                print(now)
+                print(time.time())
                 print("abs_timeout:")
                 print(abs_timeout)
                 raise RuntimeError("Kernel didn't respond in %d seconds" % timeout)

--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -22,6 +22,7 @@ class BlockingKernelClient(KernelClient):
             abs_timeout = float('inf')
         else:
             abs_timeout = time.time() + timeout
+
         # Wait for kernel info reply on shell channel
         while True:
             try:
@@ -36,6 +37,7 @@ class BlockingKernelClient(KernelClient):
             if not self.is_alive():
                 raise RuntimeError('Kernel died before replying to kernel_info')
 
+            # Check if current time is ready check time plus timeout
             if time.time() > abs_timeout:
                 raise RuntimeError("Kernel didn't respond in %d seconds" % timeout)
 

--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -35,10 +35,16 @@ class BlockingKernelClient(KernelClient):
                     break
 
             if not self.is_alive():
+                print("self.is_alive: ", self.is_alive())
                 raise RuntimeError('Kernel died before replying to kernel_info')
 
             # Check if current time is ready check time plus timeout
-            if time.time() > abs_timeout:
+            time_now = time.time()
+            if now < abs_timeout:
+                print("now:")
+                print(now)
+                print("abs_timeout:")
+                print(abs_timeout)
                 raise RuntimeError("Kernel didn't respond in %d seconds" % timeout)
 
         # Flush IOPub channel

--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -36,7 +36,7 @@ class BlockingKernelClient(KernelClient):
             if not self.is_alive():
                 raise RuntimeError('Kernel died before replying to kernel_info')
 
-            if time.time() < abs_timeout:
+            if time.time() > abs_timeout:
                 raise RuntimeError("Kernel didn't respond in %d seconds" % timeout)
 
         # Flush IOPub channel

--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -40,7 +40,7 @@ class BlockingKernelClient(KernelClient):
 
             # Check if current time is ready check time plus timeout
             time_now = time.time()
-            if now < abs_timeout:
+            if now > abs_timeout:
                 print("now:")
                 print(now)
                 print("abs_timeout:")


### PR DESCRIPTION
It looks like from the Travis logs of nbgrader and kernel gateway (when tests are run at verbosity=3) that the client was timing out prematurely. The logs seemed to indicate wait_for_ready().

I believe that there's a typo in the inequality.

Probably should add a test to cover the line with inequality.

Debug prints still need to be removed.
cc/@minrk, @takluyver, @jhamrick, @parente 