### PR TITLE
fix testing patch for pyzmq < 17

### DIFF
--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -41,7 +41,7 @@ class SessionTestCase(BaseZMQTestCase):
 @pytest.fixture
 def no_copy_threshold():
     """Disable zero-copy optimizations in pyzmq >= 17"""
-    with mock.patch.object(zmq, 'COPY_THRESHOLD', 1):
+    with mock.patch.object(zmq, 'COPY_THRESHOLD', 1, create=True):
         yield
 
 


### PR DESCRIPTION
zmq.COPY_THRESHOLD is undefined prior to pyzmq 17, so we need `create=True` to define it in that case.