### PR TITLE
set close_fds=False when starting kernels on Windows

### DIFF
--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -101,7 +101,8 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None, env=None,
         except:
             from _subprocess import DuplicateHandle, GetCurrentProcess, \
                 DUPLICATE_SAME_ACCESS, CREATE_NEW_PROCESS_GROUP
-        # Launch the kernel process
+
+        # create a handle on the parent to be inherited
         if independent:
             kwargs['creationflags'] = CREATE_NEW_PROCESS_GROUP
         else:
@@ -115,6 +116,11 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None, env=None,
         if redirect_out:
             kwargs['creationflags'] = kwargs.setdefault('creationflags', 0) | 0x08000000 # CREATE_NO_WINDOW
 
+        # Avoid closing the above parent and interrupt handles.
+        # close_fds is True by default on Python >=3.7
+        # or when no stream is captured on Python <3.7
+        # (we always capture stdin, so this is already False by default on <3.7)
+        kwargs['close_fds'] = False
     else:
         # Create a new session.
         # This makes it easier to interrupt the kernel,


### PR DESCRIPTION
Python 3.7 sets close_fds=True by default, closing the interrupt/parent handles we are trying to pass to the kernel.

We can be more explicit and use the new [STARTUPINFO.lpAttributeList](https://docs.python.org/3/library/subprocess.html?highlight=close_fds#subprocess.STARTUPINFO.lpAttributeList) (the reason for the change in default behavior) in the future to explicitly inherit only these handles, but this preserves the pre-3.7 behavior on 3.7, getting kernels back to working on py37.

closes https://github.com/ipython/ipykernel/issues/374

cf https://github.com/spyder-ide/spyder/issues/8013