### PR TITLE
Switch to `tox` for testing, docs, and coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__
 \#*#
 .#*
 .coverage
+.cache
+absolute.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,27 @@
 language: python
-python:
-    - "nightly"
-    - '3.6-dev'
-    - 3.5
-    - 3.4
-    - 3.3
-    - 2.7
+matrix:
+  include:
+    - python: 3.6
+      env: TOX_ENV=docs
+    - python: 3.6
+      env: TOX_ENV=cover
+    - python: 2.7
+      env: TOX_ENV=py27
+    - python: 3.3
+      env: TOX_ENV=py33
+    - python: 3.4
+      env: TOX_ENV=py34
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.6-dev
+      env: TOX_ENV=py36
+  allow_failures:
+    - python: nightly
+      env: TOX_ENV=py37
 sudo: false
 install:
-  - pip install --upgrade setuptools pip
-  - pip install --upgrade --pre -e .[test] pytest-cov pytest-warnings codecov
+  - pip install --upgrade tox
 script:
-  - py.test --cov jupyter_client jupyter_client
+  - tox -e "${TOX_ENV}"
 after_success:
-  - codecov
-matrix:
-    allow_failures:
-        - python: nightly
+  - if [[ "${TOX_ENV}" == "cover" ]]; then tox -e codecov; fi

--- a/README.md
+++ b/README.md
@@ -26,19 +26,18 @@ and download the dependencies of code and test suite by executing:
     pip install -e .[test]
     py.test
 
-The last command runs the test suite to verify the setup. During development, you can pass filenames to `py.test`, and it will execute only those tests.
+The last command runs the test suite to verify the setup. During development,
+you can pass filenames to `py.test`, and it will execute only those tests.
+
+Alternately, you can install and run `tox` to run all tests. For more info on
+`tox`, see [the docs](https://tox.readthedocs.io/en/latest/).
 
 ## Documentation
 
 The documentation of Jupyter Client is generated from the files in `docs/` using Sphinx. Instructions for setting up Sphinx with a selection of optional modules are in the [Documentation Guide](http://jupyter.readthedocs.io/en/latest/contrib_docs/index.html). You'll also need the `make` command.
 For a minimal Sphinx installation to process the Jupyter Client docs, execute:
 
-    pip install sphinx sphinx_rtd_theme
-
-The following commands build the documentation in HTML format and check for broken links:
-
-    cd /my/projects/jupyter_client/docs/
-    make html linkcheck
+    tox -e docs
 
 Point your browser to the following URL to access the generated documentation:
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test': ['ipykernel', 'ipython', 'pytest'],
+    'test': ['ipykernel', 'ipython', 'mock', 'pytest', 'pytest-warnings'],
 }
 
 if 'setuptools' in sys.modules:

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test': ['ipykernel', 'ipython', 'mock', 'pytest', 'pytest-warnings'],
+    'test': ['ipykernel', 'ipython', 'mock', 'pytest'],
 }
 
 if 'setuptools' in sys.modules:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+envlist = py27,py36,cover,docs
+# If an interpreter is missing locally, skip it.
+skip_missing_interpreters = true
+
+[testenv]
+commands =
+    pip install --pre .[test]
+    py.test
+
+[testenv:docs]
+# TERM is important for pretty output. :)
+passenv = TERM
+# tox needs to know that it's OK to run an external command (make):
+# https://tox.readthedocs.io/en/latest/example/basic.html#whitelisting-non-virtualenv-commands
+whitelist_externals = make
+changedir = docs
+deps = sphinx
+       sphinx_rtd_theme
+commands =
+    make html linkcheck
+
+[testenv:cover]
+deps = pytest-cov
+commands =
+    pip install --pre .[test]
+    py.test --cov jupyter_client jupyter_client
+
+[testenv:codecov]
+# codecov needs these env vars to correctly upload results, cf:
+# https://github.com/codecov/example-python#testing-with-tox
+passenv = CI TRAVIS TRAVIS_*
+deps = codecov
+commands = codecov

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ whitelist_externals = make
 changedir = docs
 deps = sphinx
        sphinx_rtd_theme
+       ipykernel
 commands =
     make html linkcheck
 


### PR DESCRIPTION
This just moves all manual steps into `tox`:
* tests are run in `tox`
* Travis uses `tox` rather than a separate config
* docs and coverage are handled via `tox`
* updated `README` to mention `tox` where appropriate.

I made two other small cleanups in the process:
* small dep cleanup (`pytest` was required but never mentioned)
* added two more entries to `.gitignore`

I've also used 3.6 as the "default" version, in the sense that coverage and
doc building use 3.6 as the base version, rather than 2.7.