### PR TITLE
avoid calling private method in subclasses of KernelSpecManager

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -254,7 +254,14 @@ class KernelSpecManager(LoggingConfigurable):
         res = {}
         for kname, resource_dir in d.items():
             try:
-                spec = self._get_kernel_spec_by_name(kname, resource_dir)
+                if self.__class__ is KernelSpecManager:
+                    spec = self._get_kernel_spec_by_name(kname, resource_dir)
+                else:
+                    # avoid calling private methods in subclasses,
+                    # which may have overridden find_kernel_specs
+                    # and get_kernel_spec, but not the newer get_all_specs
+                    spec = self.get_kernel_spec(kname)
+
                 res[kname] = {
                     "resource_dir": resource_dir,
                     "spec": spec.to_dict()


### PR DESCRIPTION
on the result of a public overrideable method, which breaks subclasses that don't override get_all_specs

rather than falling back on the public method, which is slower because it looks up the location of a directory we have already found, reserve this optimization for the base class itself, which is the only place this is a safe method to call.

closes #338

I think we should ship a 5.2.2 bugfix upon merging this one and confirming it fixes nb_conda_kernels