### PR TITLE
check that buffers are contiguous

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -708,7 +708,9 @@ class Session(Configurable):
                     view = memoryview(buf)
                 except TypeError:
                     raise TypeError("Buffer objects must support the buffer protocol.")
-            if not view.contiguous:
+            # memoryview.contiguous is new in 3.3,
+            # just skip the check on Python 2
+            if hasattr(view, 'contiguous') and not view.contiguous:
                 # zmq requires memoryviews to be contiguous
                 raise ValueError("Buffer %i (%r) is not contiguous" % (idx, buf))
 

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -699,13 +699,18 @@ class Session(Configurable):
             )
             return
         buffers = [] if buffers is None else buffers
-        for buf in buffers:
-            if not isinstance(buf, memoryview):
+        for idx, buf in enumerate(buffers):
+            if isinstance(buf, memoryview):
+                view = buf
+            else:
                 try:
                     # check to see if buf supports the buffer protocol.
-                    memoryview(buf)
+                    view = memoryview(buf)
                 except TypeError:
                     raise TypeError("Buffer objects must support the buffer protocol.")
+            if not view.contiguous:
+                # zmq requires memoryviews to be contiguous
+                raise ValueError("Buffer %i (%r) is not contiguous" % (idx, buf))
 
         if self.adapt_version:
             msg = adapt(msg, self.adapt_version)

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -122,8 +122,13 @@ class TestSession(SessionTestCase):
         self.assertEqual(new_msg['buffers'],[b'bar'])
 
         # buffers must support the buffer protocol
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             self.session.send(A, msg, ident=b'foo', buffers=[1])
+
+        # buffers must be contiguous
+        buf = memoryview(os.urandom(16))
+        with self.assertRaises(ValueError):
+            self.session.send(A, msg, ident=b'foo', buffers=[buf[::2]])
 
         A.close()
         B.close()

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -5,6 +5,7 @@
 
 import hmac
 import os
+import sys
 import uuid
 from datetime import datetime
 
@@ -127,8 +128,9 @@ class TestSession(SessionTestCase):
 
         # buffers must be contiguous
         buf = memoryview(os.urandom(16))
-        with self.assertRaises(ValueError):
-            self.session.send(A, msg, ident=b'foo', buffers=[buf[::2]])
+        if sys.version_info >= (3,3):
+            with self.assertRaises(ValueError):
+                self.session.send(A, msg, ident=b'foo', buffers=[buf[::2]])
 
         A.close()
         B.close()


### PR DESCRIPTION
zmq.send will fail on non-contiguous buffers

ensures errors due to bad arguments are raise in `Session.send` instead of potentially delayed to the async callback, which is not handled well.

cf https://github.com/ipython/ipykernel/issues/245