### PR TITLE
Fix memory leak of kernel Popen object

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -272,6 +272,10 @@ class KernelManager(ConnectionFileMixin):
             if self.is_alive():
                 time.sleep(pollinterval)
             else:
+                # If there's still a proc, wait and clear
+                if self.has_kernel:
+                    self.kernel.wait()
+                    self.kernel = None
                 break
         else:
             # OK, we've waited long enough.


### PR DESCRIPTION
After analyzing various leaked items when running either Notebook or
Jupyter Kernel Gateway, one item that recurred across each kernel
startup and shutdown sequence was the Popen object stored in the kernel
manager in `self.kernel`.

The issue is that in normal circumstances, when a kernel's termination
is successful via the ZMQ messaging, the process is never waited for
(which, in this case, is probably unnecessary but advised) nor is the
member variable set to None.  In the failing case, where the message-based
shutdown does not terminate the kernel process, the `_kill_kernel()`
method is used, which performs the `wait()` and _nullifies_ the kernel
member.  This change ensures that sequence occurs in normal situations
as well.