### PR TITLE
deprecate status='abort'

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -288,10 +288,14 @@ All reply messages have a ``'status'`` field, which will have one of the followi
           'traceback' : list(str), # traceback frames as strings
        }
 
-- ``status='abort'``: The request has been aborted in a manner that does not result in an error
-  (e.g. the request has been canceled somehow).
-  Some kernels may set this for execution halted by signals,
-  but should only do so if there is no corresponding error raised in the evaluating code.
+- ``status='abort'``: This is the same as ``status='error'``
+  but with no information about the error.
+  No fields should be present other that `status`.
+
+.. versionchanged:: 5.1
+
+    ``status='abort'`` has not proved useful, and is considered deprecated.
+    Kernels should send ``status='error'`` instead.
 
 
 .. _execute:

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -288,7 +288,11 @@ All reply messages have a ``'status'`` field, which will have one of the followi
           'traceback' : list(str), # traceback frames as strings
        }
 
-- ``status='abort'``: the task has been aborted. In this case, no additional fields should be present.
+- ``status='abort'``: The request has been aborted in a manner that does not result in an error
+  (e.g. the request has been canceled somehow).
+  Some kernels may set this for execution halted by signals,
+  but should only do so if there is no corresponding error raised in the evaluating code.
+
 
 .. _execute:
 


### PR DESCRIPTION
it's basically `status=error` without info and ~no kernels implement it, so deprecate in favor of `status='error'`.

cf ipython/ipykernel#190