### PR TITLE
Prevent creating new console on Windows

### DIFF
--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -111,6 +111,10 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None, env=None,
                                      DUPLICATE_SAME_ACCESS)
             env['JPY_PARENT_PID'] = str(int(handle))
 
+        # Prevent creating new console window on pythonw
+        if redirect_out:
+            kwargs['creationflags'] = kwargs.setdefault('creationflags', 0) | 0x08000000 # CREATE_NO_WINDOW
+
     else:
         # Create a new session.
         # This makes it easier to interrupt the kernel,


### PR DESCRIPTION
When running Jupyter via pythonw e.g. pythonw -m qtconsole, jupyter_client launches new kernel via python.exe which is a console application on Windows - a side-effect of that is a new empty console window created and shown as long as kernel is running.

This patch adds CREATE_NO_WINDOW 0x08000000 to Windows specific creationflags. This flag is not exported by subprocess module therefore has to be provides numerically.

Read more, e.g.:
https://stackoverflow.com/questions/2935704/running-shell-commands-without-a-shell-window