### PR TITLE
Soften and suppress warnings about sticky bits

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -148,7 +148,7 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
             new_permissions = permissions | stat.S_ISVTX
             if new_permissions != permissions:
                 try:
-                    os.chmod(path, permissions)
+                    os.chmod(path, new_permissions)
                 except OSError as e:
                     # failed to set sticky bit,
                     # probably not a big deal

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -10,6 +10,7 @@ related to writing and reading connections files.
 
 from __future__ import absolute_import
 
+import errno
 import glob
 import json
 import os
@@ -150,12 +151,17 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
                 try:
                     os.chmod(path, new_permissions)
                 except OSError as e:
-                    # failed to set sticky bit,
-                    # probably not a big deal
-                    warnings.warn(
-                        "Failed to set sticky bit on %r: %s" % (path, e),
-                        RuntimeWarning,
-                    )
+                    if e.errno == errno.EPERM and path == runtime_dir:
+                        # suppress permission errors setting sticky bit on runtime_dir,
+                        # which we may not own.
+                        pass
+                    else:
+                        # failed to set sticky bit, probably not a big deal
+                        warnings.warn(
+                            "Failed to set sticky bit on %r: %s"
+                            "\nProbably not a big deal, but runtime files may be cleaned up periodically." % (path, e),
+                            RuntimeWarning,
+                        )
 
     return fname, cfg
 


### PR DESCRIPTION
- specifically silence EPERM on the containing directory,
  which can happen when using tempfiles.
- when warning is triggered, explain that it's not a big deal and what might happen.

and actually set the sticky bit, which I just realized we weren't doing because I used the wrong variable to update the permissions.

cf discussion in #201

cc @takluyver @AlJohri