### PR TITLE
ensure timestamps are timezone-aware

### DIFF
--- a/jupyter_client/_version.py
+++ b/jupyter_client/_version.py
@@ -1,4 +1,4 @@
-version_info = (4, 5, 0, 'dev')
+version_info = (5, 0, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))
 
 protocol_version_info = (5, 0)

--- a/jupyter_client/adapter.py
+++ b/jupyter_client/adapter.py
@@ -6,10 +6,7 @@
 import re
 import json
 
-from datetime import datetime
-
 from jupyter_client import protocol_version_info
-
 
 def code_to_line(code, cursor_pos):
     """Turn a multiline code block and cursor position into a single line
@@ -386,9 +383,10 @@ def adapt(msg, to_version=protocol_version_info[0]):
     msg : dict
         A Jupyter message appropriate in the new version.
     """
+    from .session import utcnow
     header = msg['header']
     if 'date' not in header:
-        header['date'] = datetime.now().isoformat()
+        header['date'] = utcnow()
     if 'version' in header:
         from_version = int(header['version'].split('.')[0])
     else:

--- a/jupyter_client/jsonutil.py
+++ b/jupyter_client/jsonutil.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """Utilities to manipulate JSON objects."""
 
 # Copyright (c) Jupyter Development Team.

--- a/jupyter_client/jsonutil.py
+++ b/jupyter_client/jsonutil.py
@@ -38,7 +38,7 @@ def _ensure_tzinfo(dt):
     """
     if not dt.tzinfo:
         # No more naïve datetime objects!
-        warnings.warn(u"Interpreting naïve datetime as local %s. Please add timezone info to timestamps." % dt,
+        warnings.warn(u"Interpreting naive datetime as local %s. Please add timezone info to timestamps." % dt,
             DeprecationWarning,
             stacklevel=4)
         dt = dt.replace(tzinfo=tzlocal())

--- a/jupyter_client/jsonutil.py
+++ b/jupyter_client/jsonutil.py
@@ -4,8 +4,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import re
 from datetime import datetime
+import re
+import warnings
 
 from dateutil.parser import parse as _dateutil_parse
 from dateutil.tz import tzlocal
@@ -37,6 +38,9 @@ def _ensure_tzinfo(dt):
     """
     if not dt.tzinfo:
         # No more naïve datetime objects!
+        warnings.warn(u"Interpreting naïve datetime as local %s. Please add timezone info to timestamps." % dt,
+            DeprecationWarning,
+            stacklevel=4)
         dt = dt.replace(tzinfo=tzlocal())
     return dt
 

--- a/jupyter_client/jsonutil.py
+++ b/jupyter_client/jsonutil.py
@@ -6,6 +6,8 @@
 import re
 from datetime import datetime
 
+from dateutil.parser import parse as _dateutil_parse
+from dateutil.tz import tzlocal
 
 from ipython_genutils import py3compat
 from ipython_genutils.py3compat import string_types, iteritems
@@ -17,7 +19,7 @@ next_attr_name = '__next__' if py3compat.PY3 else 'next'
 
 # timestamp formats
 ISO8601 = "%Y-%m-%dT%H:%M:%S.%f"
-ISO8601_PAT=re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d{1,6})?Z?([\+\-]\d{2}:?\d{2})?$")
+ISO8601_PAT = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d{1,6})?(Z|([\+\-]\d{2}:?\d{2}))?$")
 
 # holy crap, strptime is not threadsafe.
 # Calling it once at import seems to help.
@@ -26,6 +28,16 @@ datetime.strptime("1", "%d")
 #-----------------------------------------------------------------------------
 # Classes and functions
 #-----------------------------------------------------------------------------
+
+def _ensure_tzinfo(dt):
+    """Ensure a datetime object has tzinfo
+    
+    If no tzinfo is present, add tzlocal
+    """
+    if not dt.tzinfo:
+        # No more naïve datetime objects!
+        dt = dt.replace(tzinfo=tzlocal())
+    return dt
 
 def parse_date(s):
     """parse an ISO8601 date string
@@ -38,13 +50,8 @@ def parse_date(s):
         return s
     m = ISO8601_PAT.match(s)
     if m:
-        # FIXME: add actual timezone support
-        # this just drops the timezone info
-        notz, ms, tz = m.groups()
-        if not ms:
-            ms = '.0'
-        notz = notz + ms
-        return datetime.strptime(notz, ISO8601)
+        dt = _dateutil_parse(s)
+        return _ensure_tzinfo(dt)
     return s
 
 def extract_dates(obj):
@@ -75,7 +82,8 @@ def squash_dates(obj):
 def date_default(obj):
     """default function for packing datetime objects in JSON."""
     if isinstance(obj, datetime):
-        return obj.isoformat()
+        obj = _ensure_tzinfo(obj)
+        return obj.isoformat().replace('+00:00', 'Z')
     else:
-        raise TypeError("%r is not JSON serializable"%obj)
+        raise TypeError("%r is not JSON serializable" % obj)
 

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -43,6 +43,13 @@ except ImportError:
     # limiting the surface of attack
     def compare_digest(a,b): return a == b
 
+try:
+    from datetime import timezone
+    utc = timezone.utc
+except ImportError:
+    from dateutil.tz import tzutc
+    utc = tzutc()
+
 import zmq
 from zmq.utils import jsonapi
 from zmq.eventloop.ioloop import IOLoop
@@ -158,6 +165,9 @@ def default_secure(cfg):
     # key/keyfile not specified, generate new UUID:
     cfg.Session.key = new_id_bytes()
 
+def utcnow():
+    """Return timezone-aware UTC timestamp"""
+    return datetime.utcnow().replace(tzinfo=utc)
 
 #-----------------------------------------------------------------------------
 # Classes
@@ -223,7 +233,8 @@ class Message(object):
 
 
 def msg_header(msg_id, msg_type, username, session):
-    date = datetime.now()
+    """Create a new message header"""
+    date = utcnow()
     version = protocol_version
     return locals()
 
@@ -519,7 +530,7 @@ class Session(Configurable):
             )
 
         # check datetime support
-        msg = dict(t=datetime.now())
+        msg = dict(t=utcnow())
         try:
             unpacked = unpack(pack(msg))
             if isinstance(unpacked['t'], datetime):

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -47,6 +47,7 @@ try:
     from datetime import timezone
     utc = timezone.utc
 except ImportError:
+    # Python 2
     from dateutil.tz import tzutc
     utc = tzutc()
 

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -258,8 +258,8 @@ class TestSession(SessionTestCase):
             session = ss.Session(unpack=lambda b: 5)
 
     def _datetime_test(self, session):
-        content = dict(t=datetime.now())
-        metadata = dict(t=datetime.now())
+        content = dict(t=ss.utcnow())
+        metadata = dict(t=ss.utcnow())
         p = session.msg('msg')
         msg = session.msg('msg', content=content, metadata=metadata, parent=p['header'])
         smsg = session.serialize(msg)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ install_requires = setuptools_args['install_requires'] = [
     'traitlets',
     'jupyter_core',
     'pyzmq>=13',
+    'python-dateutil>=2.1',
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
- use UTC timestamps everywhere
- use common Z format instead of +00:00 for UTC
- naïve timestamps are given local timezone on serialize/deserialize
- use python-dateutil for parsing, local timezone

This should trigger a major version bump because it affects the Python API (existing code that compares timestamps with naïve timestamps will break). It does not affect the message _protocol_ version, because the protocol's definition of timestamp behavior is unchanged, other than resolving the ambiguity that timezone-free timestamps are interpreted as local time.
