### PR TITLE
import warnings for 5.2.x

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -11,6 +11,7 @@ import re
 import signal
 import sys
 import time
+import warnings
 
 import zmq
 


### PR DESCRIPTION
This might need to be targeted on 5.x. We were running into an issue where a warning was being issued without `import warnings` being done at the top.