### PR TITLE
Exclude build docs from sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include README.md
 # Documentation
 graft docs
 exclude docs/\#*
+exclude docs/_*
 
 # Examples
 graft examples


### PR DESCRIPTION
This shrinks the sdist from 2MB to ~250KB... just realized that after
uploading 5.2.1 took way too long. Apparently 5.2.0 alsho shipped built
docs.