### PR TITLE
unconditionally use setuptools

### DIFF
--- a/scripts/jupyter-kernelspec
+++ b/scripts/jupyter-kernelspec
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-from jupyter_client.kernelspecapp import KernelSpecApp
-
-def main():
-    KernelSpecApp.launch_instance()
-
-if __name__ == '__main__':
-    main()

--- a/scripts/jupyter-run
+++ b/scripts/jupyter-run
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-from jupyter_client.runapp import RunApp
-
-def main():
-    RunApp.launch_instance()
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
follow pattern of other packages, requiring setuptools and disabling implicit bdist_egg

follow-up to #282 #283, resolving any inconsistencies for installing in different contexts. Prevents rare no-setuptools installs from ever being different from normal installs.