### PR TITLE
A new message type transient_display_data for transient information

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1127,10 +1127,10 @@ Transient Display Data
 
 .. versionadded:: 5.3
 
-This message is very similar to `display_data` but its is content is meant to be
-transient (e.g. not saved in output areas of notebooks). Contents that can be sent
-through this message type can include but not limited to status information of long
-calculation and debug information.
+The `transient_display_data` message has the same `data` as `display_data` with
+an additional `title`, as well as a different intent. These messages are not to be
+persisted to notebooks or other formats. Examples of how this could be used are
+status of a long calculation, debug information, and help messages.
 
 .. _transient_display_data:
 
@@ -1138,24 +1138,43 @@ Message type: ``transient_display_data``::
 
     content = {
 
-        # Description of the data
+        # Description and identifier of the message
         'title': string,
 
-        # The data dict contains key/value pairs, where the keys are MIME
-        # types and the values are the raw data of the representation in that
-        # format.
+        # The data dict contains key/value pairs, where the keys are MIME types
+        # and the values are the raw data of the representation in that format
         'data' : dict,
 
-        # A boolean flag, which, if True, will not clear existing displayed
-        # message with the same title.
-        'append': False,
+        # metadata of the message
+        'metadata' : dict,
     }
 
 
 Frontends can choose where and how to display and update `transient_display_data`.
 Due to the transient nature of such messages, a `transient_display_data` message
-would generally replace prior output although multiple messages with the same
-`title` can be grouped with `append=True`.
+would generally be displayed in a common area and be replaced by the next
+`transient_display_data` message. Two `metadata` are currently defined to adjust
+this behavior:
+
+.. sourcecode:: python
+
+    metadata = {
+
+        # A boolean flag, which, if True, will append the message to previous
+        # messages with the same title
+        'append' : false,
+
+        # Name of a 'page' to display the message. By default all messages will
+        # be sent to an "Info" panel but a different panel with specified
+        # name (e.g. `Help`) can be created and used
+        'page' : string,
+    }
+
+
+Basically, `append` allows the aggregation of multiple `transient_display_data`
+messages (e.g. debug information) with the same `title` and `page` allows the
+separation of `transient_display_data` messages into different groups.
+
 
 Code inputs
 -----------

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1122,6 +1122,41 @@ Frontends can choose how they update prior outputs (or if they regard this as a
 regular ``display_data`` message). Within the jupyter and nteract_ notebooks,
 all displays that match the ``display_id`` are updated (even if there are multiple).
 
+Transient Display Data
+----------------------
+
+.. versionadded:: 5.3
+
+This message is very similar to `display_data` but its is content is meant to be
+transient (e.g. not saved in output areas of notebooks). Contents that can be sent
+through this message type can include but not limited to status information of long
+calculation and debug information.
+
+.. _transient_display_data:
+
+Message type: ``transient_display_data``::
+
+    content = {
+
+        # Description of the data
+        'title': string,
+
+        # The data dict contains key/value pairs, where the keys are MIME
+        # types and the values are the raw data of the representation in that
+        # format.
+        'data' : dict,
+
+        # A boolean flag, which, if True, will not clear existing displayed
+        # message with the same title.
+        'append': False,
+    }
+
+
+Frontends can choose where and how to display and update `transient_display_data`.
+Due to the transient nature of such messages, a `transient_display_data` message
+would generally replace prior output although multiple messages with the same
+`title` can be grouped with `append=True`.
+
 Code inputs
 -----------
 

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1127,19 +1127,16 @@ Transient Display Data
 
 .. versionadded:: 5.3
 
-The `transient_display_data` message has the same `data` as `display_data` with
-an additional `title`, as well as a different intent. These messages are not to be
-persisted to notebooks or other formats. Examples of how this could be used are
-status of a long calculation, debug information, and help messages.
+The `transient_display_data` message is identical to `display_data` in format but
+has a different intent. These messages are not to be persisted to notebooks or other
+formats. Examples of how this could be used are status of a long calculation, debug
+information, and help messages.
 
 .. _transient_display_data:
 
 Message type: ``transient_display_data``::
 
     content = {
-
-        # Description and identifier of the message
-        'title': string,
 
         # The data dict contains key/value pairs, where the keys are MIME types
         # and the values are the raw data of the representation in that format
@@ -1150,36 +1147,18 @@ Message type: ``transient_display_data``::
     }
 
 
-Frontends can choose where and how to display and update `transient_display_data`.
-Due to the transient nature of such messages, a `transient_display_data` message
-would generally be displayed in a common area and be replaced by the next
-`transient_display_data` message. Three `metadata` are currently defined to adjust
-this behavior:
+A `metadata` is allowed but no field is defined.
 
 .. sourcecode:: python
 
     metadata = {
-
-        # A boolean flag, which, if True, will append the message to previous
-        # messages with the same title
-        'append' : false,
-
-        # Name of a 'page' to display the message. By default all messages will
-        # be sent to an "Info" panel but a different panel with specified
-        # name (e.g. `Help`) can be created and used
-        'page' : string,
-
-        # Importance of the message type so that messages of low priority
-        # (e.g. logging messages) can be accumulated in the background when
-        # more important messages are being displayed.
-        'rank' : int,
     }
 
 
-Basically, `append` allows the aggregation of multiple `transient_display_data`
-messages (e.g. debug information) with the same `title`, `page` allows the
-separation of `transient_display_data` messages into different groups, and
-`rank` avoids frequent UI updates caused by less important messages.
+Frontends can choose where and how to display and update `transient_display_data`,
+or just ignore them. Due to the transient nature of such messages,
+`transient_display_data` messages would generally be displayed in a common area
+sequentially, with limited history.
 
 
 Code inputs

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1153,7 +1153,7 @@ Message type: ``transient_display_data``::
 Frontends can choose where and how to display and update `transient_display_data`.
 Due to the transient nature of such messages, a `transient_display_data` message
 would generally be displayed in a common area and be replaced by the next
-`transient_display_data` message. Two `metadata` are currently defined to adjust
+`transient_display_data` message. Three `metadata` are currently defined to adjust
 this behavior:
 
 .. sourcecode:: python
@@ -1168,12 +1168,18 @@ this behavior:
         # be sent to an "Info" panel but a different panel with specified
         # name (e.g. `Help`) can be created and used
         'page' : string,
+
+        # Importance of the message type so that messages of low priority
+        # (e.g. logging messages) can be accumulated in the background when
+        # more important messages are being displayed.
+        'rank' : int,
     }
 
 
 Basically, `append` allows the aggregation of multiple `transient_display_data`
-messages (e.g. debug information) with the same `title` and `page` allows the
-separation of `transient_display_data` messages into different groups.
+messages (e.g. debug information) with the same `title`, `page` allows the
+separation of `transient_display_data` messages into different groups, and
+`rank` avoids frequent UI updates caused by less important messages.
 
 
 Code inputs


### PR DESCRIPTION
A proposal for a new `transient_display_data` message type (#376) with content that is **identical to `display_data`**. The messages are supposed to be displayed (or ignored) by the clients but not saved with the notebooks. [This post](https://github.com/jupyter/jupyter_client/pull/378#issuecomment-386760939) list some applications of this message type.

```
    content = {
        # The data dict contains key/value pairs, where the keys are MIME types
        # and the values are the raw data of the representation in that format
        'data' : dict,

        # metadata of the message
        'metadata' : dict,
    }
```
A `metadata` is allowed but no field is defined for now

```
    metadata = {
    }
```

**Update Dec 2018**: There has been some discussions about this message type in a JupyterLab developer meeting. The conclusion was that it is good enough (at least for now) to display the messages sequentially in a UI separated from the notebook so all the complex `title`, `page` stuff are removed from the original version of the PR. A PR is submitted to JLab to display this message in console windows jupyterlab/jupyterlab#5699.

**Update March 2019**: With the release of JupyterLab 1.0.0 alpha 3, a jupyterlab extension [transient-display-data](https://github.com/vatlab/transient-display-data) was released to send all `transient_display_data` to the console panel of notebooks. In addition, a new version of [jupyterlab-sos](https://github.com/vatlab/jupyterlab-sos) was released to make use of this feature. The easiest way to test this feature is to [go to our live server](http://128.135.144.117:8000/hub/user-redirect/lab), start a notebook with a SoS kernel, open a console window,  then execute the following trivial workflow in the notebook:

```
%run

import time

[1]
time.sleep(5)

[2]
time.sleep(5)
```
The idea is that the console window will display progress information while the workflow is running.