### PR TITLE
warn about deprecation of jupyter kernelspec install-self

### DIFF
--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -227,6 +227,8 @@ class InstallNativeKernelSpec(JupyterApp):
             }
 
     def start(self):
+        self.log.warn("`jupyter kernelspec install-self` is DEPRECATED as of 4.0."
+            " You probably want `ipython kernel install` to install the IPython kernelspec.")
         try:
             from ipykernel import kernelspec
         except ImportError:


### PR DESCRIPTION
It's been deprecated since 4.0, but we haven't been showing a message when people use it.