### PR TITLE
Test with pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,13 @@ python:
     - 3.3
     - 2.7
 sudo: false
-before_install:
-    - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
-    
 install:
-    - pip install -U setuptools pip
-    - pip install -f travis-wheels/wheelhouse -e .[test] codecov
-    - python -c 'import ipykernel.kernelspec; ipykernel.kernelspec.install(user=True)'
+  - pip install --upgrade setuptools pip
+  - pip install --upgrade --pre -e .[test] pytest-cov pytest-warnings codecov
 script:
-    - nosetests -v --with-coverage --cover-package jupyter_client jupyter_client
+  - py.test --cov jupyter_client jupyter_client
 after_success:
-    - codecov
+  - codecov
 matrix:
     allow_failures:
         - python: nightly

--- a/jupyter_client/tests/test_adapter.py
+++ b/jupyter_client/tests/test_adapter.py
@@ -6,7 +6,6 @@
 import copy
 import json
 from unittest import TestCase
-import nose.tools as nt
 
 from jupyter_client.adapter import adapt, V4toV5, V5toV4, code_to_line
 from jupyter_client.session import Session
@@ -18,12 +17,12 @@ def test_default_version():
     msg['header'].pop('version')
     original = copy.deepcopy(msg)
     adapted = adapt(original)
-    nt.assert_equal(adapted['header']['version'], V4toV5.version)
+    assert adapted['header']['version'] == V4toV5.version
 
 def test_code_to_line_no_code():
     line, pos = code_to_line("", 0)
-    nt.assert_equal(line, "")
-    nt.assert_equal(pos, 0)
+    assert line == ""
+    assert pos == 0
 
 class AdapterTest(TestCase):
 
@@ -263,7 +262,7 @@ class V5toV4TestCase(AdapterTest):
             msg = self.msg(v5_type, {'key' : 'value'})
             v5, v4 = self.adapt(msg)
             self.assertEqual(v4['header']['msg_type'], v4_type)
-            nt.assert_not_in('version', v4['header'])
+            assert 'version' not in v4['header']
             self.assertEqual(v4['content'], v5['content'])
 
     def test_execute_request(self):

--- a/jupyter_client/tests/test_client.py
+++ b/jupyter_client/tests/test_client.py
@@ -8,11 +8,11 @@ import os
 pjoin = os.path.join
 from unittest import TestCase
 
-from nose import SkipTest
-
 from jupyter_client.kernelspec import KernelSpecManager, NoSuchKernel, NATIVE_KERNEL_NAME
 from ..manager import start_new_kernel
 from .utils import test_env
+
+import pytest
 
 from ipython_genutils.py3compat import string_types
 from IPython.utils.capture import capture_output
@@ -27,7 +27,7 @@ class TestKernelClient(TestCase):
         try:
             KernelSpecManager().get_kernel_spec(NATIVE_KERNEL_NAME)
         except NoSuchKernel:
-            raise SkipTest()
+            pytest.skip()
         self.km, self.kc = start_new_kernel(kernel_name=NATIVE_KERNEL_NAME)
         self.addCleanup(self.kc.stop_channels)
         self.addCleanup(self.km.shutdown_kernel)

--- a/jupyter_client/tests/test_connect.py
+++ b/jupyter_client/tests/test_connect.py
@@ -6,8 +6,6 @@
 import json
 import os
 
-import nose.tools as nt
-
 from traitlets.config import Config
 from jupyter_core.application import JupyterApp
 from ipython_genutils.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
@@ -36,11 +34,11 @@ def test_write_connection_file():
     with TemporaryDirectory() as d:
         cf = os.path.join(d, 'kernel.json')
         connect.write_connection_file(cf, **sample_info)
-        nt.assert_true(os.path.exists(cf))
+        assert os.path.exists(cf)
         with open(cf, 'r') as f:
             info = json.load(f)
     info['key'] = str_to_bytes(info['key'])
-    nt.assert_equal(info, sample_info)
+    assert info == sample_info
 
 
 def test_load_connection_file_session():
@@ -56,8 +54,8 @@ def test_load_connection_file_session():
         app.connection_file = cf
         app.load_connection_file()
 
-    nt.assert_equal(session.key, sample_info['key'])
-    nt.assert_equal(session.signature_scheme, sample_info['signature_scheme'])
+    assert session.key == sample_info['key']
+    assert session.signature_scheme == sample_info['signature_scheme']
 
 
 def test_load_connection_file_session_with_kn():
@@ -73,8 +71,8 @@ def test_load_connection_file_session_with_kn():
         app.connection_file = cf
         app.load_connection_file()
 
-    nt.assert_equal(session.key, sample_info_kn['key'])
-    nt.assert_equal(session.signature_scheme, sample_info_kn['signature_scheme'])
+    assert session.key == sample_info_kn['key']
+    assert session.signature_scheme == sample_info_kn['signature_scheme']
 
 
 def test_app_load_connection_file():
@@ -89,7 +87,7 @@ def test_app_load_connection_file():
         if attr in ('key', 'signature_scheme'):
             continue
         value = getattr(app, attr)
-        nt.assert_equal(value, expected, "app.%s = %s != %s" % (attr, value, expected))
+        assert value == expected, "app.%s = %s != %s" % (attr, value, expected)
 
 
 def test_load_connection_info():
@@ -131,7 +129,7 @@ def test_find_connection_file():
             '*ernel*',
             'k*',
             ):
-            nt.assert_equal(connect.find_connection_file(query, path=security_dir), profile_cf)
+            assert connect.find_connection_file(query, path=security_dir) == profile_cf
 
         JupyterApp._instance = None
 

--- a/jupyter_client/tests/test_jsonutil.py
+++ b/jupyter_client/tests/test_jsonutil.py
@@ -14,8 +14,6 @@ except ImportError:
     # py2
     import mock
 
-import nose.tools as nt
-
 from dateutil.tz import tzlocal, tzoffset
 from jupyter_client import jsonutil
 from jupyter_client.session import utcnow
@@ -33,29 +31,29 @@ def test_extract_dates():
     extracted = jsonutil.extract_dates(timestamps)
     ref = extracted[0]
     for dt in extracted:
-        nt.assert_true(isinstance(dt, datetime.datetime))
-        nt.assert_not_equal(dt.tzinfo, None)
+        assert isinstance(dt, datetime.datetime)
+        assert dt.tzinfo != None
 
-    nt.assert_equal(extracted[0].tzinfo.utcoffset(ref), tzlocal().utcoffset(ref))
-    nt.assert_equal(extracted[1].tzinfo.utcoffset(ref), timedelta(0))
-    nt.assert_equal(extracted[2].tzinfo.utcoffset(ref), timedelta(hours=-8))
-    nt.assert_equal(extracted[3].tzinfo.utcoffset(ref), timedelta(hours=8))
-    nt.assert_equal(extracted[4].tzinfo.utcoffset(ref), timedelta(hours=-8))
-    nt.assert_equal(extracted[5].tzinfo.utcoffset(ref), timedelta(hours=8))
+    assert extracted[0].tzinfo.utcoffset(ref) == tzlocal().utcoffset(ref)
+    assert extracted[1].tzinfo.utcoffset(ref) == timedelta(0)
+    assert extracted[2].tzinfo.utcoffset(ref) == timedelta(hours=-8)
+    assert extracted[3].tzinfo.utcoffset(ref) == timedelta(hours=8)
+    assert extracted[4].tzinfo.utcoffset(ref) == timedelta(hours=-8)
+    assert extracted[5].tzinfo.utcoffset(ref) == timedelta(hours=8)
 
 def test_parse_ms_precision():
     base = '2013-07-03T16:34:52'
     digits = '1234567890'
     
     parsed = jsonutil.parse_date(base)
-    nt.assert_is_instance(parsed, datetime.datetime)
+    assert isinstance(parsed, datetime.datetime)
     for i in range(len(digits)):
         ts = base + '.' + digits[:i]
         parsed = jsonutil.parse_date(ts)
         if i >= 1 and i <= 6:
-            nt.assert_is_instance(parsed, datetime.datetime)
+            assert isinstance(parsed, datetime.datetime)
         else:
-            nt.assert_is_instance(parsed, str)
+            assert isinstance(parsed, str)
 
 
 
@@ -66,10 +64,10 @@ def test_date_default():
     data = dict(naive=naive, utc=utcnow(), withtz=naive.replace(tzinfo=other))
     with mock.patch.object(jsonutil, 'tzlocal', lambda : local):
         jsondata = json.dumps(data, default=jsonutil.date_default)
-    nt.assert_in("Z", jsondata)
-    nt.assert_equal(jsondata.count("Z"), 1)
+    assert "Z" in jsondata
+    assert jsondata.count("Z") == 1
     extracted = jsonutil.extract_dates(json.loads(jsondata))
     for dt in extracted.values():
-        nt.assert_is_instance(dt, datetime.datetime)
-        nt.assert_not_equal(dt.tzinfo, None)
+        assert isinstance(dt, datetime.datetime)
+        assert dt.tzinfo != None
 

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -13,13 +13,11 @@ import sys
 import time
 from unittest import TestCase
 
-from ipython_genutils.testing import decorators as dec
-
 from traitlets.config.loader import Config
 from jupyter_core import paths
 from jupyter_client import KernelManager
 from ..manager import start_new_kernel
-from .utils import test_env
+from .utils import test_env, skip_win32
 
 TIMEOUT = 30
 
@@ -67,7 +65,7 @@ class TestKernelManager(TestCase):
         km = self._get_tcp_km()
         self._run_lifecycle(km)
 
-    @dec.skip_win32
+    @skip_win32
     def test_ipc_lifecycle(self):
         km = self._get_ipc_km()
         self._run_lifecycle(km)
@@ -82,8 +80,8 @@ class TestKernelManager(TestCase):
             'key', 'signature_scheme',
         ])
         self.assertEqual(keys, expected)
-    
-    @dec.skip_win32
+
+    @skip_win32
     def test_signal_kernel_subprocesses(self):
         self._install_test_kernel()
         km, kc = start_new_kernel(kernel_name='signaltest')

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -13,12 +13,13 @@ from subprocess import Popen, PIPE, STDOUT
 import sys
 import unittest
 
+import pytest
+
 if str is bytes: # py2
     StringIO = io.BytesIO
 else:
     StringIO = io.StringIO
 
-from ipython_genutils.testing.decorators import onlyif
 from ipython_genutils.tempdir import TemporaryDirectory
 from jupyter_client import kernelspec
 from jupyter_core import paths
@@ -123,7 +124,9 @@ class KernelSpecTests(unittest.TestCase):
         self.ksm.log.removeHandler(handler)
         self.assertNotIn("may not be found", captured)
 
-    @onlyif(os.name != 'nt' and not os.access('/usr/local/share', os.W_OK), "needs Unix system without root privileges")
+    @pytest.mark.skipif(
+        not (os.name != 'nt' and not os.access('/usr/local/share', os.W_OK)),
+        reason="needs Unix system without root privileges")
     def test_cant_install_kernel_spec(self):
         with self.assertRaises(OSError):
             self.ksm.install_kernel_spec(self.installable_kernel,

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -4,12 +4,11 @@ from subprocess import PIPE
 import time
 from unittest import TestCase
 
-from ipython_genutils.testing import decorators as dec
-
 from traitlets.config.loader import Config
 from ..localinterfaces import localhost
 from jupyter_client import KernelManager
 from jupyter_client.multikernelmanager import MultiKernelManager
+from .utils import skip_win32
 
 class TestKernelManager(TestCase):
 
@@ -75,12 +74,12 @@ class TestKernelManager(TestCase):
         km = self._get_tcp_km()
         self._run_cinfo(km, 'tcp', localhost())
 
-    @dec.skip_win32
+    @skip_win32
     def test_ipc_lifecycle(self):
         km = self._get_ipc_km()
         self._run_lifecycle(km)
 
-    @dec.skip_win32
+    @skip_win32
     def test_ipc_cinfo(self):
         km = self._get_ipc_km()
         self._run_cinfo(km, 'ipc', 'test')

--- a/jupyter_client/tests/test_public_api.py
+++ b/jupyter_client/tests/test_public_api.py
@@ -4,8 +4,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import nose.tools as nt
-
 from jupyter_client import launcher, connect
 import jupyter_client
 
@@ -13,17 +11,17 @@ import jupyter_client
 def test_kms():
     for base in ("", "Multi"):
         KM = base + "KernelManager"
-        nt.assert_in(KM, dir(jupyter_client))
+        assert KM in dir(jupyter_client)
 
 def test_kcs():
     for base in ("", "Blocking"):
         KM = base + "KernelClient"
-        nt.assert_in(KM, dir(jupyter_client))
+        assert KM in dir(jupyter_client)
 
 def test_launcher():
     for name in launcher.__all__:
-        nt.assert_in(name, dir(jupyter_client))
+        assert name in dir(jupyter_client)
 
 def test_connect():
     for name in connect.__all__:
-        nt.assert_in(name, dir(jupyter_client))
+        assert name in dir(jupyter_client)

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -8,6 +8,8 @@ import os
 import uuid
 from datetime import datetime
 
+import pytest
+
 import zmq
 
 from zmq.tests import BaseZMQTestCase
@@ -16,7 +18,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 from jupyter_client import session as ss
 from jupyter_client import jsonutil
 
-from ipython_genutils.testing.decorators import skipif, module_not_available
 from ipython_genutils.py3compat import string_types
 
 def _bad_packer(obj):
@@ -286,9 +287,8 @@ class TestSession(SessionTestCase):
         session = ss.Session(packer='pickle')
         self._datetime_test(session)
 
-    @skipif(module_not_available('msgpack'))
     def test_datetimes_msgpack(self):
-        import msgpack
+        msgpack = pytest.importorskip('msgpack')
 
         session = ss.Session(
             pack=msgpack.packb,

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -46,11 +46,11 @@ def execute(code='', kc=None, **kwargs):
     validate_message(reply, 'execute_reply', msg_id)
     busy = kc.get_iopub_msg(timeout=TIMEOUT)
     validate_message(busy, 'status', msg_id)
-    nt.assert_equal(busy['content']['execution_state'], 'busy')
+    assert busy['content']['execution_state'] == 'busy'
 
     if not kwargs.get('silent'):
         execute_input = kc.get_iopub_msg(timeout=TIMEOUT)
         validate_message(execute_input, 'execute_input', msg_id)
-        nt.assert_equal(execute_input['content']['code'], code)
+        assert execute_input['content']['code'] == code
 
     return msg_id, reply['content']

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -3,12 +3,19 @@
 """
 import os
 pjoin = os.path.join
+import sys
 try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
 
+import pytest
+
 from ipython_genutils.tempdir import TemporaryDirectory
+
+
+skip_win32 = pytest.mark.skipif(sys.platform.startswith('win'), reason="Windows")
+
 
 class test_env(object):
     """Set Jupyter path variables to a temporary directory

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test': ['ipykernel', 'ipython', 'nose_warnings_filters'],
+    'test': ['ipykernel', 'ipython', 'pytest'],
 }
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
instead of nose.

This is just the minimum to switch over - converting `nt.assert_` to bare asserts and genutils decorators to `pytest.mark`. I left all of the `self.assertFoo` alone, since there's no reason to change them once they exist, but new tests can use bare asserts from now on.