### PR TITLE
validate kernelspec names

### DIFF
--- a/docs/kernels.rst
+++ b/docs/kernels.rst
@@ -108,6 +108,9 @@ locations:
 The user location takes priority over the system locations, and the case of the
 names is ignored, so selecting kernels works the same way whether or not the
 filesystem is case sensitive.
+Since kernelspecs show up in URLs and other places,
+they are required to be simple names, only containing ASCII letters and numbers,
+and the simple separators: ``-``, ``.``, ``_``.
 
 Other locations may also be searched if the :envvar:`JUPYTER_PATH` environment
 variable is set.

--- a/docs/kernels.rst
+++ b/docs/kernels.rst
@@ -109,8 +109,7 @@ The user location takes priority over the system locations, and the case of the
 names is ignored, so selecting kernels works the same way whether or not the
 filesystem is case sensitive.
 Since kernelspecs show up in URLs and other places,
-they are required to be simple names, only containing ASCII letters and numbers,
-and the simple separators: ``-``, ``.``, ``_``.
+a kernelspec is required to have a simple name, only containing ASCII letters, ASCII numbers, and the simple separators: ``-`` hyphen, ``.`` period, ``_`` underscore.
 
 Other locations may also be searched if the :envvar:`JUPYTER_PATH` environment
 variable is set.

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -65,7 +65,8 @@ def _is_valid_kernel_name(name):
     return _kernel_name_pat.match(name)
 
 
-_kernel_name_description = "Kernel names can only contain ASCII letters and numbers and these separators: -._"
+_kernel_name_description = "Kernel names can only contain ASCII letters and numbers and these separators:" \
+ " - . _ (hyphen, period, and underscore)."
 
 
 def _is_kernel_dir(path):

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """Tests for the KernelSpecManager"""
 
 # Copyright (c) Jupyter Development Team.
@@ -141,3 +142,23 @@ class KernelSpecTests(unittest.TestCase):
         )
         out, _ = p.communicate()
         self.assertEqual(p.returncode, 0, out.decode('utf8', 'replace'))
+
+    def test_validate_kernel_name(self):
+        for good in [
+            'julia-0.4',
+            'ipython',
+            'R',
+            'python_3',
+            'Haskell-1-2-3',
+        ]:
+            assert kernelspec._is_valid_kernel_name(good)
+        
+        for bad in [
+            'has space',
+            u'ünicode',
+            '%percent',
+            'question?',
+        ]:
+            assert not kernelspec._is_valid_kernel_name(bad)
+
+


### PR DESCRIPTION
allow only: ascii letters, numbers, period, hyphen, underscore.

cf https://github.com/jupyterlab/jupyterlab/issues/1018