### PR TITLE
Parenthesize conditional requirement in setup.py

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,13 @@
 Changes in Jupyter Client
 =========================
 
+5.2.1
+=====
+
+- Add parenthesis to conditional pytest requirement to work around a bug in the
+  ``wheel`` package, that generate a ``.whl`` which otherwise always depends on
+  ``pytest`` see :ghissue:`324` and :ghpull:`325`
+
 5.2
 ===
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup_args = dict(
     extras_require   = {
         'test': ['ipykernel', 'ipython', 'mock'],
         'test:python_version == "3.3"': ['pytest<3.3.0'],
-        'test:python_version >= "3.4" or python_version == "2.7"': ['pytest'],
+        'test:(python_version >= "3.4" or python_version == "2.7")': ['pytest'],
     },
     cmdclass         = {
         'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,


### PR DESCRIPTION
Du to a likely bug in wheel, the conditional dependency on pytest ends
up being unconditional. Seem like adding parenthesis fix that (as a work
around).

See https://github.com/pypa/setuptools/issues/1242
Closes #324