### PR TITLE
Prototype new kernel discovery machinery

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ with Jupyter kernels.
 
    kernels
    wrapperkernels
+   kernel_providers
 
 .. toctree::
    :maxdepth: 2

--- a/docs/kernel_providers.rst
+++ b/docs/kernel_providers.rst
@@ -1,0 +1,146 @@
+================
+Kernel providers
+================
+
+.. note::
+   This is a new interface under development. Not all Jupyter applications
+   use this yet. See :ref:`kernelspecs` for the established way of discovering
+   kernel types.
+
+By writing a kernel provider, you can extend how Jupyter applications discover
+and start kernels. To do so, subclass
+:class:`jupyter_client.discovery.KernelProviderBase`, giving your provider an ID
+and overriding two methods.
+
+.. class:: MyKernelProvider
+
+   .. attribute:: id
+
+      A short string identifying this provider. Cannot contain forward slash
+      (``/``).
+
+   .. method:: find_kernels()
+
+      Get the available kernel types this provider knows about.
+      Return an iterable of 2-tuples: (name, attributes).
+      *name* is a short string identifying the kernel type.
+      *attributes* is a dictionary with information to allow selecting a kernel.
+
+   .. method:: make_manager(name)
+
+      Prepare and return a :class:`~jupyter_client.KernelManager` instance
+      ready to start a new kernel instance of the type identified by *name*.
+      The input will be one of the names given by :meth:`find_kernels`.
+
+For example, imagine we want to tell Jupyter about kernels for a new language
+called *oblong*::
+
+    # oblong_provider.py
+    from jupyter_client.discover import KernelProviderBase
+    from jupyter_client import KernelManager
+    from shutil import which
+
+    class OblongKernelProvider(KernelProviderBase):
+        id = 'oblong'
+
+        def find_kernels(self):
+            if not which('oblong-kernel'):
+                return  # Check it's available
+
+            # Two variants - for a real kernel, these could be different
+            # environments
+            yield 'standard', {
+                'display_name': 'Oblong (standard)',
+                'language': {'name': 'oblong'},
+                'argv': ['oblong-kernel'],
+            }
+            yield 'rounded', {
+                'display_name': 'Oblong (rounded)',
+                'language': {'name': 'oblong'},
+                'argv': ['oblong-kernel'],
+            }
+
+        def make_manager(self, name):
+            if name == 'standard':
+                return KernelManager(kernel_cmd=['oblong-kernel'],
+                                     extra_env={'ROUNDED': '0'})
+            elif name == 'rounded':
+                return KernelManager(kernel_cmd=['oblong-kernel'],
+                                     extra_env={'ROUNDED': '1'})
+            else:
+                raise ValueError("Unknown kernel %s" % name)
+
+You would then register this with an *entry point*. In your ``setup.py``, put
+something like this::
+
+    setup(...
+        entry_points = {
+        'jupyter_client.kernel_providers' : [
+            # The name before the '=' should match the id attribute
+            'oblong = oblong_provider:OblongKernelProvider',
+        ]
+    })
+
+To find and start kernels in client code, use
+:class:`jupyter_client.discovery.KernelFinder`. This has a similar API to kernel
+providers, but it wraps a set of kernel providers. The kernel names it works
+with have the provider ID as a prefix, e.g. ``oblong/rounded`` (from the example
+above).
+
+::
+
+    from jupyter_client.discovery import KernelFinder
+    kf = KernelFinder.from_entrypoints()
+
+    ## Find available kernel types
+    for name, attributes in kf.find_kernels():
+        print(name, ':', attributes['display_name'])
+    # oblong/standard : Oblong (standard)
+    # oblong/rounded : Oblong(rounded)
+    # ...
+
+    ## Start a kernel by name
+    manager = kf.make_manager('oblong/standard')
+    manager.start_kernel()
+
+.. module:: jupyter_client.discovery
+
+.. autoclass:: KernelFinder
+
+   .. automethod:: from_entrypoints
+
+   .. automethod:: find_kernels
+
+   .. automethod:: make_manager
+
+Included kernel providers
+=========================
+
+``jupyter_client`` includes two kernel providers:
+
+.. autoclass:: KernelSpecProvider
+
+   .. seealso:: :ref:`kernelspecs`
+
+.. autoclass:: IPykernelProvider
+
+Glossary
+========
+
+Kernel instance
+  A running kernel, a process which can accept ZMQ connections from frontends.
+  Its state includes a namespace and an execution counter.
+
+Kernel type
+  Allows starting multiple, initially similar kernel instances. The kernel type
+  entails the combination of software to run the kernel, and the context in
+  which it starts. For instance, one kernel type may be associated with one
+  conda environment containing ``ipykernel``. The same kernel software in
+  another environment would be a different kernel type. Another software package
+  for a kernel, such as ``IRkernel``, would also be a different kernel type.
+
+Kernel provider
+  A Python class to discover kernel types and allow a client to start instances
+  of those kernel types. For instance, one kernel provider might find conda
+  environments containing ``ipykernel`` and allow starting kernel instances in
+  these environments.

--- a/docs/kernel_providers.rst
+++ b/docs/kernel_providers.rst
@@ -81,6 +81,9 @@ something like this::
         ]
     })
 
+Finding kernel types
+====================
+
 To find and start kernels in client code, use
 :class:`jupyter_client.discovery.KernelFinder`. This has a similar API to kernel
 providers, but it wraps a set of kernel providers. The kernel names it works

--- a/docs/kernel_providers.rst
+++ b/docs/kernel_providers.rst
@@ -3,12 +3,18 @@ Kernel providers
 ================
 
 .. note::
-   This is a new interface under development. Not all Jupyter applications
-   use this yet. See :ref:`kernelspecs` for the established way of discovering
-   kernel types.
+   This is a new interface under development, and may still change.
+   Not all Jupyter applications use this yet.
+   See :ref:`kernelspecs` for the established way of discovering kernel types.
+
+Creating a kernel provider
+==========================
 
 By writing a kernel provider, you can extend how Jupyter applications discover
-and start kernels. To do so, subclass
+and start kernels. For example, you could find kernels in an environment system
+like conda, or kernels on remote systems which you can access.
+
+To write a kernel provider, subclass
 :class:`jupyter_client.discovery.KernelProviderBase`, giving your provider an ID
 and overriding two methods.
 
@@ -47,8 +53,8 @@ called *oblong*::
             if not which('oblong-kernel'):
                 return  # Check it's available
 
-            # Two variants - for a real kernel, these could be different
-            # environments
+            # Two variants - for a real kernel, these could be something like
+            # different conda environments.
             yield 'standard', {
                 'display_name': 'Oblong (standard)',
                 'language': {'name': 'oblong'},
@@ -85,8 +91,9 @@ Finding kernel types
 ====================
 
 To find and start kernels in client code, use
-:class:`jupyter_client.discovery.KernelFinder`. This has a similar API to kernel
-providers, but it wraps a set of kernel providers. The kernel names it works
+:class:`jupyter_client.discovery.KernelFinder`. This uses multiple kernel
+providers to find available kernels. Like a kernel provider, it has methods
+``find_kernels`` and ``make_manager``. The kernel names it works
 with have the provider ID as a prefix, e.g. ``oblong/rounded`` (from the example
 above).
 
@@ -116,8 +123,8 @@ above).
 
    .. automethod:: make_manager
 
-Included kernel providers
-=========================
+Kernel providers included in ``jupyter_client``
+===============================================
 
 ``jupyter_client`` includes two kernel providers:
 
@@ -135,9 +142,9 @@ Kernel instance
   Its state includes a namespace and an execution counter.
 
 Kernel type
-  Allows starting multiple, initially similar kernel instances. The kernel type
-  entails the combination of software to run the kernel, and the context in
-  which it starts. For instance, one kernel type may be associated with one
+  The software to run a kernel instance, along with the context in which a
+  kernel starts. One kernel type allows starting multiple, initially similar
+  kernel instances. For instance, one kernel type may be associated with one
   conda environment containing ``ipykernel``. The same kernel software in
   another environment would be a different kernel type. Another software package
   for a kernel, such as ``IRkernel``, would also be a different kernel type.

--- a/jupyter_client/discovery.py
+++ b/jupyter_client/discovery.py
@@ -25,7 +25,7 @@ class KernelProviderBase(six.with_metaclass(ABCMeta, object)):
         pass
 
 class KernelSpecProvider(KernelProviderBase):
-    """Find kernels from installed kernelspec directories.
+    """Offers kernel types from installed kernelspec directories.
     """
     id = 'spec'
 
@@ -48,7 +48,9 @@ class KernelSpecProvider(KernelProviderBase):
 
 
 class IPykernelProvider(KernelProviderBase):
-    """Find ipykernel on this Python version by trying to import it.
+    """Offers a kernel type using the Python interpreter it's running in.
+
+    This checks if ipykernel is importable first.
     """
     id = 'pyimport'
 
@@ -83,7 +85,9 @@ class IPykernelProvider(KernelProviderBase):
 
 
 class KernelFinder(object):
-    """Manages a collection of kernel providers to find available kernels
+    """Manages a collection of kernel providers to find available kernel types
+
+    *providers* should be a list of kernel provider instances.
     """
     def __init__(self, providers):
         self.providers = providers
@@ -109,17 +113,17 @@ class KernelFinder(object):
         return cls(providers)
 
     def find_kernels(self):
-        """Iterate over available kernels.
+        """Iterate over available kernel types.
 
-        Yields 2-tuples of (id_str, attributes)
+        Yields 2-tuples of (prefixed_name, attributes)
         """
         for provider in self.providers:
             for kid, attributes in provider.find_kernels():
                 id = provider.id + '/' + kid
                 yield id, attributes
 
-    def make_manager(self, id):
-        """Make a KernelManager instance for a given kernel ID.
+    def make_manager(self, name):
+        """Make a KernelManager instance for a given kernel type.
         """
         provider_id, kernel_id = id.split('/', 1)
         for provider in self.providers:

--- a/jupyter_client/discovery.py
+++ b/jupyter_client/discovery.py
@@ -1,13 +1,14 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 import entrypoints
 import logging
+import six
 
 from .kernelspec import KernelSpecManager
 from .manager import KernelManager
 
 log = logging.getLogger(__name__)
 
-class KernelFinderBase(ABC):
+class KernelFinderBase(six.with_metaclass(ABCMeta, object)):
     id = None  # Should be a short string identifying the finder class.
 
     @abstractmethod

--- a/jupyter_client/discovery.py
+++ b/jupyter_client/discovery.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import entrypoints
 import logging
 
@@ -6,7 +7,23 @@ from .manager import KernelManager
 
 log = logging.getLogger(__name__)
 
-class KernelSpecFinder(object):
+class KernelFinderBase(ABC):
+    id = None  # Should be a short string identifying the finder class.
+
+    @abstractmethod
+    def find_kernels(self):
+        """Return an iterator of (kernel_name, kernel_info_dict) tuples."""
+        pass
+
+    @abstractmethod
+    def make_manager(self, name):
+        """Make and return a KernelManager instance to start a specified kernel
+
+        name will be one of the kernel names produced by find_kernels()
+        """
+        pass
+
+class KernelSpecFinder(KernelFinderBase):
     """Find kernels from installed kernelspec directories.
     """
     id = 'spec'
@@ -29,7 +46,7 @@ class KernelSpecFinder(object):
         return KernelManager(kernel_cmd=spec.argv, extra_env=spec.env)
 
 
-class IPykernelFinder(object):
+class IPykernelFinder(KernelFinderBase):
     """Find ipykernel on this Python version by trying to import it.
     """
     id = 'pyimport'

--- a/jupyter_client/discovery.py
+++ b/jupyter_client/discovery.py
@@ -22,7 +22,7 @@ class KernelSpecFinder(object):
 
     def make_manager(self, name):
         spec = self.ksm.get_kernel_spec(name)
-        return KernelManager(kernel_cmd=spec.argv)  # TODO: env
+        return KernelManager(kernel_cmd=spec.argv, extra_env=spec.env)
 
 
 class IPykernelFinder(object):
@@ -53,7 +53,7 @@ class IPykernelFinder(object):
                 'argv': info['spec']['argv'],
             }
 
-    def make_manager(self):
+    def make_manager(self, name):
         info = self._check_for_kernel()
         if info is None:
             raise Exception("ipykernel is not importable")

--- a/jupyter_client/discovery.py
+++ b/jupyter_client/discovery.py
@@ -125,7 +125,7 @@ class KernelFinder(object):
     def make_manager(self, name):
         """Make a KernelManager instance for a given kernel type.
         """
-        provider_id, kernel_id = id.split('/', 1)
+        provider_id, kernel_id = name.split('/', 1)
         for provider in self.providers:
             if provider_id == provider.id:
                 return provider.make_manager(kernel_id)

--- a/jupyter_client/discovery.py
+++ b/jupyter_client/discovery.py
@@ -1,0 +1,80 @@
+from .kernelspec import KernelSpecManager
+from .manager import KernelManager
+
+
+class KernelSpecFinder(object):
+    """Find kernels from installed kernelspec directories.
+    """
+    id = 'spec'
+
+    def __init__(self):
+        self.ksm = KernelSpecManager()
+
+    def find_kernels(self):
+        for name, resdir in self.ksm.find_kernel_specs().items():
+            spec = self.ksm._get_kernel_spec_by_name(name, resdir)
+            yield name, {
+                # TODO: get full language info
+                'language': {'name': spec.language},
+                'display_name': spec.display_name,
+                'argv': spec.argv,
+            }
+
+    def make_manager(self, name):
+        spec = self.ksm.get_kernel_spec(name)
+        return KernelManager(kernel_cmd=spec.argv)  # TODO: env
+
+
+class IPykernelFinder(object):
+    """Find ipykernel on this Python version by trying to import it.
+    """
+    id = 'pyimport'
+
+    def _check_for_kernel(self):
+        try:
+            from ipykernel.kernelspec import RESOURCES, get_kernel_dict
+            from ipykernel.ipkernel import IPythonKernel
+        except ImportError:
+            return None
+        else:
+            return {
+                'spec': get_kernel_dict(),
+                'language_info': IPythonKernel.language_info,
+                'resources_dir': RESOURCES,
+            }
+
+    def find_kernels(self):
+        info = self._check_for_kernel()
+
+        if info:
+            yield 'kernel', {
+                'language': info['language_info'],
+                'display_name': info['spec']['display_name'],
+                'argv': info['spec']['argv'],
+            }
+
+    def make_manager(self):
+        info = self._check_for_kernel()
+        if info is None:
+            raise Exception("ipykernel is not importable")
+        return KernelManager(kernel_cmd=info['spec']['argv'])
+
+
+class MetaKernelFinder(object):
+    def __init__(self):
+        self.finders = [
+            KernelSpecFinder(),
+            IPykernelFinder(),
+        ]
+
+    def find_kernels(self):
+        for finder in self.finders:
+            for kid, attributes in finder.find_kernels():
+                id = finder.id + '/' + kid
+                yield id, attributes
+
+    def make_manager(self, id):
+        finder_id, kernel_id = id.split('/', 1)
+        for finder in self.finders:
+            if finder_id == finder.id:
+                return finder.make_manager(kernel_id)

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -22,7 +22,7 @@ import zmq
 from ipython_genutils.importstring import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
-    Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName
+    Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName, Dict
 )
 from jupyter_client import (
     launch_kernel,
@@ -87,23 +87,13 @@ class KernelManager(ConnectionFileMixin):
             self._kernel_spec = self.kernel_spec_manager.get_kernel_spec(self.kernel_name)
         return self._kernel_spec
 
-    kernel_cmd = List(Unicode(), config=True,
-        help="""DEPRECATED: Use kernel_name instead.
-
-        The Popen Command to launch the kernel.
-        Override this if you have a custom kernel.
-        If kernel_cmd is specified in a configuration file,
-        Jupyter does not pass any arguments to the kernel,
-        because it cannot make any assumptions about the
-        arguments that the kernel understands. In particular,
-        this means that the kernel does not receive the
-        option --debug if it given on the Jupyter command line.
-        """
+    kernel_cmd = List(Unicode(),
+        help="""The Popen Command to launch the kernel."""
     )
 
-    def _kernel_cmd_changed(self, name, old, new):
-        warnings.warn("Setting kernel_cmd is deprecated, use kernel_spec to "
-                      "start different kernels.")
+    extra_env = Dict(
+        help="""Extra environment variables to be set for the kernel."""
+    )
 
     @property
     def ipykernel(self):
@@ -254,6 +244,8 @@ class KernelManager(ConnectionFileMixin):
             # If kernel_cmd has been set manually, don't refer to a kernel spec
             # Environment variables from kernel spec are added to os.environ
             env.update(self.kernel_spec.env or {})
+        elif self.extra_env:
+            env.update(self.extra_env)
         
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)

--- a/jupyter_client/tests/test_discovery.py
+++ b/jupyter_client/tests/test_discovery.py
@@ -3,9 +3,9 @@ import sys
 from jupyter_client import KernelManager
 from jupyter_client import discovery
 
-def test_ipykernel_finder():
+def test_ipykernel_provider():
     import ipykernel  # Fail clearly if ipykernel not installed
-    ikf = discovery.IPykernelFinder()
+    ikf = discovery.IPykernelProvider()
 
     res = list(ikf.find_kernels())
     assert len(res) == 1, res
@@ -13,8 +13,8 @@ def test_ipykernel_finder():
     assert id == 'kernel'
     assert info['argv'][0] == sys.executable
 
-class DummyKernelFinder(discovery.KernelFinderBase):
-    """A dummy kernel finder for testing MetaKernelFinder"""
+class DummyKernelProvider(discovery.KernelProviderBase):
+    """A dummy kernel provider for testing KernelFinder"""
     id = 'dummy'
 
     def find_kernels(self):
@@ -24,9 +24,9 @@ class DummyKernelFinder(discovery.KernelFinderBase):
         return KernelManager(kernel_cmd=['dummy_kernel'])
 
 def test_meta_kernel_finder():
-    mkf = discovery.MetaKernelFinder(finders=[DummyKernelFinder()])
-    assert list(mkf.find_kernels()) == \
+    kf = discovery.KernelFinder(providers=[DummyKernelProvider()])
+    assert list(kf.find_kernels()) == \
         [('dummy/sample', {'argv': ['dummy_kernel']})]
 
-    manager = mkf.make_manager('dummy/sample')
+    manager = kf.make_manager('dummy/sample')
     assert manager.kernel_cmd == ['dummy_kernel']

--- a/jupyter_client/tests/test_discovery.py
+++ b/jupyter_client/tests/test_discovery.py
@@ -1,0 +1,32 @@
+import sys
+
+from jupyter_client import KernelManager
+from jupyter_client import discovery
+
+def test_ipykernel_finder():
+    import ipykernel  # Fail clearly if ipykernel not installed
+    ikf = discovery.IPykernelFinder()
+
+    res = list(ikf.find_kernels())
+    assert len(res) == 1, res
+    id, info = res[0]
+    assert id == 'kernel'
+    assert info['argv'][0] == sys.executable
+
+class DummyKernelFinder(discovery.KernelFinderBase):
+    """A dummy kernel finder for testing MetaKernelFinder"""
+    id = 'dummy'
+
+    def find_kernels(self):
+        yield 'sample', {'argv': ['dummy_kernel']}
+
+    def make_manager(self, name):
+        return KernelManager(kernel_cmd=['dummy_kernel'])
+
+def test_meta_kernel_finder():
+    mkf = discovery.MetaKernelFinder(finders=[DummyKernelFinder()])
+    assert list(mkf.find_kernels()) == \
+        [('dummy/sample', {'argv': ['dummy_kernel']})]
+
+    manager = mkf.make_manager('dummy/sample')
+    assert manager.kernel_cmd == ['dummy_kernel']

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,10 @@ setup_args = dict(
         'console_scripts': [
             'jupyter-kernelspec = jupyter_client.kernelspecapp:KernelSpecApp.launch_instance',
             'jupyter-run = jupyter_client.runapp:RunApp.launch_instance',
+        ],
+        'jupyter_client.kernel_finders' : [
+            'spec = jupyter_client.discovery:KernelSpecFinder',
+            'pyimport = jupyter_client.discovery:IPykernelFinder',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,8 @@ setup_args = dict(
             'jupyter-run = jupyter_client.runapp:RunApp.launch_instance',
         ],
         'jupyter_client.kernel_providers' : [
-            'spec = jupyter_client.discovery:KernelSpecFinder',
-            'pyimport = jupyter_client.discovery:IPykernelFinder',
+            'spec = jupyter_client.discovery:KernelSpecProvider',
+            'pyimport = jupyter_client.discovery:IPykernelProvider',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup_args = dict(
             'jupyter-kernelspec = jupyter_client.kernelspecapp:KernelSpecApp.launch_instance',
             'jupyter-run = jupyter_client.runapp:RunApp.launch_instance',
         ],
-        'jupyter_client.kernel_finders' : [
+        'jupyter_client.kernel_providers' : [
             'spec = jupyter_client.discovery:KernelSpecFinder',
             'pyimport = jupyter_client.discovery:IPykernelFinder',
         ]

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup_args = dict(
         'jupyter_core',
         'pyzmq>=13',
         'python-dateutil>=2.1',
+        'entrypoints',
     ],
     extras_require   = {
         'test': ['ipykernel', 'ipython', 'mock', 'pytest'],


### PR DESCRIPTION
Following jupyter/nbformat#81, this PR introduces extensible kernel finder machinery, to pave the way for different kernel pickers.

The kernel finder machinery would work like this:

* A MetaKernelFinder object holds a collection of different kernel finder objects.
* Each kernel finder has a short ID, and two methods:
  * `find_kernels()` yields pairs of id (str) and kernel attributes (dict). The attributes contain information about the kernel. At present this has no required fields, but we'll probably want to require things similar to the language info in `kernel_info_reply`.
  * `make_manager(kernel_id)` returns an instance of `KernelManager`, or a subclass, ready to start a kernel of the specified kind.
* The implementation here provides two kernel finders: one using kernel specs (the same way we already look for kernels), and one trying to import `ipykernel` in the current Python.
* Other kernel finders could find kernels in conda environments, virtualenvs, docker containers, VMs, or remote hosts. These would be distributed separately and found using entry points (not yet implemented).
* The MetaKernelManager namespaces kernels IDs according to the finder responsible for them, so an ID such as `spec/python3` means the `python3` kernel from the `spec` finder. Other qualified kernel IDs might look like: `conda/myenv` or `docker/ipython/ipykernel-nightly`.
* Specifying a kernel at e.g. a command line will use the qualified ID, e.g. `jupyter console --kernel spec/python3`. I propose that unqualified names (e.g. `python3`) are treated as if they were prefixed with `spec/`, ensuring backwards compatibility.
* Thus, specifying `pyimport/kernel` (or whatever we change that name to) will always get a kernel running on the same Python executable as the process starting it.
* When we start a kernel for a notebook, a KernelPicker object (not yet implemented) will get the IDs and attributes from `find_kernels()` and use it to select the most appropriate one.

Implementation notes:

* This involves going back on changes we had previously made to KernelManager to make it aware of kernelspecs. In this design, the kernel discovery machinery sits a level above KernelManager, rather than a level below it. In the long run, I think that we'll be glad of reduced complexity in KernelManager, but in the shorter term, it still needs to be aware of kernelspecs for backwards compatibility.
* We will likely want some finders to cache kernel info, especially if finding kernels involves launching processes or communicating with other systems. I haven't yet tried to design any mechanisms to control gathering or invalidating cache information, but I expect that we'll need these.