### PR TITLE
 Apply the traitlets observe and default patterns

### DIFF
--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -18,7 +18,7 @@ import time
 
 import zmq
 
-from traitlets import Type
+from traitlets import Type, default
 from jupyter_client.channels import HBChannel
 from jupyter_client.client import KernelClient
 from .channels import ZMQSocketChannel
@@ -163,7 +163,8 @@ class BlockingKernelClient(KernelClient):
     shutdown = reqrep(KernelClient.shutdown)
 
 
-    def _stdin_hook_default(self, msg):
+    @default('stdin_hook')
+    def _default_stdin_hook(self, msg):
         """Handle an input request"""
         content = msg['content']
         if content.get('password', False):
@@ -187,7 +188,8 @@ class BlockingKernelClient(KernelClient):
         if not (self.stdin_channel.msg_ready() or self.shell_channel.msg_ready()):
             self.input(raw_data)
 
-    def _output_hook_default(self, msg):
+    @default('output_hook')
+    def _default_output_hook(self, msg):
         """Default hook for redisplaying plain-text output"""
         msg_type = msg['header']['msg_type']
         content = msg['content']
@@ -282,7 +284,7 @@ class BlockingKernelClient(KernelClient):
                               stop_on_error=stop_on_error,
         )
         if stdin_hook is None:
-            stdin_hook = self._stdin_hook_default
+            stdin_hook = self._default_stdin_hook
         if output_hook is None:
             # detect IPython kernel
             if 'IPython' in sys.modules:
@@ -298,7 +300,7 @@ class BlockingKernelClient(KernelClient):
                     )
         if output_hook is None:
             # default: redisplay plain-text outputs
-            output_hook = self._output_hook_default
+            output_hook = self._default_output_hook
 
         # set deadline based on timeout
         if timeout is not None:

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -10,7 +10,7 @@ from ipython_genutils.py3compat import string_types, iteritems
 import zmq
 
 from traitlets import (
-    Any, Instance, Type,
+    Any, Instance, Type, default, observe
 )
 
 from .channelsabc import (ChannelABC, HBChannelABC)
@@ -50,7 +50,8 @@ class KernelClient(ConnectionFileMixin):
 
     # The PyZMQ Context to use for communication with the kernel.
     context = Instance(zmq.Context)
-    def _context_default(self):
+    @default('context')
+    def _default_context(self):
         return zmq.Context.instance()
 
     # The classes to use for the various channels

--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -18,7 +18,7 @@ import warnings
 from traitlets.config.application import boolean_flag
 from ipython_genutils.path import filefind
 from traitlets import (
-    Dict, List, Unicode, CUnicode, CBool, Any
+    Dict, List, Unicode, CUnicode, CBool, Any, default, observe
 )
 
 from jupyter_core.application import base_flags, base_aliases
@@ -122,7 +122,8 @@ class JupyterConsoleApp(ConnectionFileMixin):
     sshkey = Unicode('', config=True,
         help="""Path to the ssh key to use for logging in to the ssh server.""")
     
-    def _connection_file_default(self):
+    @default('connection_file')
+    def _default_connection_file(self):
         return 'kernel-%i.json' % os.getpid()
 
     existing = CUnicode('', config=True,

--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -11,6 +11,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 from traitlets import (
     Instance,
     Type,
+    default
 )
 
 from jupyter_client.manager import KernelManager
@@ -26,7 +27,8 @@ def as_zmqstream(f):
 class IOLoopKernelManager(KernelManager):
 
     loop = Instance('tornado.ioloop.IOLoop')
-    def _loop_default(self):
+    @default('loop')
+    def _default_loop(self):
         return ioloop.IOLoop.current()
 
     restarter_class = Type(

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -14,14 +14,16 @@ from zmq.eventloop import ioloop
 
 from jupyter_client.restarter import KernelRestarter
 from traitlets import (
-    Instance,
+    Instance, default
+
 )
 
 class IOLoopKernelRestarter(KernelRestarter):
     """Monitor and autorestart a kernel."""
 
     loop = Instance('tornado.ioloop.IOLoop')
-    def _loop_default(self):
+    @default('loop')
+    def _default_loop(self):
         warnings.warn("IOLoopKernelRestarter.loop is deprecated in jupyter-client 5.2",
             DeprecationWarning, stacklevel=4,
         )

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -15,7 +15,7 @@ pjoin = os.path.join
 
 from ipython_genutils.py3compat import PY3
 from traitlets import (
-    HasTraits, List, Unicode, Dict, Set, Bool, Type, CaselessStrEnum
+    HasTraits, List, Unicode, Dict, Set, Bool, Type, CaselessStrEnum, default, observe
 )
 from traitlets.config import LoggingConfigurable
 
@@ -127,11 +127,13 @@ class KernelSpecManager(LoggingConfigurable):
     )
 
     data_dir = Unicode()
-    def _data_dir_default(self):
+    @default('data_dir')
+    def _default_data_dir(self):
         return jupyter_data_dir()
 
     user_kernel_dir = Unicode()
-    def _user_kernel_dir_default(self):
+    @default('user_kernel_dir')
+    def _default_user_kernel_dir(self):
         return pjoin(self.data_dir, 'kernels')
 
     whitelist = Set(config=True,
@@ -143,7 +145,8 @@ class KernelSpecManager(LoggingConfigurable):
     kernel_dirs = List(
         help="List of kernel directories to search. Later ones take priority over earlier."
     )
-    def _kernel_dirs_default(self):
+    @default('kernel_dirs')
+    def _default_kernel_dirs(self):
         dirs = jupyter_path('kernels')
         # At some point, we should stop adding .ipython/kernels to the path,
         # but the cost to keeping it is very small.

--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -13,7 +13,7 @@ from traitlets.config.application import Application
 from jupyter_core.application import (
     JupyterApp, base_flags, base_aliases
 )
-from traitlets import Instance, Dict, Unicode, Bool, List
+from traitlets import Instance, Dict, Unicode, Bool, List, default
 
 from . import __version__
 from .kernelspec import KernelSpecManager
@@ -36,7 +36,8 @@ class ListKernelSpecs(JupyterApp):
              'debug': base_flags['debug'],
             }
 
-    def _kernel_spec_manager_default(self):
+    @default('kernel_spec_manager')
+    def _default_kernel_spec_manager(self):
         return KernelSpecManager(parent=self, data_dir=self.data_dir)
 
     def start(self):
@@ -83,14 +84,16 @@ class InstallKernelSpec(JupyterApp):
     usage = "jupyter kernelspec install SOURCE_DIR [--options]"
     kernel_spec_manager = Instance(KernelSpecManager)
 
-    def _kernel_spec_manager_default(self):
+    @default('kernel_spec_manager')
+    def _default_kernel_spec_manager(self):
         return KernelSpecManager(data_dir=self.data_dir)
 
     sourcedir = Unicode()
     kernel_name = Unicode("", config=True,
         help="Install the kernel spec with this name"
     )
-    def _kernel_name_default(self):
+    @default('kernel_name')
+    def _default_kernel_name(self):
         return os.path.basename(self.sourcedir)
 
     user = Bool(False, config=True,
@@ -164,7 +167,8 @@ class RemoveKernelSpec(JupyterApp):
     spec_names = List(Unicode())
     
     kernel_spec_manager = Instance(KernelSpecManager)
-    def _kernel_spec_manager_default(self):
+    @default('kernel_spec_manager')
+    def _default_kernel_spec_manager(self):
         return KernelSpecManager(data_dir=self.data_dir, parent=self)
     
     flags = {
@@ -213,7 +217,8 @@ class InstallNativeKernelSpec(JupyterApp):
     description = """[DEPRECATED] Install the IPython kernel spec directory for this Python."""
     kernel_spec_manager = Instance(KernelSpecManager)
 
-    def _kernel_spec_manager_default(self):
+    @default('kernel_spec_manager')
+    def _default_kernel_spec_manager(self):
         return KernelSpecManager(data_dir=self.data_dir)
 
     user = Bool(False, config=True,

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -11,7 +11,7 @@ It is an incomplete base class, and must be subclassed.
 
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets import (
-    Instance, Float, Dict, Bool, Integer,
+    Instance, Float, Dict, Bool, Integer, default
 )
 
 
@@ -43,7 +43,8 @@ class KernelRestarter(LoggingConfigurable):
     _initial_startup = Bool(True)
 
     callbacks = Dict()
-    def _callbacks_default(self):
+    @default('callbacks')
+    def _default_callbacks(self):
         return dict(restart=[], dead=[])
 
     def start(self):


### PR DESCRIPTION
The traitlet pattern of naming methods _xxx_default and _xxx_changed is deprecated in favor of using the observe and default patters as documented [here](https://traitlets.readthedocs.io/en/stable/using_traitlets.html). This pr closes #386.