### PR TITLE
Pin Python to 3.5 for RTD build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 - pyzmq
-- python=3
+- python==3.5
 - traitlets>=4.1
 - jupyter_core
 - sphinx>=1.3.6


### PR DESCRIPTION
Currently, RTD is not building 3.6 so we must pin to 3.5 until 3.6 is supported.