### PR TITLE
require tornado

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup_args = dict(
         'pyzmq>=13',
         'python-dateutil>=2.1',
         'entrypoints',
+        'tornado>=4.1',
     ],
     extras_require   = {
         'test': ['ipykernel', 'ipython', 'mock'],


### PR DESCRIPTION
we use zmq.eventloop, which generally requires tornado. The polyfill allowing this to be importable without tornado present is going away in a future release of pyzmq.

closes #321