### PR TITLE
Make kernel shutdown timeout configuration

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -22,7 +22,7 @@ import zmq
 from ipython_genutils.importstring import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
-    Any, Instance, Integer, Unicode, List, Bool, Type, DottedObjectName
+    Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName
 )
 from jupyter_client import (
     launch_kernel,
@@ -67,8 +67,8 @@ class KernelManager(ConnectionFileMixin):
     def _kernel_spec_manager_changed(self):
         self._kernel_spec = None
 
-    shutdown_wait_time = Integer(
-        5, config=True,
+    shutdown_wait_time = Float(
+        5.0, config=True,
         help="Time to wait for a kernel to terminate before killing it, "
              "in seconds.")
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -265,6 +265,7 @@ class KernelManager(ConnectionFileMixin):
         else:
             # OK, we've waited long enough.
             if self.has_kernel:
+                self.log.debug("Kernel is taking too long to finish, killing")
                 self._kill_kernel()
 
     def cleanup(self, connection_file=True):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -132,7 +132,7 @@ class MultiKernelManager(LoggingConfigurable):
         """Ask a kernel to shut down by its kernel uuid"""
 
     @kernel_method
-    def finish_shutdown(self, kernel_id, waittime=1, pollinterval=0.1):
+    def finish_shutdown(self, kernel_id, waittime=None, pollinterval=0.1):
         """Wait for a kernel to finish shutting down, and kill it if it doesn't
         """
         self.log.info("Kernel shutdown: %s" % kernel_id)


### PR DESCRIPTION
Adds a `shutdown_wait_time` parameter to kernelspecs, which allows setting the timeout to a greater value (the default is one second, after which the kernel is killed).

This is useful for special kernels that do things on exit, such as closing a remote connection, saving history/state to disk, cleaning up files, etc.


Alternatively users might be able to implement this using a custom Manager, though it is more work.