### PR TITLE
Wrap setting of kernel_id with method that can then be overridden in …

### DIFF
--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -90,7 +90,7 @@ class MultiKernelManager(LoggingConfigurable):
 
         The kernel ID for the newly started kernel is returned.
         """
-        kernel_id = kwargs.pop('kernel_id', unicode_type(uuid.uuid4()))
+        kernel_id = self.determine_kernel_id(**kwargs)
         if kernel_id in self:
             raise DuplicateKernelError('Kernel already exists: %s' % kernel_id)
 
@@ -315,3 +315,13 @@ class MultiKernelManager(LoggingConfigurable):
         =======
         stream : zmq Socket or ZMQStream
         """
+
+    def determine_kernel_id(self, **kwargs):
+        """
+        Returns the kernel_id to use for this request.  If kernel_id is already in the arguments list,
+        that value will be used.  Otherwise, a newly generated uuid is used.  Subclasses may override
+        this method to substitute other sources of kernel ids.
+        :param kwargs:
+        :return: string-ized version 4 uuid
+        """
+        return kwargs.pop('kernel_id', unicode_type(uuid.uuid4()))

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -86,11 +86,11 @@ class MultiKernelManager(LoggingConfigurable):
         """Start a new kernel.
 
         The caller can pick a kernel_id by passing one in as a keyword arg,
-        otherwise one will be picked using a uuid.
+        otherwise one will be generated using new_kernel_id().
 
         The kernel ID for the newly started kernel is returned.
         """
-        kernel_id = self.determine_kernel_id(**kwargs)
+        kernel_id = kwargs.pop('kernel_id', self.new_kernel_id(**kwargs))
         if kernel_id in self:
             raise DuplicateKernelError('Kernel already exists: %s' % kernel_id)
 
@@ -316,12 +316,11 @@ class MultiKernelManager(LoggingConfigurable):
         stream : zmq Socket or ZMQStream
         """
 
-    def determine_kernel_id(self, **kwargs):
+    def new_kernel_id(self, **kwargs):
         """
-        Returns the kernel_id to use for this request.  If kernel_id is already in the arguments list,
-        that value will be used.  Otherwise, a newly generated uuid is used.  Subclasses may override
+        Returns the id to associate with the kernel for this request. Subclasses may override
         this method to substitute other sources of kernel ids.
         :param kwargs:
         :return: string-ized version 4 uuid
         """
-        return kwargs.pop('kernel_id', unicode_type(uuid.uuid4()))
+        return unicode_type(uuid.uuid4())


### PR DESCRIPTION
…subclasses.

A recent requirement for [Jupyter Enterprise Gateway](https://github.com/jupyter-incubator/enterprise_gateway) is for clients to be able to
specify the kernel_id for new kernels.  Although `jupyter_client.start_kernel()` will
honor client-provided kernel_ids, Notebook's override of `start_kernel()` changes
the semantics of a non-null kernel_id in the argument list to mean an existing
(persisted) kernel should be _started_.  As a result, applications that derive
from the kernel management infrastructure beyond Notebook cannot influence the
derivation of the kernel's id via the existing argument list behavior.

By introducing the `determine_kernel_id()` method, subclasses are able to derive
the kernel's id however they wish.

With the ability to know the kernel's id prior to its invocation, a number of
things can be done that wouldn't be possible otherwise.  For example, this
provides the ability to setup a shared filesystem location possibly pre-populated
with data relative to what the request (i.e., kernel) is going to need.