### PR TITLE
ensure control socket is connected before using it

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -254,6 +254,8 @@ class KernelManager(ConnectionFileMixin):
         """
         content = dict(restart=restart)
         msg = self.session.msg("shutdown_request", content=content)
+        # ensure control socket is connected
+        self._connect_control_socket()
         self.session.send(self._control_socket, msg)
 
     def finish_shutdown(self, waittime=None, pollinterval=0.1):


### PR DESCRIPTION
`_control_socket` can be None if `shutdown_kernel` is called more than once.

related to https://github.com/jupyter/notebook/issues/1544