### PR TITLE
Fix leak of IOLoopKernelManager object

### DIFF
--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -54,6 +54,7 @@ class IOLoopKernelManager(KernelManager):
         if self.autorestart:
             if self._restarter is not None:
                 self._restarter.stop()
+                self._restarter = None
 
     connect_shell = as_zmqstream(KernelManager.connect_shell)
     connect_iopub = as_zmqstream(KernelManager.connect_iopub)

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -286,6 +286,7 @@ class KernelManager(ConnectionFileMixin):
 
         self.cleanup_ipc_files()
         self._close_control_socket()
+        self.session.parent = None
 
     def shutdown_kernel(self, now=False, restart=False):
         """Attempts to stop the kernel process cleanly.


### PR DESCRIPTION
After analyzing various leaked items when running either Notebook or
Jupyter Kernel Gateway, one item that recurred across each kernel
startup and shutdown sequence was an instance of IOLoopKernelManager.
(Of course, when using JKG, this instance was KernelGatewayIOLoopKernelManager
since it derives from the former.)

The leak is caused by the circular references established in the `self._restarter`
and `self.session.parent` members. This change breaks the circular reference when
the restarter is stopped and during `cleanup()` of the kernel manager.  Once the
references are broken, the kernel manager instance can be garbage collected.