### PR TITLE
Update log.warn to log.warning

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -139,7 +139,7 @@ class KernelSpecManager(LoggingConfigurable):
                                NATIVE_KERNEL_NAME, RESOURCES)
                 d[NATIVE_KERNEL_NAME] = RESOURCES
             except ImportError:
-                self.log.warn("Native kernel (%s) is not available", NATIVE_KERNEL_NAME)
+                self.log.warning("Native kernel (%s) is not available", NATIVE_KERNEL_NAME)
 
         if self.whitelist:
             # filter if there's a whitelist
@@ -258,7 +258,7 @@ class KernelSpecManager(LoggingConfigurable):
         
         kernel_dir = os.path.dirname(destination)
         if kernel_dir not in self.kernel_dirs:
-            self.log.warn("Installing to %s, which is not in %s. The kernelspec may not be found.",
+            self.log.warning("Installing to %s, which is not in %s. The kernelspec may not be found.",
                 kernel_dir, self.kernel_dirs,
             )
         

--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -229,7 +229,7 @@ class InstallNativeKernelSpec(JupyterApp):
             }
 
     def start(self):
-        self.log.warn("`jupyter kernelspec install-self` is DEPRECATED as of 4.0."
+        self.log.warning("`jupyter kernelspec install-self` is DEPRECATED as of 4.0."
             " You probably want `ipython kernel install` to install the IPython kernelspec.")
         try:
             from ipykernel import kernelspec

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -92,7 +92,7 @@ class KernelRestarter(LoggingConfigurable):
                 self._restart_count = 1
 
             if self._restart_count >= self.restart_limit:
-                self.log.warn("KernelRestarter: restart failed")
+                self.log.warning("KernelRestarter: restart failed")
                 self._fire_callbacks('dead')
                 self._restarting = False
                 self._restart_count = 0


### PR DESCRIPTION
Log.warn has been in deprecation since at least 2.7