### PR TITLE
Tell Travis not to test the push from MrMeeseeks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ after_success:
 matrix:
     allow_failures:
         - python: nightly
+branches:
+  except:
+    - /^auto-backport-of-pr-[0-9]+$/


### PR DESCRIPTION
Use the ability to exclude branches as describe there:

 - https://docs.travis-ci.com/user/customizing-the-build/#Safelisting-or-blocklisting-branches

Relatively easy as MrMeeseeks push a known branch format.
This of course cannot be tested until merged and backported, and another
backport triggered.
  