### PR TITLE
Allow to use the resource directory in the kernel command-line

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -186,6 +186,10 @@ class KernelManager(ConnectionFileMixin):
         ns = dict(connection_file=self.connection_file,
                   prefix=sys.prefix,
                  )
+
+        if self.kernel_spec:
+            ns["resource_dir"] = self.kernel_spec.resource_dir
+
         ns.update(self._launch_args)
 
         pat = re.compile(r'\{([A-Za-z0-9_]+)\}')


### PR DESCRIPTION
I'd like to place some static files in the resource directory on installation, however, I currently have no way of accessing them from the kernel.