### PR TITLE
Fixed broken highlighting in messaging.rst

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -76,7 +76,7 @@ kernel has four sockets that serve the following functions:
    to allow important messages to avoid queueing behind execution requests (e.g. shutdown or abort).
 
 5. **Heartbeat**: This socket allows for simple bytestring messages to be sent
-    between the frontend and the kernel to ensure that they are still connected.
+   between the frontend and the kernel to ensure that they are still connected.
 
 The actual format of the messages allowed on each of these channels is
 specified below.  Messages are dicts of dicts with string keys and values that


### PR DESCRIPTION
There was an extra space before Introduction > Heartbeat that caused the whole line to be highlighted.