### PR TITLE
add Session.clone

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -371,8 +371,9 @@ class ConnectionFileMixin(LoggingConfigurable):
             control_port=self.control_port,
         )
         if session:
-            # add session
-            info['session'] = self.session
+            # add *clone* of my session,
+            # so that state such as digest_history is not shared.
+            info['session'] = self.session.clone()
         else:
             # add session info
             info.update(dict(

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -488,6 +488,24 @@ class Session(Configurable):
         if not self.key:
             get_logger().warning("Message signing is disabled.  This is insecure and not recommended!")
 
+    def clone(self):
+        """Create a copy of this Session
+
+        Useful when connecting multiple times to a given kernel.
+        This prevents a shared digest_history warning about duplicate digests
+        due to multiple connections to IOPub in the same process.
+
+        .. versionadded:: 5.1
+        """
+        # make a copy
+        new_session = type(self)()
+        for name in self.traits():
+            setattr(new_session, name, getattr(self, name))
+        # fork digest_history
+        new_session.digest_history = set()
+        new_session.digest_history.update(self.digest_history)
+        return new_session
+
     @property
     def msg_id(self):
         """always return new uuid"""

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -320,3 +320,15 @@ class TestSession(SessionTestCase):
         A.close()
         B.close()
         ctx.term()
+    
+    def test_clone(self):
+        s = self.session
+        s._add_digest('initial')
+        s2 = s.clone()
+        assert s2.session == s.session
+        assert s2.digest_history == s.digest_history
+        assert s2.digest_history is not s.digest_history
+        digest = 'abcdef'
+        s._add_digest(digest)
+        assert digest in s.digest_history
+        assert digest not in s2.digest_history


### PR DESCRIPTION
and use it when instantiating new Clients with Manager.client()

If multiple Clients are instantiated against the same kernel, they mustn’t share a digest_history because they could all be receiving the same iopub messages which would cause hash collisions.

relevant to https://github.com/jupyter/kernel_gateway/pull/230