### PR TITLE
kernelspec: interpret 'python' as sys.executable

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -174,6 +174,15 @@ class KernelManager(ConnectionFileMixin):
         else:
             cmd = self.kernel_spec.argv + extra_arguments
 
+        if cmd and cmd[0] == 'python':
+            # executable is 'python', use sys.executable.
+            # These will typically be the same,
+            # but if the current process is in an env
+            # and has been launched by abspath without
+            # activating the env, python on PATH may not be sys.executable,
+            # but it should be.
+            cmd[0] = sys.executable
+
         ns = dict(connection_file=self.connection_file,
                   prefix=sys.prefix,
                  )


### PR DESCRIPTION
allows kernelspecs to use 'python' as the executable to launch to indicate the parent environment, which in turn should enable Python packages providing kernelspecs to include their kernelspec in a wheel.

With activated environments, this makes no difference because `which python` and `sys.executable` are the same.

The only case where behavior should differ is when the Manager is in an env, but has been launched without activating the env, e.g. by absolute path (`/path/to/env/bin/jupyter notebook`). In this case, the new behavior seems preferable to the old.

This should only be used for *portable* kernelspecs (e.g. in wheels). Absolute paths are preferable wherever available (e.g. conda packages, local install from source).

cf https://github.com/ipython/ipykernel/pull/223