### PR TITLE
handle classes having been torn down in atexit

### DIFF
--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -80,7 +80,10 @@ class HBChannel(Thread):
     @staticmethod
     @atexit.register
     def _notice_exit():
-        HBChannel._exiting = True
+        # Class definitions can be torn down during interpreter shutdown.
+        # We only need to set _exiting flag if this hasn't happened.
+        if HBChannel is not None:
+            HBChannel._exiting = True
 
     def _create_socket(self):
         if self.socket is not None:

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -151,7 +151,10 @@ class IOLoopThread(Thread):
     @staticmethod
     @atexit.register
     def _notice_exit():
-        IOLoopThread._exiting = True
+        # Class definitions can be torn down during interpreter shutdown.
+        # We only need to set _exiting flag if this hasn't happened.
+        if IOLoopThread is not None:
+            IOLoopThread._exiting = True
 
     def run(self):
         """Run my loop, ignoring EINTR events in the poller"""


### PR DESCRIPTION
we could probably avoid this if we registered/unregistered atexit callbacks for instances instead of registering it once for classes at import time

closes #323

Perhaps more hygenic, if more complex alternative that would use instances:

- register atexit callback in `__init__`
- use a weakref to avoid keeping a reference forever
- unregister callback in `__del__`

Attaching it to an instance should prevent any process-teardown issues, since classes don't get deleted while they still have running instances (I'm pretty sure).