### PR TITLE
Also install jupyter-run without setuptools

### DIFF
--- a/scripts/jupyter-run
+++ b/scripts/jupyter-run
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+from jupyter_client.runapp import RunApp
+
+def main():
+    RunApp.launch_instance()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Can be pulled additionally to #282, since it’ll make jupyter-run installable on systems without setuptools.