### PR TITLE
upgrade pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 sudo: false
 install:
   - pip install --upgrade setuptools pip
-  - pip install --upgrade --pre -e .[test] pytest-cov codecov 'coverage<5'
+  - pip install --upgrade --upgrade-strategy eager --pre -e .[test] pytest-cov codecov 'coverage<5'
   - pip freeze
 script:
   - py.test --cov jupyter_client jupyter_client

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ python:
 sudo: false
 install:
   - pip install --upgrade setuptools pip
-  - pip install --upgrade --pre -e .[test] pytest-cov pytest-warnings codecov 'coverage<5'
+  - pip install --upgrade --pre -e .[test] pytest-cov codecov 'coverage<5'
+  - pip freeze
 script:
   - py.test --cov jupyter_client jupyter_client
 after_success:


### PR DESCRIPTION
pip has changed its default upgrade strategy, even when `--upgrade` is specified to leave known-incompatible old versions installed. Switch to `--upgrade-strategy=eager` to ensure that things are correctly installed.