### PR TITLE
ensure kernel_name is defined on ConnectionFileMixin

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -299,6 +299,7 @@ class ConnectionFileMixin(LoggingConfigurable):
     _connection_file_written = Bool(False)
 
     transport = CaselessStrEnum(['tcp', 'ipc'], default_value='tcp', config=True)
+    kernel_name = Unicode()
 
     ip = Unicode(config=True,
         help="""Set the kernel\'s IP address [default localhost].


### PR DESCRIPTION
since it is used when passing to write_connection_file

This comes up in tests with DummyConfigurable with traitlets master, which removes the `Constructor(attr=value)` assignment for non-trait attributes.