### PR TITLE
[WIP] Changes necessary to get async kernel startup working

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -13,7 +13,7 @@ import sys
 import time
 
 import zmq
-from tornado import gen
+
 from ipython_genutils.importstring import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
@@ -205,7 +205,6 @@ class KernelManager(ConnectionFileMixin):
         self._control_socket.close()
         self._control_socket = None
 
-    @gen.coroutine
     def start_kernel(self, **kw):
         """Starts a kernel on this host in a separate process.
 
@@ -247,7 +246,8 @@ class KernelManager(ConnectionFileMixin):
 
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)
-        self.kernel = yield gen.maybe_future(self._launch_kernel(kernel_cmd, env=env, **kw))
+        self.kernel = self._launch_kernel(kernel_cmd, env=env,
+                                    **kw)
         self.start_restarter()
         self._connect_control_socket()
 
@@ -324,7 +324,6 @@ class KernelManager(ConnectionFileMixin):
 
         self.cleanup(connection_file=not restart)
 
-    @gen.coroutine
     def restart_kernel(self, now=False, newports=False, **kw):
         """Restarts a kernel with the arguments that were used to launch it.
 
@@ -362,7 +361,7 @@ class KernelManager(ConnectionFileMixin):
 
             # Start new kernel.
             self._launch_args.update(kw)
-            yield gen.maybe_future(self.start_kernel(**self._launch_args))
+            self.start_kernel(**self._launch_args)
 
     @property
     def has_kernel(self):

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -13,7 +13,7 @@ import sys
 import time
 
 import zmq
-
+from tornado import gen
 from ipython_genutils.importstring import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
@@ -205,6 +205,7 @@ class KernelManager(ConnectionFileMixin):
         self._control_socket.close()
         self._control_socket = None
 
+    @gen.coroutine
     def start_kernel(self, **kw):
         """Starts a kernel on this host in a separate process.
 
@@ -246,8 +247,7 @@ class KernelManager(ConnectionFileMixin):
 
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)
-        self.kernel = self._launch_kernel(kernel_cmd, env=env,
-                                    **kw)
+        self.kernel = yield gen.maybe_future(self._launch_kernel(kernel_cmd, env=env, **kw))
         self.start_restarter()
         self._connect_control_socket()
 
@@ -324,6 +324,7 @@ class KernelManager(ConnectionFileMixin):
 
         self.cleanup(connection_file=not restart)
 
+    @gen.coroutine
     def restart_kernel(self, now=False, newports=False, **kw):
         """Restarts a kernel with the arguments that were used to launch it.
 
@@ -361,7 +362,7 @@ class KernelManager(ConnectionFileMixin):
 
             # Start new kernel.
             self._launch_args.update(kw)
-            self.start_kernel(**self._launch_args)
+            yield gen.maybe_future(self.start_kernel(**self._launch_args))
 
     @property
     def has_kernel(self):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import
 
 import os
 import uuid
+
 import zmq
 
-from tornado import gen
 from traitlets.config.configurable import LoggingConfigurable
 from ipython_genutils.importstring import import_item
 from traitlets import (
@@ -82,7 +82,6 @@ class MultiKernelManager(LoggingConfigurable):
     def __contains__(self, kernel_id):
         return kernel_id in self._kernels
 
-    @gen.coroutine
     def start_kernel(self, kernel_name=None, **kwargs):
         """Start a new kernel.
 
@@ -108,9 +107,9 @@ class MultiKernelManager(LoggingConfigurable):
                     parent=self, log=self.log, kernel_name=kernel_name,
                     **constructor_kwargs
         )
-        yield gen.maybe_future(km.start_kernel(**kwargs))
+        km.start_kernel(**kwargs)
         self._kernels[kernel_id] = km
-        raise gen.Return(kernel_id)
+        return kernel_id
 
     @kernel_method
     def shutdown_kernel(self, kernel_id, now=False, restart=False):
@@ -187,25 +186,15 @@ class MultiKernelManager(LoggingConfigurable):
         """
         self.log.info("Signaled Kernel %s with %s" % (kernel_id, signum))
 
-    @gen.coroutine
+    @kernel_method
     def restart_kernel(self, kernel_id, now=False):
         """Restart a kernel by its uuid, keeping the same ports.
 
         Parameters
         ==========
         kernel_id : uuid
-            The id of the kernel to restart.
-
-        now : bool, optional
-            If True, the kernel is forcefully restarted *immediately*, without
-            having a chance to do any cleanup action.  Otherwise the kernel is
-            given 1s to clean up before a forceful restart is issued.
-
-            In all cases the kernel is restarted, the only difference is whether
-            it is given a chance to perform a clean shutdown or not.
+            The id of the kernel to interrupt.
         """
-        km = self.get_kernel(kernel_id)
-        yield gen.maybe_future(km.restart_kernel(now))
         self.log.info("Kernel restarted: %s" % kernel_id)
 
     @kernel_method


### PR DESCRIPTION
Inspired by @Carreau's work in #402, this pull request essentially applies the same model used in Notebook for supporting coroutines with appropriately placed yield statements in order to start multiple kernels simultaneously within the same server instance.  The reason I needed to adopt this approach is because Enterprise Gateway has a [long-standing issue](https://github.com/jupyter/enterprise_gateway/issues/86) with concurrent kernel startup requests and runs in both python 2.7 and 3.x.

Since EG supports running remote kernels launched by pluggable resource managers (Hadoop YARN, Kubernetes, Docker Swarm, etc.) kernel startup requests can take anywhere from 5 to 15 seconds, depending on the platform.  Moreover, because EG is a headless web server, essentially exposing "Kernel As A Service" behaviors, it is not unusual for simultaneous startup requests to occur - unlike typical single-user Notebook servers.

These changes have been tested with applicable changes in Enterprise Gateway and "single-threaded" POSTs are now eliminated.

I have also run the Notebook nosetests using the applicable dev build of jupyter_client.  In addition, I have used a previous version of EG (our recently released beta) running against jupyter_client.  No issues were found using either of those "clients" - so backwards compatibility appears to be present.  

Because local kernels are so fast to start, it is difficult to determine if these changes are all that are necessary for concurrent starts outside of EG.  EG uses poll loops for discovery and startup confirmation and it was this area where blocking was occurring.   This, coupled with large start windows make it much easier to determine that the blocking has been addressed.  That said, I believe there are similar issues on shutdown (see the timing loop in [`finish_shutdown()`](https://github.com/jupyter/jupyter_client/blob/master/jupyter_client/manager.py#L271-L273)) where further progress can be made.  However, kernel shutdowns are not nearly as urgent for end-users.

Given there don't appear to be compatibility issues, I'm hoping these changes can be merged to master and 5.x since EG has existing customers that would like this behavior.