### PR TITLE
prepare for tornado 5

### DIFF
--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -1,15 +1,7 @@
 """A kernel manager with a tornado IOLoop"""
 
-#-----------------------------------------------------------------------------
-#  Copyright (c) The Jupyter Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import absolute_import
 
@@ -24,10 +16,6 @@ from traitlets import (
 from jupyter_client.manager import KernelManager
 from .restarter import IOLoopKernelRestarter
 
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
-
 
 def as_zmqstream(f):
     def wrapped(self, *args, **kwargs):
@@ -37,9 +25,9 @@ def as_zmqstream(f):
 
 class IOLoopKernelManager(KernelManager):
 
-    loop = Instance('zmq.eventloop.ioloop.IOLoop')
+    loop = Instance('tornado.ioloop.IOLoop')
     def _loop_default(self):
-        return ioloop.IOLoop.instance()
+        return ioloop.IOLoop.current()
 
     restarter_class = Type(
         default_value=IOLoopKernelRestarter,

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -4,37 +4,28 @@ This watches a kernel's state using KernelManager.is_alive and auto
 restarts the kernel if it dies.
 """
 
-#-----------------------------------------------------------------------------
-#  Copyright (c) The Jupyter Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
-
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import absolute_import
+import warnings
 
 from zmq.eventloop import ioloop
-
 
 from jupyter_client.restarter import KernelRestarter
 from traitlets import (
     Instance,
 )
 
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
-
 class IOLoopKernelRestarter(KernelRestarter):
     """Monitor and autorestart a kernel."""
 
-    loop = Instance('zmq.eventloop.ioloop.IOLoop')
+    loop = Instance('tornado.ioloop.IOLoop')
     def _loop_default(self):
-        return ioloop.IOLoop.instance()
+        warnings.warn("IOLoopKernelRestarter.loop is deprecated in jupyter-client 5.2",
+            DeprecationWarning, stacklevel=4,
+        )
+        return ioloop.IOLoop.current()
 
     _pcallback = None
 
@@ -42,7 +33,7 @@ class IOLoopKernelRestarter(KernelRestarter):
         """Start the polling of the kernel."""
         if self._pcallback is None:
             self._pcallback = ioloop.PeriodicCallback(
-                self.poll, 1000*self.time_to_dead, self.loop
+                self.poll, 1000*self.time_to_dead,
             )
             self._pcallback.start()
 

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -191,9 +191,9 @@ class SessionFactory(LoggingConfigurable):
     session = Instance('jupyter_client.session.Session',
                        allow_none=True)
 
-    loop = Instance('zmq.eventloop.ioloop.IOLoop')
+    loop = Instance('tornado.ioloop.IOLoop')
     def _loop_default(self):
-        return IOLoop.instance()
+        return IOLoop.current()
 
     def __init__(self, **kwargs):
         super(SessionFactory, self).__init__(**kwargs)

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -8,6 +8,10 @@ import os
 import sys
 import uuid
 from datetime import datetime
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import pytest
 
@@ -34,6 +38,14 @@ class SessionTestCase(BaseZMQTestCase):
         self.session = ss.Session()
 
 
+@pytest.fixture
+def no_copy_threshold():
+    """Disable zero-copy optimizations in pyzmq >= 17"""
+    with mock.patch.object(zmq, 'COPY_THRESHOLD', 1):
+        yield
+
+
+@pytest.mark.usefixtures('no_copy_threshold')
 class TestSession(SessionTestCase):
 
     def test_msg(self):


### PR DESCRIPTION
- use IOLoop.current over IOLoop.instance
- drop removed `loop` arg from PeriodicCallback
- deprecate now-unused IOLoopKernelRestarter.loop

pyzmq 17 will be needed to be fully compatible with tornado 5, which runs on asyncio on Python 3.