### PR TITLE
handle when python -OO removes docstrings

### DIFF
--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -46,6 +46,11 @@ def reqrep(meth):
 
         return self._recv_reply(msg_id, timeout=timeout)
     
+    if not meth.__doc__:
+        # python -OO removes docstrings,
+        # so don't bother building the wrapped docstring
+        return wrapped
+    
     basedoc, _ = meth.__doc__.split('Returns\n', 1)
     parts = [basedoc.strip()]
     if 'Parameters' not in basedoc:


### PR DESCRIPTION
`__doc__` is None when run with `-OO`, so don't bother trying to build the expanded docstrings for wrapped methods.

closes https://github.com/ipython/ipyparallel/issues/261