### PR TITLE
protocol version is 5.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,14 @@ Changes in Jupyter Client
 5.0
 ===
 
+5.0.1
+-----
+
+`5.0.1 on GitHub <https://github.com/jupyter/jupyter_client/milestones/5.0.1>`__
+
+- Update internal protocol version number to 5.1,
+  which should have been done in 5.0.0.
+
 5.0.0
 -----
 
@@ -14,6 +22,7 @@ Changes in Jupyter Client
 
 New features:
 
+- Implement Jupyter protocol version 5.1.
 - Introduce :command:`jupyter run` command for running scripts with a kernel, for instance::
 
     jupyter run --kernel python3 myscript.py

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -21,7 +21,7 @@ Versioning
 
 The Jupyter message specification is versioned independently of the packages
 that use it.
-The current version of the specification is 5.0.
+The current version of the specification is 5.1.
 
 .. note::
    *New in* and *Changed in* messages in this document refer to versions of the

--- a/jupyter_client/_version.py
+++ b/jupyter_client/_version.py
@@ -1,5 +1,5 @@
 version_info = (5, 1, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))
 
-protocol_version_info = (5, 0)
+protocol_version_info = (5, 1)
 protocol_version = "%i.%i" % protocol_version_info


### PR DESCRIPTION
We forgot to update this field in the 5.0 release. Should cut a 5.0.1 with this promptly.