### PR TITLE
Fix wait_for_ready() dying early for slow-starting kernels

### DIFF
--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -36,11 +36,12 @@ class BlockingKernelClient(KernelClient):
 
         from ..manager import KernelManager
         if not isinstance(self.parent, KernelManager):
-            # We aren't connected to a manager,
-            # so first wait for kernel to become responsive to heartbeats
+            # This Client was not created by a KernelManager,
+            # so wait for kernel to become responsive to heartbeats
+            # before checking for kernel_info reply
             while not self.is_alive():
                 if time.time() > abs_timeout:
-                    raise RuntimeError("Kernel didn't respond to heartbeats in %d seconds" % timeout)
+                    raise RuntimeError("Kernel didn't respond to heartbeats in %d seconds and timed out" % timeout)
                 time.sleep(0.2)
 
         # Wait for kernel info reply on shell channel

--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -34,6 +34,15 @@ class BlockingKernelClient(KernelClient):
         else:
             abs_timeout = time.time() + timeout
 
+        from ..manager import KernelManager
+        if not isinstance(self.parent, KernelManager):
+            # We aren't connected to a manager,
+            # so first wait for kernel to become responsive to heartbeats
+            while not self.is_alive():
+                if time.time() > abs_timeout:
+                    raise RuntimeError("Kernel didn't respond to heartbeats in %d seconds" % timeout)
+                time.sleep(0.2)
+
         # Wait for kernel info reply on shell channel
         while True:
             try:

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -183,7 +183,8 @@ class KernelClient(ConnectionFileMixin):
         """Is the kernel process still running?"""
         from .manager import KernelManager
         if isinstance(self.parent, KernelManager):
-            # We were created by a KernelManager, we can ask them:
+            # This KernelClient was created by a KernelManager,
+            # we can ask the parent KernelManager:
             return self.parent.is_alive()
         if self._hb_channel is not None:
             # We don't have access to the KernelManager,

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -181,9 +181,13 @@ class KernelClient(ConnectionFileMixin):
 
     def is_alive(self):
         """Is the kernel process still running?"""
+        from .manager import KernelManager
+        if isinstance(self.parent, KernelManager):
+            # We were created by a KernelManager, we can ask them:
+            return self.parent.is_alive()
         if self._hb_channel is not None:
-            # We didn't start the kernel with this KernelManager so we
-            # use the heartbeat.
+            # We don't have access to the KernelManager,
+            # so we use the heartbeat.
             return self._hb_channel.is_beating()
         else:
             # no heartbeat and not local, we can't tell if it's running,

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -64,5 +64,7 @@ class SignalTestApp(IPKernelApp):
         pass # disable stdout/stderr capture
 
 if __name__ == '__main__':
+    # make startup artificially slow,
+    # so that we exercise client logic for slow-starting kernels
     time.sleep(2)
     SignalTestApp.launch_instance()

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -56,13 +56,13 @@ class SignalTestKernel(Kernel):
         
         triggers slow-response code in KernelClient.wait_for_ready
         """
-        time.sleep(1)
         return super(SignalTestKernel, self).kernel_info_request(*args, **kwargs)
 
 class SignalTestApp(IPKernelApp):
     kernel_class = SignalTestKernel
     def init_io(self):
         pass # disable stdout/stderr capture
-    
+
 if __name__ == '__main__':
+    time.sleep(2)
     SignalTestApp.launch_instance()


### PR DESCRIPTION
KernelClient.is_alive() checks heartbeat responsiveness, so it can be False early on if the kernel process is slow to start. This can cause `wait_for_ready` to falsely claim the Kernel died before it has finished starting.

The fix is two-fold:

1. Use KernelManager.is_alive when Manager is available (most of the time).
   This isn't sensitive to slow startup.
2. When Manager isn't available,
   wait for `is_alive()` to become True at least once before entering the wait
   for the ready-reply.
 
cc @jhamrick, @willingc