### PR TITLE
Link to complete echo_kernel example repo

### DIFF
--- a/docs/wrapperkernels.rst
+++ b/docs/wrapperkernels.rst
@@ -36,7 +36,7 @@ following methods and attributes:
      This should contain the key ``mimetype`` with the mimetype of code in the
      target language (e.g. ``'text/x-python'``), the ``name`` of the language
      being implemented (e.g. ``'python'``), and ``file_extension`` (e.g.
-     ``'py'``).
+     ``'.py'``).
      It may also contain keys ``codemirror_mode`` and ``pygments_lexer`` if they
      need to differ from :attr:`language`.
 
@@ -81,7 +81,11 @@ Example
         implementation_version = '1.0'
         language = 'no-op'
         language_version = '0.1'
-        language_info = {'mimetype': 'text/plain'}
+        language_info = {
+            'name': 'Any text',
+            'mimetype': 'text/plain',
+            'file_extension': '.txt',
+        }
         banner = "Echo kernel - as useful as a parrot"
 
         def do_execute(self, code, silent, store_history=True, user_expressions=None,

--- a/docs/wrapperkernels.rst
+++ b/docs/wrapperkernels.rst
@@ -72,6 +72,11 @@ Now create a `JSON kernel spec file <https://jupyter-client.readthedocs.io/en/la
 Example
 -------
 
+.. seealso::
+
+    `echo_kernel <https://github.com/jupyter/echo_kernel>`__
+      A packaged, installable version of the condensed example below.
+
 ``echokernel.py`` will simply echo any input it's given to stdout::
 
     from ipykernel.kernelbase import Kernel


### PR DESCRIPTION
At @jdemeyer's suggestion, I put together a packaged, pip-installable version of the echo kernel example, to serve as a reference for kernel authors.

I also fixed a couple of mistakes I spotted in the docs.