### PR TITLE
Removed static connection file naming

### DIFF
--- a/jupyter_client/kernelapp.py
+++ b/jupyter_client/kernelapp.py
@@ -32,8 +32,6 @@ class KernelApp(JupyterApp):
         super(KernelApp, self).initialize(argv)
         self.km = KernelManager(kernel_name=self.kernel_name,
                                 config=self.config)
-        cf_basename = 'kernel-%s.json' % uuid.uuid4()
-        self.km.connection_file = os.path.join(self.runtime_dir, cf_basename)
         self.loop = IOLoop.current()
         self.loop.add_callback(self._record_started)
 

--- a/jupyter_client/tests/test_kernelapp.py
+++ b/jupyter_client/tests/test_kernelapp.py
@@ -37,7 +37,7 @@ def test_kernelapp_lifecycle():
     try:
         p = _launch({'JUPYTER_RUNTIME_DIR': runtime_dir,
                      'JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE': started,
-                    })
+                     },)
         # Wait for start
         for _ in range(WAIT_TIME * POLL_FREQ):
             if os.path.isfile(started):
@@ -47,18 +47,10 @@ def test_kernelapp_lifecycle():
             raise AssertionError("No started file created in {} seconds"
                                  .format(WAIT_TIME))
 
-        # Connection file should be there by now
-        files = os.listdir(runtime_dir)
-        assert len(files) == 1
-        cf = files[0]
-        assert cf.startswith('kernel')
-        assert cf.endswith('.json')
-
         # Send SIGTERM to shut down
         p.terminate()
         if PY3:
             _, stderr = p.communicate(timeout=WAIT_TIME)
-            assert cf in stderr.decode('utf-8', 'replace')
         else:
             hacky_wait(p)
     finally:


### PR DESCRIPTION
I removed the static connection file name declaration on kernelapp initialize method.

There was also an issue about this: Fixes #381 