### PR TITLE
Fix documentation error.

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -415,7 +415,7 @@ Execution results
 Message type: ``execute_reply``::
 
     content = {
-      # One of: 'ok' OR 'error' OR 'abort'
+      # One of: 'ok' OR 'error' OR 'aborted'
       'status' : str,
 
       # The global kernel counter that increases by one with each request that


### PR DESCRIPTION
Consider the following sequence of events for a kernel.
* Client A sends execution request (id: R1)
* Client B sends execution request (id: R2)
* R1 raises an exception
* Client A receives `execute_reply` with content `{"status": "error", ...}`
* Client B recieves `execute_reply` with content `{"status": "aborted"}`

The documentation says that B should received `abort` rather than `aborted`, but the IPython kernel returns `aborted` (and is probably what it actually should be).

Additionally, the language around `stop_on_error` is confusing (I think the documentation has it backwards but I'm not sure).