### PR TITLE
return None kernel_spec if kernel_name not set

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -77,7 +77,7 @@ class KernelManager(ConnectionFileMixin):
 
     @property
     def kernel_spec(self):
-        if self._kernel_spec is None:
+        if self._kernel_spec is None and self.kernel_name is not '':
             self._kernel_spec = self.kernel_spec_manager.get_kernel_spec(self.kernel_name)
         return self._kernel_spec
 


### PR DESCRIPTION
This restores the ability of using the deprecated `kernel_cmd`, which previously allowed you to run an arbitrary kernel without having to write a kernelspec. Without this, when using `kernel_cmd`, a lookup on an empty `kernel_name` (with `""` as value) was being performed.