### PR TITLE
install current version on readthedocs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,7 +6,5 @@ dependencies:
 - python=3
 - traitlets>=4.1
 - jupyter_core
-- ipython
-- ipykernel
 - sphinx>=1.3.6
 - sphinx_rtd_theme

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,3 +4,4 @@ conda:
     file: docs/environment.yml
 python:
   version: 3
+  pip_install: true


### PR DESCRIPTION
avoids building the docs against the latest release on conda

also remove unused dependencies from docs environment.yml

closes #194