### PR TITLE
kill process group when killing kernel

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -372,7 +372,10 @@ class KernelManager(ConnectionFileMixin):
             # Signal the kernel to terminate (sends SIGKILL on Unix and calls
             # TerminateProcess() on Win32).
             try:
-                self.kernel.kill()
+                if hasattr(signal, 'SIGKILL'):
+                    self.signal_kernel(signal.SIGKILL)
+                else:
+                    self.kernel.kill()
             except OSError as e:
                 # In Windows, we will get an Access Denied error if the process
                 # has already terminated. Ignore it.


### PR DESCRIPTION
if killpg is available. Keeps kill_kernel consistent with other signals.

This should cleanup process groups (e.g. multiprocessing subprocesses) and make EADDRINUSE less likely during restart (ipython/ipykernel#274)
when kernels don't cleanup after themselves (ipykernel#290).