### PR TITLE
describe cursor_pos ambiguity and bump protocol to 5.2

### DIFF
--- a/jupyter_client/_version.py
+++ b/jupyter_client/_version.py
@@ -1,5 +1,5 @@
 version_info = (5, 1, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))
 
-protocol_version_info = (5, 1)
+protocol_version_info = (5, 2)
 protocol_version = "%i.%i" % protocol_version_info


### PR DESCRIPTION
cursor_pos with characters after 0x10000 is officially ambiguous with respect to surrogate pairs in versions 5.1 and earlier due to a widespread bug in javascript frontends.

Thus bumps the protocol to 5.2 with the sole change that cursor_pos is no longer ambiguous (i.e. clients that correctly implement cursor_pos in 5.1 can bump to 5.2 with no other changes).

cf #259

cross-refs for frontend implementations:

- https://github.com/sagemathinc/cocalc/issues/1994
- https://github.com/jupyterlab/jupyterlab/issues/2255
- https://github.com/nteract/nteract/issues/1706
- https://github.com/jupyter/notebook/issues/2509

cc @stevengj @rgbkrk @Carreau @blink1073 @williamstein