### PR TITLE
Improve logic for restarting kernels with new ports during initial startup

### DIFF
--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -133,7 +133,7 @@ class KernelRestarter(LoggingConfigurable):
             self._restarting = False
 
     def is_kernel_response_timedout(self):
-        if self.kernel_monitor_enabled:
+        if self.kernel_monitor_enabled and self.startup_time > 0:
             if not self._kernel_info_requested:
                 self.kernel_client = self.kernel_manager.client()
                 self._kernel_info_timeout = time.time() + self.startup_time

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -36,7 +36,7 @@ class KernelRestarter(LoggingConfigurable):
         help="""Kernel heartbeat interval in seconds."""
     )
 
-    startup_time = Float(20.0, config=True,
+    startup_time = Float(0.0, config=True,
         help="""Waiting time for kernel_info reply during initial startup.
         0 indicates that kernel_info reply check disabled."""
     )

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -137,18 +137,18 @@ class KernelRestarter(LoggingConfigurable):
             if not self._kernel_info_requested:
                 self.kernel_client = self.kernel_manager.client()
                 self._kernel_info_timeout = time.time() + self.startup_time
-                self.log.info("KernelRestarter: Requesting kernel info")
+                self.log.debug("KernelRestarter: Requesting kernel info")
                 self.kernel_client.kernel_info()
                 self._kernel_info_requested = True
             if time.time() > self._kernel_info_timeout:
-                self.log.info("KernelRestarter: Kernel Info reply timed out")
+                self.log.warning("KernelRestarter: Kernel Info reply timed out. Restarting kernel")
                 self._kernel_info_requested = False
                 self._restarting = True
                 return True
             try:
                 msg = self.kernel_client.shell_channel.get_msg(block=True, timeout=0)
             except Empty:
-                self.log.info("KernelRestarter: No message received")
+                self.log.debug("KernelRestarter: No message received")
                 pass
             else:
                 if msg['msg_type'] == 'kernel_info_reply':

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -136,8 +136,8 @@ class KernelRestarter(LoggingConfigurable):
 
     def is_kernel_response_timedout(self):
         """
-        Sends kernel_info request and checks a response. If the response is not received within kernel info timeout
-        then returns True, and sets marks kernel as _restarting. If the response received or kernel startup timeout
+        The method sends kernel_info request and checks a response. If the response is not received within kernel info timeout
+        then returns True, and sets _restarting to True. If the response received or kernel startup timeout
         is not expired then returns False.
         :return: bool
         """

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -133,6 +133,12 @@ class KernelRestarter(LoggingConfigurable):
             self._restarting = False
 
     def is_kernel_response_timedout(self):
+        """
+        Sends kernel_info request and checks a response. If the response is not received within kernel info timeout
+        then returns True, and sets marks kernel as _restarting. If the response received or kernel startup timeout
+        is not expired then returns False.
+        :return: bool
+        """
         if self.kernel_monitor_enabled and self.startup_time > 0:
             if not self._kernel_info_requested:
                 self.kernel_client = self.kernel_manager.client()

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -13,6 +13,11 @@ from traitlets.config.configurable import LoggingConfigurable
 from traitlets import (
     Instance, Float, Dict, Bool, Integer,
 )
+import time
+try:
+    from queue import Empty  # Python 3
+except ImportError:
+    from Queue import Empty  # Python 2
 
 
 class KernelRestarter(LoggingConfigurable):
@@ -31,6 +36,10 @@ class KernelRestarter(LoggingConfigurable):
         help="""Kernel heartbeat interval in seconds."""
     )
 
+    startup_time = Float(20.0, config=True,
+        help="""Waiting time for kernel_info reply during initial startup"""
+    )
+
     restart_limit = Integer(5, config=True,
         help="""The number of consecutive autorestarts before the kernel is presumed dead."""
     )
@@ -38,9 +47,16 @@ class KernelRestarter(LoggingConfigurable):
     random_ports_until_alive = Bool(True, config=True,
         help="""Whether to choose new random ports when restarting before the kernel is alive."""
     )
+
+    kernel_monitor_enabled = Bool(True, config=True,
+        help="""Whether to restart kernel with new ports if response is not received within startup_time timeout"""
+    )
     _restarting = Bool(False)
     _restart_count = Integer(0)
     _initial_startup = Bool(True)
+    _kernel_info_requested = Bool(False)
+    _kernel_info_timeout = Float(0)
+    kernel_client = None
 
     callbacks = Dict()
     def _callbacks_default(self):
@@ -79,23 +95,22 @@ class KernelRestarter(LoggingConfigurable):
         except ValueError:
             pass
 
-    def _fire_callbacks(self, event):
+    def _fire_callbacks(self, event, **kwargs):
         """fire our callbacks for a particular event"""
         for callback in self.callbacks[event]:
             try:
-                callback()
+                callback(**kwargs)
             except Exception as e:
                 self.log.error("KernelRestarter: %s callback %r failed", event, callback, exc_info=True)
 
     def poll(self):
         if self.debug:
             self.log.debug('Polling kernel...')
-        if not self.kernel_manager.is_alive():
+        if not self.kernel_manager.is_alive() or self.is_kernel_response_timedout():
             if self._restarting:
                 self._restart_count += 1
             else:
                 self._restart_count = 1
-
             if self._restart_count >= self.restart_limit:
                 self.log.warning("KernelRestarter: restart failed")
                 self._fire_callbacks('dead')
@@ -109,12 +124,37 @@ class KernelRestarter(LoggingConfigurable):
                     self.restart_limit,
                     'new' if newports else 'keep'
                 )
-                self._fire_callbacks('restart')
                 self.kernel_manager.restart_kernel(now=True, newports=newports)
+                self._fire_callbacks('restart', newports=newports)
                 self._restarting = True
         else:
-            if self._initial_startup:
-                self._initial_startup = False
             if self._restarting:
                 self.log.debug("KernelRestarter: restart apparently succeeded")
             self._restarting = False
+
+    def is_kernel_response_timedout(self):
+        if self.kernel_monitor_enabled:
+            if not self._kernel_info_requested:
+                self.kernel_client = self.kernel_manager.client()
+                self._kernel_info_timeout = time.time() + self.startup_time
+                self.log.info("KernelRestarter: Requesting kernel info")
+                self.kernel_client.kernel_info()
+                self._kernel_info_requested = True
+            if time.time() > self._kernel_info_timeout:
+                self.log.info("KernelRestarter: Kernel Info reply timed out")
+                self._kernel_info_requested = False
+                self._restarting = True
+                return True
+            try:
+                msg = self.kernel_client.shell_channel.get_msg(block=True, timeout=0)
+            except Empty:
+                self.log.info("KernelRestarter: No message received")
+                pass
+            else:
+                if msg['msg_type'] == 'kernel_info_reply':
+                    self.kernel_client._handle_kernel_info_reply(msg)
+                    self.log.info("KernelRestarter: Kernel info reply received")
+                    self.kernel_monitor_enabled = False
+                    if self._initial_startup:
+                        self._initial_startup = False
+        return False

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -99,6 +99,9 @@ class KernelRestarter(LoggingConfigurable):
         for callback in self.callbacks[event]:
             try:
                 callback(**kwargs)
+            except TypeError:
+                self.log.warning("KernelRestarter: arguments are not supported by callback. Arguments will not be set")
+                callback()
             except Exception as e:
                 self.log.error("KernelRestarter: %s callback %r failed", event, callback, exc_info=True)
 


### PR DESCRIPTION
The proposal defines the logic in `restarter.py` for setting `_initial_startup` value to `False` only when the kernel sends kernel_info reply. Introduced changes solve issues described in https://github.com/jupyter/jupyter_client/issues/347. The introduced changes allow to identify issues with shell channel (e.g. due to the `ZMQError: Address already in use` issue)
The proposal also defines logic for notifying client (Notebook Server, Kernel gateway, etc.) that the kernel was restarted with new ports.
The Proposal includes the following changes:
- Add the logic for monitoring shell channel:
 - Configurable `startup_time` parameter is introduced. This parameter defines the timeout for kernel_reply response. Default value is set to 0 (kernel_info reply monitoring disables). It is disabled by default, because different kernels (e.g. kernels with spark context) require  different time before the kernel will be ready.
 - If `startup_time` > `0` then `kernel_info` request is sent to kernel with the first execution of restarter's `poll` function
 - Every time when `poll` function is executed the kernel_info response from shell channel is checked (within `startup_time`). It is done to prevent application blocking while waiting for the shell messages
 - After receiving `kernel_info` reply the kernel monitor is disabled
 - If the `kernel_info` reply is not received within `startup_time` then kernel is restarted with new ports and restart callback with `newports=True` parameter is executed
- Add `**kwargs` support for registered callback: `callback(**kwargs)`. If additional parameters are not supported then `callback()` will be executed.
- When the kernel is restarted then `newports` parameter indicating whether new ports are initialised is sent. Client could apply the action based on this information
- Restart callback is fired after `kernel_manager.restart_kernel` function is executed. It is required because a connection file with new ports is created during kernel restart