### PR TITLE
Updates to the kernel messaging spec

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1228,7 +1228,8 @@ Message type: ``status``::
     content = {
         # When the kernel starts to handle a message, it will enter the 'busy'
         # state and when it finishes, it will enter the 'idle' state.
-        execution_state : ('busy', 'idle', other optional states)
+        # The kernel will publish state 'starting' exactly once at process startup.
+        execution_state : ('busy', 'idle', 'starting')
     }
 
 When a kernel receives a request and begins processing it,
@@ -1238,10 +1239,6 @@ and has finished publishing associated IOPub messages, if any,
 it shall publish a status message with ``execution_state: 'idle'``.
 Thus, the outputs associated with a given execution shall generally arrive
 between the busy and idle status messages associated with a given request.
-
-A kernel may send optional status messages with execution states other than
-`busy` or `idle`. For example, a kernel may send a status message with a
-`starting` execution state exactly once at process startup.
 
 .. note::
 

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1205,6 +1205,8 @@ Message type: ``error``::
 
     ``pyerr`` renamed to ``error``
 
+.. _status:
+
 Kernel status
 -------------
 
@@ -1215,8 +1217,7 @@ Message type: ``status``::
     content = {
         # When the kernel starts to handle a message, it will enter the 'busy'
         # state and when it finishes, it will enter the 'idle' state.
-        # The kernel will publish state 'starting' exactly once at process startup.
-        execution_state : ('busy', 'idle', 'starting')
+        execution_state : ('busy', 'idle', other optional states)
     }
 
 When a kernel receives a request and begins processing it,
@@ -1226,6 +1227,10 @@ and has finished publishing associated IOPub messages, if any,
 it shall publish a status message with ``execution_state: 'idle'``.
 Thus, the outputs associated with a given execution shall generally arrive
 between the busy and idle status messages associated with a given request.
+
+A kernel may send optional status messages with execution states other than
+`busy` or `idle`. For example, a kernel may send a status message with a
+`starting` execution state exactly once at process startup.
 
 .. note::
 
@@ -1242,14 +1247,6 @@ between the busy and idle status messages associated with a given request.
 
     Busy and idle messages should be sent before/after handling every request,
     not just execution.
-
-.. note::
-
-    Extra status messages are added between the notebook webserver and websocket clients
-    that are not sent by the kernel. These are:
-
-    - restarting (kernel has died, but will be automatically restarted)
-    - dead (kernel has died, restarting has failed)
 
 Clear output
 ------------

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -124,15 +124,26 @@ A message is defined by the following four-dictionary structure::
 
 .. note::
 
-A client session value, in message headers from a client, should be unique among
-all clients connected to a kernel and should be constant over the lifetime of
-the client. A kernel session value, in message headers from a kernel, should be
-generated on kernel startup or restart and should be constant for the lifetime
-of the kernel.
+    The ``session`` id in a message header identifies a unique entity with state,
+    such as a kernel process or client process.
+
+    A client session id, in message headers from a client, should be unique among
+    all clients connected to a kernel. When a client reconnects to a kernel, it
+    should use the same client session id in its message headers. When a client
+    restarts, it should generate a new client session id.
+
+    A kernel session id, in message headers from a kernel, should identify a
+    particular kernel process. If a kernel is restarted, the kernel session id
+    should be regenerated.
+
+    The session id in a message header can be used to identify the sending entity.
+    For example, if a client disconnects and reconnects to a kernel, and messages
+    from the kernel have a different kernel session id than prior to the disconnect,
+    the client should assume that the kernel was restarted.
 
 .. versionchanged:: 5.0
 
-   ``version`` key added to the header.
+    ``version`` key added to the header.
 
 .. versionchanged:: 5.1
 

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -122,6 +122,14 @@ A message is defined by the following four-dictionary structure::
       'buffers': list,
     }
 
+.. note::
+
+A client session value, in message headers from a client, should be unique among
+all clients connected to a kernel and should be constant over the lifetime of
+the client. A kernel session value, in message headers from a kernel, should be
+generated on kernel startup or restart and should be constant for the lifetime
+of the kernel.
+
 .. versionchanged:: 5.0
 
    ``version`` key added to the header.

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -147,8 +147,9 @@ Compatibility
 =============
 
 Kernels must implement the :ref:`execute <execute>` and :ref:`kernel info
-<msging_kernel_info>` messages in order to be usable. All other message types
-are optional, although we recommend implementing :ref:`completion
+<msging_kernel_info>` messages, along with the associated busy and idle
+:ref:`status` messages. All other message types are
+optional, although we recommend implementing :ref:`completion
 <msging_completion>` if possible. Kernels do not need to send any reply for
 messages they don't handle, and frontends should provide sensible behaviour if
 no reply arrives (except for the required execution and kernel info messages).

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -943,8 +943,7 @@ multiple cases:
 
 The client sends a shutdown request to the kernel, and once it receives the
 reply message (which is otherwise empty), it can assume that the kernel has
-completed shutdown safely.  The request can be sent on either the `control` or
-`shell` channels.
+completed shutdown safely.  The request is sent on the `control` channel.
 
 Upon their own shutdown, client applications will typically execute a last
 minute sanity check and forcefully terminate any kernel that is still alive, to
@@ -967,6 +966,12 @@ Message type: ``shutdown_reply``::
    When the clients detect a dead kernel thanks to inactivity on the heartbeat
    socket, they simply send a forceful process termination signal, since a dead
    process is unlikely to respond in any useful way to messages.
+
+.. versionchanged:: 5.4
+
+    Sending a ``shutdown_request`` message on the ``shell`` channel is deprecated.
+
+
 
 .. _msging_interrupt:
 

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -35,12 +35,13 @@ def validate_string_dict(dct):
 class KernelClient(ConnectionFileMixin):
     """Communicates with a single kernel on any host via zmq channels.
 
-    There are four channels associated with each kernel:
+    There are five channels associated with each kernel:
 
     * shell: for request/reply calls to the kernel.
     * iopub: for the kernel to publish results to frontends.
     * hb: for monitoring the kernel's heartbeat.
     * stdin: for frontends to reply to raw_input calls in the kernel.
+    * control: for kernel management calls to the kernel.
 
     The messages that can be sent on these channels are exposed as methods of the
     client (KernelClient.execute, complete, history, etc.). These methods only
@@ -58,12 +59,14 @@ class KernelClient(ConnectionFileMixin):
     iopub_channel_class = Type(ChannelABC)
     stdin_channel_class = Type(ChannelABC)
     hb_channel_class = Type(HBChannelABC)
+    control_channel_class = Type(ChannelABC)
 
     # Protected traits
     _shell_channel = Any()
     _iopub_channel = Any()
     _stdin_channel = Any()
     _hb_channel = Any()
+    _control_channel = Any()
 
     # flag for whether execute requests should be allowed to call raw_input:
     allow_stdin = True
@@ -84,11 +87,15 @@ class KernelClient(ConnectionFileMixin):
         """Get a message from the stdin channel"""
         return self.stdin_channel.get_msg(*args, **kwargs)
 
+    def get_control_msg(self, *args, **kwargs):
+        """Get a message from the control channel"""
+        return self.control_channel.get_msg(*args, **kwargs)
+
     #--------------------------------------------------------------------------
     # Channel management methods
     #--------------------------------------------------------------------------
 
-    def start_channels(self, shell=True, iopub=True, stdin=True, hb=True):
+    def start_channels(self, shell=True, iopub=True, stdin=True, hb=True, control=True):
         """Starts the channels for this kernel.
 
         This will create the channels if they do not exist and then start
@@ -109,6 +116,9 @@ class KernelClient(ConnectionFileMixin):
             self.allow_stdin = False
         if hb:
             self.hb_channel.start()
+        if control:
+            self.control_channel.start()
+            self.kernel_info()
 
     def stop_channels(self):
         """Stops all the running channels for this kernel.
@@ -123,12 +133,15 @@ class KernelClient(ConnectionFileMixin):
             self.stdin_channel.stop()
         if self.hb_channel.is_alive():
             self.hb_channel.stop()
+        if self.control_channel.is_alive():
+            self.control_channel.stop()
 
     @property
     def channels_running(self):
         """Are any of the channels created and running?"""
         return (self.shell_channel.is_alive() or self.iopub_channel.is_alive() or
-                self.stdin_channel.is_alive() or self.hb_channel.is_alive())
+                self.stdin_channel.is_alive() or self.hb_channel.is_alive() or
+                self.control_channel.is_alive())
 
     ioloop = None  # Overridden in subclasses that use pyzmq event loop
 
@@ -178,6 +191,18 @@ class KernelClient(ConnectionFileMixin):
                 self.context, self.session, url
             )
         return self._hb_channel
+
+    @property
+    def control_channel(self):
+        """Get the control channel object for this kernel."""
+        if self._control_channel is None:
+            url = self._make_url('control')
+            self.log.debug("connecting control channel to %s", url)
+            socket = self.connect_control(identity=self.session.bsession)
+            self._control_channel = self.control_channel_class(
+                socket, self.session, self.ioloop
+            )
+        return self._control_channel
 
     def is_alive(self):
         """Is the kernel process still running?"""
@@ -401,7 +426,7 @@ class KernelClient(ConnectionFileMixin):
         # Send quit message to kernel. Once we implement kernel-side setattr,
         # this should probably be done that way, but for now this will do.
         msg = self.session.msg('shutdown_request', {'restart':restart})
-        self.shell_channel.send(msg)
+        self.control_channel.send(msg)
         return msg['header']['msg_id']
 
     def is_complete(self, code):

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -118,7 +118,6 @@ class KernelClient(ConnectionFileMixin):
             self.hb_channel.start()
         if control:
             self.control_channel.start()
-            self.kernel_info()
 
     def stop_channels(self):
         """Stops all the running channels for this kernel.

--- a/jupyter_client/clientabc.py
+++ b/jupyter_client/clientabc.py
@@ -47,12 +47,16 @@ class KernelClientABC(with_metaclass(abc.ABCMeta, object)):
     def stdin_channel_class(self):
         pass
 
+    @abc.abstractproperty
+    def control_channel_class(self):
+        pass
+
     #--------------------------------------------------------------------------
     # Channel management methods
     #--------------------------------------------------------------------------
 
     @abc.abstractmethod
-    def start_channels(self, shell=True, iopub=True, stdin=True, hb=True):
+    def start_channels(self, shell=True, iopub=True, stdin=True, hb=True, control=True):
         pass
 
     @abc.abstractmethod
@@ -77,4 +81,8 @@ class KernelClientABC(with_metaclass(abc.ABCMeta, object)):
 
     @abc.abstractproperty
     def hb_channel(self):
+        pass
+
+    @abc.abstractproperty
+    def control_channel(self):
         pass

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -226,7 +226,7 @@ def find_connection_file(filename='kernel-*.json', path=None, profile=None):
 def tunnel_to_kernel(connection_info, sshserver, sshkey=None):
     """tunnel connections to a kernel via ssh
 
-    This will open four SSH tunnels from localhost on this machine to the
+    This will open five SSH tunnels from localhost on this machine to the
     ports associated with the kernel.  They can be either direct
     localhost-localhost tunnels, or if an intermediate server is necessary,
     the kernel must be listening on a public IP.
@@ -246,8 +246,8 @@ def tunnel_to_kernel(connection_info, sshserver, sshkey=None):
     Returns
     -------
 
-    (shell, iopub, stdin, hb) : ints
-        The four ports on localhost that have been forwarded to the kernel.
+    (shell, iopub, stdin, hb, control) : ints
+        The five ports on localhost that have been forwarded to the kernel.
     """
     from .ssh import tunnel
     if isinstance(connection_info, string_types):
@@ -257,8 +257,8 @@ def tunnel_to_kernel(connection_info, sshserver, sshkey=None):
 
     cf = connection_info
 
-    lports = tunnel.select_random_ports(4)
-    rports = cf['shell_port'], cf['iopub_port'], cf['stdin_port'], cf['hb_port']
+    lports = tunnel.select_random_ports(5)
+    rports = cf['shell_port'], cf['iopub_port'], cf['stdin_port'], cf['hb_port'], cf['control_port']
 
     remote_ip = cf['ip']
 

--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -72,6 +72,7 @@ app_aliases = dict(
     shell = 'JupyterConsoleApp.shell_port',
     iopub = 'JupyterConsoleApp.iopub_port',
     stdin = 'JupyterConsoleApp.stdin_port',
+    control = 'JupyterConsoleApp.control_port',
     existing = 'JupyterConsoleApp.existing',
     f = 'JupyterConsoleApp.connection_file',
 
@@ -222,7 +223,8 @@ class JupyterConsoleApp(ConnectionFileMixin):
                     shell_port=self.shell_port,
                     iopub_port=self.iopub_port,
                     stdin_port=self.stdin_port,
-                    hb_port=self.hb_port
+                    hb_port=self.hb_port,
+                    control_port=self.control_port
         )
         
         self.log.info("Forwarding connections to %s via %s"%(ip, self.sshserver))
@@ -236,7 +238,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
             self.log.error("Could not setup tunnels", exc_info=True)
             self.exit(1)
         
-        self.shell_port, self.iopub_port, self.stdin_port, self.hb_port = newports
+        self.shell_port, self.iopub_port, self.stdin_port, self.hb_port, self.control_port = newports
         
         cf = self.connection_file
         root, ext = os.path.splitext(cf)
@@ -275,6 +277,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
                                     iopub_port=self.iopub_port,
                                     stdin_port=self.stdin_port,
                                     hb_port=self.hb_port,
+                                    control_port=self.control_port,
                                     connection_file=self.connection_file,
                                     kernel_name=self.kernel_name,
                                     parent=self,
@@ -302,6 +305,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
         self.iopub_port=km.iopub_port
         self.stdin_port=km.stdin_port
         self.hb_port=km.hb_port
+        self.control_port=km.control_port
         self.connection_file = km.connection_file
 
         atexit.register(self.kernel_manager.cleanup_connection_file)
@@ -318,6 +322,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
                                 iopub_port=self.iopub_port,
                                 stdin_port=self.stdin_port,
                                 hb_port=self.hb_port,
+                                control_port=self.control_port,
                                 connection_file=self.connection_file,
                                 parent=self,
             )

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -297,7 +297,7 @@ class KernelManager(ConnectionFileMixin):
 
         This attempts to shutdown the kernels cleanly by:
 
-        1. Sending it a shutdown message over the shell channel.
+        1. Sending it a shutdown message over the control channel.
         2. If that fails, the kernel is shutdown forcibly by sending it
            a signal.
 

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -230,14 +230,14 @@ class ThreadedKernelClient(KernelClient):
 
     ioloop_thread = Instance(IOLoopThread, allow_none=True)
 
-    def start_channels(self, shell=True, iopub=True, stdin=True, hb=True):
+    def start_channels(self, shell=True, iopub=True, stdin=True, hb=True, control=True):
         self.ioloop_thread = IOLoopThread()
         self.ioloop_thread.start()
 
         if shell:
             self.shell_channel._inspect = self._check_kernel_info_reply
 
-        super(ThreadedKernelClient, self).start_channels(shell, iopub, stdin, hb)
+        super(ThreadedKernelClient, self).start_channels(shell, iopub, stdin, hb, control)
 
     def _check_kernel_info_reply(self, msg):
         """This is run in the ioloop thread when the kernel info reply is received
@@ -255,3 +255,4 @@ class ThreadedKernelClient(KernelClient):
     shell_channel_class = Type(ThreadedZMQSocketChannel)
     stdin_channel_class = Type(ThreadedZMQSocketChannel)
     hb_channel_class = Type(HBChannel)
+    control_channel_class = Type(ThreadedZMQSocketChannel)


### PR DESCRIPTION
These came out of conversations with @minrk.

CC also @SylvainCorlay, who I think has been advocating for the deprecation of sending a shutdown message on the shell channel.

Marking as work-in-progress since I plan to work on this more in the near future. But I also think these changes are pretty self-contained, so I wouldn't regret us merging these now and submitting another PR later either.
