### PR TITLE
Allow HBChannel and IOLoopThread to be garbage collected

### DIFF
--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -70,7 +70,6 @@ class HBChannel(Thread):
                 raise InvalidPortNumber(message)
             address = "tcp://%s:%i" % address
         self.address = address
-        atexit.register(self._notice_exit)
 
         # running is False until `.start()` is called
         self._running = False
@@ -78,8 +77,10 @@ class HBChannel(Thread):
         self._pause = False
         self.poller = zmq.Poller()
 
-    def _notice_exit(self):
-        self._exiting = True
+    @staticmethod
+    @atexit.register
+    def _notice_exit():
+        HBChannel._exiting = True
 
     def _create_socket(self):
         if self.socket is not None:

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -141,14 +141,17 @@ class ThreadedZMQSocketChannel(object):
 class IOLoopThread(Thread):
     """Run a pyzmq ioloop in a thread to send and receive messages
     """
+    _exiting = False
+
     def __init__(self, loop):
         super(IOLoopThread, self).__init__()
         self.daemon = True
-        atexit.register(self._notice_exit)
         self.ioloop = loop or ioloop.IOLoop()
 
-    def _notice_exit(self):
-        self._exiting = True
+    @staticmethod
+    @atexit.register
+    def _notice_exit():
+        IOLoopThread._exiting = True
 
     def run(self):
         """Run my loop, ignoring EINTR events in the poller"""


### PR DESCRIPTION
`HBChannel` and `IOLoopThread` both classes were registering a
bound method `_notice_exit` via `atexit.register` which meant
they would never be garbage collected until the process exited.
It is now replaced with a function which instead sets the
`_exiting` class variable instead of attribute on the instances.