### PR TITLE
[WIP] add kernelspec directory to PATH when starting kernels

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -242,6 +242,14 @@ class KernelManager(ConnectionFileMixin):
             # Environment variables from kernel spec are added to os.environ
             env.update(self.kernel_spec.env or {})
         
+        if os.path.isdir(self.kernel_spec.resources_dir):
+            # add kernelspec directory to PATH,
+            # so that any executables are in there
+            if 'PATH' in env:
+                path = env['PATH']
+            else:
+                path = os.getenv('PATH') or os.defpath
+            env['PATH'] = os.pathsep.join(self.kernel_spec.resources_dir, path)
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)
         self.kernel = self._launch_kernel(kernel_cmd, env=env,


### PR DESCRIPTION
- [ ] <del>verify that pip rewrites shebang lines in data_files, otherwise this is pretty pointless</del> it doesn't
- [ ] test

allows kernel command to be a script in the spec dir, which should in turn allow shebang in the script to set executable, enabling kernelspecs in Python wheels, so that pip installs can behave the same as conda installs.

This should allow us to install the IPython kernelspec on pip install, making it much harder to have ipykernel installed without  the IPython kernelspec present (largely eliminating any use of the NATIVE_KERNEL).

relevant to https://github.com/jupyter/echo_kernel/issues/3