### PR TITLE
update python version testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
     - "nightly"
-    - "3-7-dev"
+    - "3.7-dev"
     - 3.6
     - 3.5
     - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
     - "nightly"
-    - '3.6-dev'
+    - "3-7-dev"
+    - 3.6
     - 3.5
     - 3.4
-    - 3.3
     - 2.7
 sudo: false
 install:

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -141,7 +141,7 @@ class TestSession(SessionTestCase):
 
         # buffers must be contiguous
         buf = memoryview(os.urandom(16))
-        if sys.version_info >= (3,3):
+        if sys.version_info >= (3,4):
             with self.assertRaises(ValueError):
                 self.session.send(A, msg, ident=b'foo', buffers=[buf[::2]])
 
@@ -339,7 +339,7 @@ class TestSession(SessionTestCase):
         A.close()
         B.close()
         ctx.term()
-    
+
     def test_clone(self):
         s = self.session
         s._add_digest('initial')

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ name = 'jupyter_client'
 import sys
 
 v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
-    error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
+if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,4)):
+    error = "ERROR: %s requires Python version 2.7 or 3.4 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -92,10 +92,9 @@ setup_args = dict(
         'entrypoints',
         'tornado>=4.1',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     extras_require   = {
         'test': ['ipykernel', 'ipython', 'mock'],
-        'test:python_version == "3.3"': ['pytest>=3,<3.3.0'],
         'test:(python_version >= "3.4" or python_version == "2.7")': ['pytest'],
     },
     cmdclass         = {


### PR DESCRIPTION
3.3is EOL since last year, and pip print warnings in the test-suite.