### PR TITLE
Don't include extra buffers in message signature

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -779,7 +779,8 @@ class Session(Configurable):
             to_send.extend(ident)
 
         to_send.append(DELIM)
-        to_send.append(self.sign(msg_list))
+        # Don't include buffers in signature (per spec).
+        to_send.append(self.sign(msg_list[0:4]))
         to_send.extend(msg_list)
         stream.send_multipart(to_send, flags, copy=copy)
 


### PR DESCRIPTION
Closes #383 and makes `Session.send_raw` compliant with the protocol wire specification (w.r.t. signing optional binary data buffers at the end of messages).

Not sure if this would warrant test cases on the way signatures are handled in the presence of data buffers.