### PR TITLE
Allow third-party kernels to get additional args

### DIFF
--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -285,10 +285,8 @@ class JupyterConsoleApp(ConnectionFileMixin):
             self.exit(1)
 
         self.kernel_manager.client_factory = self.kernel_client_class
-        # FIXME: remove special treatment of IPython kernels
         kwargs = {}
-        if self.kernel_manager.ipykernel:
-            kwargs['extra_arguments'] = self.kernel_argv
+        kwargs['extra_arguments'] = self.kernel_argv
         self.kernel_manager.start_kernel(**kwargs)
         atexit.register(self.kernel_manager.cleanup_ipc_files)
 


### PR DESCRIPTION
This removes special treatment of IPython console so that other kernels can get command-line args. This doesn't allow the passing of flags, but does allow filenames, etc. Once this fix is in place, kernels can get these args via self.parent.extra_args