### PR TITLE
Fixes for starting a new kernel

### DIFF
--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -22,6 +22,7 @@ class BlockingKernelClient(KernelClient):
             abs_timeout = float('inf')
         else:
             abs_timeout = time.time() + timeout
+
         # Wait for kernel info reply on shell channel
         while True:
             try:
@@ -36,7 +37,8 @@ class BlockingKernelClient(KernelClient):
             if not self.is_alive():
                 raise RuntimeError('Kernel died before replying to kernel_info')
 
-            if time.time() < abs_timeout:
+            # Check if current time is ready check time plus timeout
+            if time.time() > abs_timeout:
                 raise RuntimeError("Kernel didn't respond in %d seconds" % timeout)
 
         # Flush IOPub channel

--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -16,8 +16,19 @@ from jupyter_client.channels import HBChannel
 from jupyter_client.client import KernelClient
 from .channels import ZMQSocketChannel
 
+
 class BlockingKernelClient(KernelClient):
+    """A BlockingKernelClient """
+    
     def wait_for_ready(self, timeout=None):
+        """Waits for a response when a client is blocked
+        
+        - Sets future time for timeout
+        - Blocks on shell channel until a message is received
+        - Exit if the kernel has died
+        - If client times out before receiving a message from the kernel, send RuntimeError
+        - Flush the IOPub channel
+        """
         if timeout is None:
             abs_timeout = float('inf')
         else:

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -72,8 +72,10 @@ class HBChannel(Thread):
         self.address = address
         atexit.register(self._notice_exit)
 
+        # running is False until `.start()` is called
         self._running = False
-        self._pause = True
+        # don't start paused
+        self._pause = False
         self.poller = zmq.Poller()
 
     def _notice_exit(self):

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -18,12 +18,11 @@ class SignalTestKernel(Kernel):
     implementation = 'signaltest'
     implementation_version = '0.0'
     banner = ''
-    
+
     def __init__(self, **kwargs):
         kwargs.pop('user_ns', None)
         super(SignalTestKernel, self).__init__(**kwargs)
         self.children = []
-        
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None,
                    allow_stdin=False):
@@ -51,6 +50,14 @@ class SignalTestKernel(Kernel):
             reply['evalue'] = code
             reply['traceback'] = ['no such command: %s' % code]
         return reply
+    
+    def kernel_info_request(self, *args, **kwargs):
+        """Add delay to kernel_info_request
+        
+        triggers slow-response code in KernelClient.wait_for_ready
+        """
+        time.sleep(1)
+        return super(SignalTestKernel, self).kernel_info_request(*args, **kwargs)
 
 class SignalTestApp(IPKernelApp):
     kernel_class = SignalTestKernel

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -120,3 +120,12 @@ class TestKernelManager(TestCase):
                 break
         # verify that subprocesses were interrupted
         self.assertEqual(reply['user_expressions']['poll'], [-signal.SIGINT] * N)
+
+    def test_start_new_kernel(self):
+        self._install_test_kernel()
+        km, kc = start_new_kernel(kernel_name='signaltest')
+        self.addCleanup(kc.stop_channels)
+        self.addCleanup(km.shutdown_kernel)
+
+        self.assertTrue(km.is_alive())
+        self.assertTrue(kc.is_alive())


### PR DESCRIPTION
- timeout was backwards in Client.wait_for_ready
- don't start heartbeat in paused state, which causes is_beating() to return False