### PR TITLE
Small deps and gitignore cleanups.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__
 \#*#
 .#*
 .coverage
+.cache
+absolute.json

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The last command runs the test suite to verify the setup. During development, yo
 The documentation of Jupyter Client is generated from the files in `docs/` using Sphinx. Instructions for setting up Sphinx with a selection of optional modules are in the [Documentation Guide](http://jupyter.readthedocs.io/en/latest/contrib_docs/index.html). You'll also need the `make` command.
 For a minimal Sphinx installation to process the Jupyter Client docs, execute:
 
-    pip install sphinx sphinx_rtd_theme
+    pip install ipykernel sphinx sphinx_rtd_theme
 
 The following commands build the documentation in HTML format and check for broken links:
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    'test': ['ipykernel', 'ipython', 'pytest'],
+    'test': ['ipykernel', 'ipython', 'mock', 'pytest'],
 }
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
* Update the test deps (`mock` is required)
* Update doc deps (`ipykernel` is required)
* Add a few files to `.gitignore`.
* Small `README.md` update for docs-buidling deps.

(These are the salvageable bits from #275, which attempted to add `tox` for
testing.)