### PR TITLE
Add support for async kernel management via subclassing

### DIFF
--- a/jupyter_client/__init__.py
+++ b/jupyter_client/__init__.py
@@ -4,7 +4,7 @@ from ._version import version_info, __version__, protocol_version_info, protocol
 from .connect import *
 from .launcher import *
 from .client import KernelClient
-from .manager import KernelManager, run_kernel
+from .manager import KernelManager, AsyncKernelManager, run_kernel
 from .blocking import BlockingKernelClient
 from .asynchronous import AsyncKernelClient
-from .multikernelmanager import MultiKernelManager
+from .multikernelmanager import MultiKernelManager, AsyncMultiKernelManager

--- a/jupyter_client/ioloop/__init__.py
+++ b/jupyter_client/ioloop/__init__.py
@@ -1,2 +1,2 @@
-from .manager import IOLoopKernelManager
-from .restarter import IOLoopKernelRestarter
+from .manager import IOLoopKernelManager, AsyncIOLoopKernelManager
+from .restarter import IOLoopKernelRestarter, AsyncIOLoopKernelRestarter

--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -75,7 +75,7 @@ class AsyncIOLoopKernelManager(AsyncKernelManager):
         klass=AsyncIOLoopKernelRestarter,
         help=(
             'Type of KernelRestarter to use. '
-            'Must be a subclass of IOLoopKernelRestarter.\n'
+            'Must be a subclass of AsyncIOLoopKernelManager.\n'
             'Override this to customize how kernel restarts are managed.'
         ),
         config=True,

--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -11,8 +11,8 @@ from traitlets import (
     Type,
 )
 
-from jupyter_client.manager import KernelManager
-from .restarter import IOLoopKernelRestarter
+from jupyter_client.manager import KernelManager, AsyncKernelManager
+from .restarter import IOLoopKernelRestarter, AsyncIOLoopKernelRestarter
 
 
 def as_zmqstream(f):
@@ -21,9 +21,11 @@ def as_zmqstream(f):
         return ZMQStream(socket, self.loop)
     return wrapped
 
+
 class IOLoopKernelManager(KernelManager):
 
     loop = Instance('tornado.ioloop.IOLoop')
+
     def _loop_default(self):
         return ioloop.IOLoop.current()
 
@@ -59,3 +61,43 @@ class IOLoopKernelManager(KernelManager):
     connect_iopub = as_zmqstream(KernelManager.connect_iopub)
     connect_stdin = as_zmqstream(KernelManager.connect_stdin)
     connect_hb = as_zmqstream(KernelManager.connect_hb)
+
+
+class AsyncIOLoopKernelManager(AsyncKernelManager):
+
+    loop = Instance('tornado.ioloop.IOLoop')
+
+    def _loop_default(self):
+        return ioloop.IOLoop.current()
+
+    restarter_class = Type(
+        default_value=AsyncIOLoopKernelRestarter,
+        klass=AsyncIOLoopKernelRestarter,
+        help=(
+            'Type of KernelRestarter to use. '
+            'Must be a subclass of IOLoopKernelRestarter.\n'
+            'Override this to customize how kernel restarts are managed.'
+        ),
+        config=True,
+    )
+    _restarter = Instance('jupyter_client.ioloop.AsyncIOLoopKernelRestarter', allow_none=True)
+
+    def start_restarter(self):
+        if self.autorestart and self.has_kernel:
+            if self._restarter is None:
+                self._restarter = self.restarter_class(
+                    kernel_manager=self, loop=self.loop,
+                    parent=self, log=self.log
+                )
+            self._restarter.start()
+
+    def stop_restarter(self):
+        if self.autorestart:
+            if self._restarter is not None:
+                self._restarter.stop()
+                self._restarter = None
+
+    connect_shell = as_zmqstream(AsyncKernelManager.connect_shell)
+    connect_iopub = as_zmqstream(AsyncKernelManager.connect_iopub)
+    connect_stdin = as_zmqstream(AsyncKernelManager.connect_stdin)
+    connect_hb = as_zmqstream(AsyncKernelManager.connect_hb)

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -48,14 +48,6 @@ class IOLoopKernelRestarter(KernelRestarter):
 
 class AsyncIOLoopKernelRestarter(IOLoopKernelRestarter):
 
-    def start(self):
-        """Start the polling of the kernel."""
-        if self._pcallback is None:
-            self._pcallback = ioloop.PeriodicCallback(
-                self.poll, 1000*self.time_to_dead,
-            )
-            self._pcallback.start()
-
     async def poll(self):
         if self.debug:
             self.log.debug('Polling kernel...')

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -9,6 +9,7 @@ restarts the kernel if it dies.
 
 import warnings
 
+from tornado import gen
 from zmq.eventloop import ioloop
 
 from jupyter_client.restarter import KernelRestarter
@@ -16,10 +17,12 @@ from traitlets import (
     Instance,
 )
 
+
 class IOLoopKernelRestarter(KernelRestarter):
     """Monitor and autorestart a kernel."""
 
     loop = Instance('tornado.ioloop.IOLoop')
+
     def _loop_default(self):
         warnings.warn("IOLoopKernelRestarter.loop is deprecated in jupyter-client 5.2",
             DeprecationWarning, stacklevel=4,
@@ -41,3 +44,48 @@ class IOLoopKernelRestarter(KernelRestarter):
         if self._pcallback is not None:
             self._pcallback.stop()
             self._pcallback = None
+
+
+class AsyncIOLoopKernelRestarter(IOLoopKernelRestarter):
+
+    def start(self):
+        """Start the polling of the kernel."""
+        if self._pcallback is None:
+            self._pcallback = ioloop.PeriodicCallback(
+                self.poll, 1000*self.time_to_dead,
+            )
+            self._pcallback.start()
+
+    @gen.coroutine
+    def poll(self):
+        if self.debug:
+            self.log.debug('Polling kernel...')
+        is_alive = yield gen.maybe_future(self.kernel_manager.is_alive())
+        if not is_alive:
+            if self._restarting:
+                self._restart_count += 1
+            else:
+                self._restart_count = 1
+
+            if self._restart_count >= self.restart_limit:
+                self.log.warning("AsyncIOLoopKernelRestarter: restart failed")
+                self._fire_callbacks('dead')
+                self._restarting = False
+                self._restart_count = 0
+                self.stop()
+            else:
+                newports = self.random_ports_until_alive and self._initial_startup
+                self.log.info('AsyncIOLoopKernelRestarter: restarting kernel (%i/%i), %s random ports',
+                    self._restart_count,
+                    self.restart_limit,
+                    'new' if newports else 'keep'
+                )
+                self._fire_callbacks('restart')
+                yield self.kernel_manager.restart_kernel(now=True, newports=newports)
+                self._restarting = True
+        else:
+            if self._initial_startup:
+                self._initial_startup = False
+            if self._restarting:
+                self.log.debug("AsyncIOLoopKernelRestarter: restart apparently succeeded")
+            self._restarting = False

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -9,7 +9,6 @@ restarts the kernel if it dies.
 
 import warnings
 
-from tornado import gen
 from zmq.eventloop import ioloop
 
 from jupyter_client.restarter import KernelRestarter
@@ -51,7 +50,7 @@ class AsyncIOLoopKernelRestarter(IOLoopKernelRestarter):
     async def poll(self):
         if self.debug:
             self.log.debug('Polling kernel...')
-        is_alive = self.kernel_manager.is_alive()
+        is_alive = await self.kernel_manager.is_alive()
         if not is_alive:
             if self._restarting:
                 self._restart_count += 1

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -56,11 +56,10 @@ class AsyncIOLoopKernelRestarter(IOLoopKernelRestarter):
             )
             self._pcallback.start()
 
-    @gen.coroutine
-    def poll(self):
+    async def poll(self):
         if self.debug:
             self.log.debug('Polling kernel...')
-        is_alive = yield gen.maybe_future(self.kernel_manager.is_alive())
+        is_alive = self.kernel_manager.is_alive()
         if not is_alive:
             if self._restarting:
                 self._restart_count += 1
@@ -81,7 +80,7 @@ class AsyncIOLoopKernelRestarter(IOLoopKernelRestarter):
                     'new' if newports else 'keep'
                 )
                 self._fire_callbacks('restart')
-                yield self.kernel_manager.restart_kernel(now=True, newports=newports)
+                await self.kernel_manager.restart_kernel(now=True, newports=newports)
                 self._restarting = True
         else:
             if self._initial_startup:

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -715,12 +715,23 @@ class AsyncKernelManager(KernelManager):
         else:
             raise RuntimeError("Cannot signal kernel. No kernel is running!")
 
+    async def is_alive(self):
+        """Is the kernel process still running?"""
+        if self.has_kernel:
+            if self.kernel.poll() is None:
+                return True
+            else:
+                return False
+        else:
+            # we don't have a kernel
+            return False
+
     async def _async_wait(self, pollinterval=0.1):
         # Use busy loop at 100ms intervals, polling until the process is
         # not alive.  If we find the process is no longer alive, complete
         # its cleanup via the blocking wait().  Callers are responsible for
         # issuing calls to wait() using a timeout (see _kill_kernel()).
-        while self.is_alive():
+        while await self.is_alive():
             await asyncio.sleep(pollinterval)
 
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -13,6 +13,7 @@ import warnings
 
 import zmq
 
+from tornado import gen
 from ipython_genutils.importstring import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
@@ -223,8 +224,8 @@ class KernelManager(ConnectionFileMixin):
         self._control_socket.close()
         self._control_socket = None
 
-    def start_kernel(self, **kw):
-        """Starts a kernel on this host in a separate process.
+    def pre_start_kernel(self, **kw):
+        """Prepares a kernel for startup in a separate process.
 
         If random ports (port=0) are being used, this method must be called
         before the channels are created.
@@ -261,12 +262,9 @@ class KernelManager(ConnectionFileMixin):
             env.update(self._get_env_substitutions(self.kernel_spec.env, env))
         elif self.extra_env:
             env.update(self._get_env_substitutions(self.extra_env, env))
+        kw['env'] = env
 
-        # launch the kernel subprocess
-        self.log.debug("Starting kernel: %s", kernel_cmd)
-        self.kernel = self._launch_kernel(kernel_cmd, env=env, **kw)
-        self.start_restarter()
-        self._connect_control_socket()
+        return kernel_cmd, kw
 
     def _get_env_substitutions(self, templated_env, substitution_values):
         """ Walks env entries in templated_env and applies possible substitutions from current env
@@ -283,6 +281,29 @@ class KernelManager(ConnectionFileMixin):
             for k, v in templated_env.items():
                 substituted_env.update({k: Template(v).safe_substitute(substitution_values)})
         return substituted_env
+
+    def post_start_kernel(self, **kw):
+        self.start_restarter()
+        self._connect_control_socket()
+
+    def start_kernel(self, **kw):
+        """Starts a kernel on this host in a separate process.
+
+        If random ports (port=0) are being used, this method must be called
+        before the channels are created.
+
+        Parameters
+        ----------
+        `**kw` : optional
+             keyword arguments that are passed down to build the kernel_cmd
+             and launching the kernel (e.g. Popen kwargs).
+        """
+        kernel_cmd, kw = self.pre_start_kernel(**kw)
+
+        # launch the kernel subprocess
+        self.log.debug("Starting kernel: %s", kernel_cmd)
+        self.kernel = self._launch_kernel(kernel_cmd, **kw)
+        self.post_start_kernel(**kw)
 
     def request_shutdown(self, restart=False):
         """Send a shutdown request via control channel
@@ -488,6 +509,238 @@ class KernelManager(ConnectionFileMixin):
             return False
 
 
+class AsyncKernelManager(KernelManager):
+    """Manages kernels in an asynchronous manner """
+
+    @gen.coroutine
+    def _launch_kernel(self, kernel_cmd, **kw):
+        """actually launch the kernel
+
+        override in a subclass to launch kernel subprocesses differently
+        """
+        res = yield gen.maybe_future(launch_kernel(kernel_cmd, **kw))
+        raise gen.Return(res)
+
+    @gen.coroutine
+    def start_kernel(self, **kw):
+        """Starts a kernel in a separate process in an asynchronous manner.
+
+        If random ports (port=0) are being used, this method must be called
+        before the channels are created.
+
+        Parameters
+        ----------
+        `**kw` : optional
+             keyword arguments that are passed down to build the kernel_cmd
+             and launching the kernel (e.g. Popen kwargs).
+        """
+        kernel_cmd, kw = self.pre_start_kernel(**kw)
+
+        # launch the kernel subprocess
+        self.log.debug("Starting kernel (async): %s", kernel_cmd)
+        self.kernel = yield self._launch_kernel(kernel_cmd, **kw)
+        self.post_start_kernel(**kw)
+
+    @gen.coroutine
+    def request_shutdown(self, restart=False):
+        """Send a shutdown request via control channel
+        """
+        yield gen.maybe_future(super(AsyncKernelManager, self).request_shutdown(restart))
+
+    @gen.coroutine
+    def finish_shutdown(self, waittime=None, pollinterval=0.1):
+        """Wait for kernel shutdown, then kill process if it doesn't shutdown.
+
+        This does not send shutdown requests - use :meth:`request_shutdown`
+        first.
+        """
+        if waittime is None:
+            waittime = max(self.shutdown_wait_time, 0)
+        for i in range(int(waittime/pollinterval)):
+            is_alive = yield self.is_alive()
+            if is_alive:
+                yield gen.sleep(pollinterval)
+            else:
+                # If there's still a proc, wait and clear
+                if self.has_kernel:
+                    yield gen.maybe_future(self.kernel.wait())
+                    self.kernel = None
+                break
+        else:
+            # OK, we've waited long enough.
+            if self.has_kernel:
+                self.log.debug("Kernel is taking too long to finish, killing")
+                yield self._kill_kernel()
+
+    @gen.coroutine
+    def cleanup(self, connection_file=True):
+        """Clean up resources when the kernel is shut down"""
+        yield gen.maybe_future(super(AsyncKernelManager, self).cleanup(connection_file))
+
+    @gen.coroutine
+    def shutdown_kernel(self, now=False, restart=False):
+        """Attempts to stop the kernel process cleanly.
+
+        This attempts to shutdown the kernels cleanly by:
+
+        1. Sending it a shutdown message over the shell channel.
+        2. If that fails, the kernel is shutdown forcibly by sending it
+           a signal.
+
+        Parameters
+        ----------
+        now : bool
+            Should the kernel be forcible killed *now*. This skips the
+            first, nice shutdown attempt.
+        restart: bool
+            Will this kernel be restarted after it is shutdown. When this
+            is True, connection files will not be cleaned up.
+        """
+        # Stop monitoring for restarting while we shutdown.
+        self.stop_restarter()
+
+        if now:
+            yield self._kill_kernel()
+        else:
+            yield self.request_shutdown(restart=restart)
+            # Don't send any additional kernel kill messages immediately, to give
+            # the kernel a chance to properly execute shutdown actions. Wait for at
+            # most 1s, checking every 0.1s.
+            yield self.finish_shutdown()
+
+        yield self.cleanup(connection_file=not restart)
+
+    @gen.coroutine
+    def restart_kernel(self, now=False, newports=False, **kw):
+        """Restarts a kernel with the arguments that were used to launch it.
+
+        Parameters
+        ----------
+        now : bool, optional
+            If True, the kernel is forcefully restarted *immediately*, without
+            having a chance to do any cleanup action.  Otherwise the kernel is
+            given 1s to clean up before a forceful restart is issued.
+
+            In all cases the kernel is restarted, the only difference is whether
+            it is given a chance to perform a clean shutdown or not.
+
+        newports : bool, optional
+            If the old kernel was launched with random ports, this flag decides
+            whether the same ports and connection file will be used again.
+            If False, the same ports and connection file are used. This is
+            the default. If True, new random port numbers are chosen and a
+            new connection file is written. It is still possible that the newly
+            chosen random port numbers happen to be the same as the old ones.
+
+        `**kw` : optional
+            Any options specified here will overwrite those used to launch the
+            kernel.
+        """
+        if self._launch_args is None:
+            raise RuntimeError("Cannot restart the kernel. "
+                               "No previous call to 'start_kernel'.")
+        else:
+            # Stop currently running kernel.
+            yield self.shutdown_kernel(now=now, restart=True)
+
+            if newports:
+                self.cleanup_random_ports()
+
+            # Start new kernel.
+            self._launch_args.update(kw)
+            yield self.start_kernel(**self._launch_args)
+        raise gen.Return(None)
+
+    @gen.coroutine
+    def _kill_kernel(self):
+        """Kill the running kernel.
+
+        This is a private method, callers should use shutdown_kernel(now=True).
+        """
+        if self.has_kernel:
+
+            # Signal the kernel to terminate (sends SIGKILL on Unix and calls
+            # TerminateProcess() on Win32).
+            try:
+                if hasattr(signal, 'SIGKILL'):
+                    yield self.signal_kernel(signal.SIGKILL)
+                else:
+                    yield gen.maybe_future(self.kernel.kill())
+            except OSError as e:
+                # In Windows, we will get an Access Denied error if the process
+                # has already terminated. Ignore it.
+                if sys.platform == 'win32':
+                    if e.winerror != 5:
+                        raise
+                # On Unix, we may get an ESRCH error if the process has already
+                # terminated. Ignore it.
+                else:
+                    from errno import ESRCH
+                    if e.errno != ESRCH:
+                        raise
+
+            # Block until the kernel terminates.
+            yield gen.maybe_future(self.kernel.wait())
+            self.kernel = None
+        else:
+            raise RuntimeError("Cannot kill kernel. No kernel is running!")
+
+    @gen.coroutine
+    def interrupt_kernel(self):
+        """Interrupts the kernel by sending it a signal.
+
+        Unlike ``signal_kernel``, this operation is well supported on all
+        platforms.
+        """
+        if self.has_kernel:
+            interrupt_mode = self.kernel_spec.interrupt_mode
+            if interrupt_mode == 'signal':
+                if sys.platform == 'win32':
+                    from .win_interrupt import send_interrupt
+                    send_interrupt(self.kernel.win32_interrupt_event)
+                else:
+                    yield self.signal_kernel(signal.SIGINT)
+
+            elif interrupt_mode == 'message':
+                msg = self.session.msg("interrupt_request", content={})
+                self._connect_control_socket()
+                self.session.send(self._control_socket, msg)
+        else:
+            raise RuntimeError("Cannot interrupt kernel. No kernel is running!")
+
+    @gen.coroutine
+    def signal_kernel(self, signum):
+        """Sends a signal to the process group of the kernel (this
+        usually includes the kernel and any subprocesses spawned by
+        the kernel).
+
+        Note that since only SIGTERM is supported on Windows, this function is
+        only useful on Unix systems.
+        """
+        if self.has_kernel:
+            if hasattr(os, "getpgid") and hasattr(os, "killpg"):
+                try:
+                    pgid = os.getpgid(self.kernel.pid)
+                    os.killpg(pgid, signum)
+                    return
+                except OSError:
+                    pass
+            yield gen.maybe_future(self.kernel.send_signal(signum))
+        else:
+            raise RuntimeError("Cannot signal kernel. No kernel is running!")
+
+    @gen.coroutine
+    def is_alive(self):
+        """Is the kernel process still running?"""
+        is_alive = False
+        if self.has_kernel:
+            ret = yield gen.maybe_future(self.kernel.poll())
+            if ret is None:
+                is_alive = True
+
+        raise gen.Return(is_alive)
+
+
 KernelManagerABC.register(KernelManager)
 
 
@@ -505,6 +758,24 @@ def start_new_kernel(startup_timeout=60, kernel_name='python', **kwargs):
         raise
 
     return km, kc
+
+
+@gen.coroutine
+def start_new_async_kernel(startup_timeout=60, kernel_name='python', **kwargs):
+    """Start a new kernel, and return its Manager and Client"""
+    km = AsyncKernelManager(kernel_name=kernel_name)
+    yield km.start_kernel(**kwargs)
+    kc = km.client()
+    kc.start_channels()
+    try:
+        kc.wait_for_ready(timeout=startup_timeout)
+    except RuntimeError:
+        kc.stop_channels()
+        yield km.shutdown_kernel()
+        raise
+
+    raise gen.Return((km, kc))
+
 
 @contextmanager
 def run_kernel(**kwargs):

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -344,12 +344,13 @@ class TestAsyncKernelManager(AsyncTestCase):
 
     async def _run_lifecycle(self, km):
         await km.start_kernel(stdout=PIPE, stderr=PIPE)
-        self.assertTrue(km.is_alive())
+        self.assertTrue(await km.is_alive())
         await km.restart_kernel(now=True)
-        self.assertTrue(km.is_alive())
+        self.assertTrue(await km.is_alive())
         await km.interrupt_kernel()
         self.assertTrue(isinstance(km, AsyncKernelManager))
         await km.shutdown_kernel(now=True)
+        self.assertFalse(await km.is_alive())
 
     @gen_test
     async def test_tcp_lifecycle(self):
@@ -425,8 +426,8 @@ class TestAsyncKernelManager(AsyncTestCase):
         # Note: we cannot use addCleanup(<func>) for these since it doesn't properly handle
         # coroutines - which km.shutdown_kernel now is.
         try:
-            self.assertTrue(km.is_alive())
-            self.assertTrue(kc.is_alive())
+            self.assertTrue(await km.is_alive())
+            self.assertTrue(await kc.is_alive())
         finally:
             await km.shutdown_kernel(now=True)
             kc.stop_channels()

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -15,14 +15,16 @@ import threading
 import multiprocessing as mp
 import pytest
 from unittest import TestCase
+from tornado.testing import AsyncTestCase, gen_test, gen
 
 from traitlets.config.loader import Config
 from jupyter_core import paths
-from jupyter_client import KernelManager
-from ..manager import start_new_kernel
+from jupyter_client import KernelManager, AsyncKernelManager
+from ..manager import start_new_kernel, start_new_async_kernel
 from .utils import test_env, skip_win32
 
 TIMEOUT = 30
+
 
 class TestKernelManager(TestCase):
     def setUp(self):
@@ -89,6 +91,7 @@ class TestKernelManager(TestCase):
     def test_signal_kernel_subprocesses(self):
         self._install_test_kernel()
         km, kc = start_new_kernel(kernel_name='signaltest')
+
         def execute(cmd):
             kc.execute(cmd)
             reply = kc.get_shell_msg(TIMEOUT)
@@ -268,7 +271,7 @@ class TestParallel:
             proc.join()
 
         assert proc.exitcode == 0
-    
+
     def _prepare_kernel(self, km, startup_timeout=TIMEOUT, **kwargs):
         km.start_kernel(**kwargs)
         kc = km.client()
@@ -303,3 +306,130 @@ class TestParallel:
         execute('check')
 
         km.shutdown_kernel()
+
+
+class TestAsyncKernelManager(AsyncTestCase):
+    def setUp(self):
+        super(TestAsyncKernelManager, self).setUp()
+        self.env_patch = test_env()
+        self.env_patch.start()
+
+    def tearDown(self):
+        super(TestAsyncKernelManager, self).tearDown()
+        self.env_patch.stop()
+
+    def _install_test_kernel(self):
+        kernel_dir = pjoin(paths.jupyter_data_dir(), 'kernels', 'signaltest')
+        os.makedirs(kernel_dir)
+        with open(pjoin(kernel_dir, 'kernel.json'), 'w') as f:
+            f.write(json.dumps({
+                'argv': [sys.executable,
+                         '-m', 'jupyter_client.tests.signalkernel',
+                         '-f', '{connection_file}'],
+                'display_name': "Signal Test Kernel",
+            }))
+
+    def _get_tcp_km(self):
+        c = Config()
+        km = AsyncKernelManager(config=c)
+        return km
+
+    def _get_ipc_km(self):
+        c = Config()
+        c.KernelManager.transport = 'ipc'
+        c.KernelManager.ip = 'test'
+        km = AsyncKernelManager(config=c)
+        return km
+
+    @gen.coroutine
+    def _run_lifecycle(self, km):
+        yield km.start_kernel(stdout=PIPE, stderr=PIPE)
+        is_alive = yield km.is_alive()
+        self.assertTrue(is_alive)
+        yield km.restart_kernel(now=True)
+        is_alive = yield km.is_alive()
+        self.assertTrue(is_alive)
+        yield km.interrupt_kernel()
+        self.assertTrue(isinstance(km, AsyncKernelManager))
+        yield km.shutdown_kernel(now=True)
+
+    @gen_test
+    def test_tcp_lifecycle(self):
+        km = self._get_tcp_km()
+        yield self._run_lifecycle(km)
+
+    @skip_win32
+    @gen_test
+    def test_ipc_lifecycle(self):
+        km = self._get_ipc_km()
+        yield self._run_lifecycle(km)
+
+    def test_get_connect_info(self):
+        km = self._get_tcp_km()
+        cinfo = km.get_connection_info()
+        keys = sorted(cinfo.keys())
+        expected = sorted([
+            'ip', 'transport',
+            'hb_port', 'shell_port', 'stdin_port', 'iopub_port', 'control_port',
+            'key', 'signature_scheme',
+        ])
+        self.assertEqual(keys, expected)
+
+    @skip_win32
+    @gen_test
+    def test_signal_kernel_subprocesses(self):
+        self._install_test_kernel()
+        km, kc = yield start_new_async_kernel(kernel_name='signaltest')
+
+        def execute(cmd):
+            kc.execute(cmd)
+            reply = kc.get_shell_msg(TIMEOUT)
+            content = reply['content']
+            self.assertEqual(content['status'], 'ok')
+            return content
+        # Ensure that shutdown_kernel and stop_channels are called at the end of the test.
+        # Note: we cannot use addCleanup(<func>) for these since it doesn't prpperly handle
+        # coroutines - which km.shutdown_kernel now is.
+        try:
+            N = 5
+            for i in range(N):
+                execute("start")
+            time.sleep(1)  # make sure subprocs stay up
+            reply = execute('check')
+            self.assertEqual(reply['user_expressions']['poll'], [None] * N)
+
+            # start a job on the kernel to be interrupted
+            kc.execute('sleep')
+            time.sleep(1)  # ensure sleep message has been handled before we interrupt
+            yield km.interrupt_kernel()
+            reply = kc.get_shell_msg(TIMEOUT)
+            content = reply['content']
+            self.assertEqual(content['status'], 'ok')
+            self.assertEqual(content['user_expressions']['interrupted'], True)
+            # wait up to 5s for subprocesses to handle signal
+            for i in range(50):
+                reply = execute('check')
+                if reply['user_expressions']['poll'] != [-signal.SIGINT] * N:
+                    time.sleep(0.1)
+                else:
+                    break
+            # verify that subprocesses were interrupted
+            self.assertEqual(reply['user_expressions']['poll'], [-signal.SIGINT] * N)
+        finally:
+            yield km.shutdown_kernel(now=True)
+            kc.stop_channels()
+
+    @gen_test
+    def test_start_new_async_kernel(self):
+        self._install_test_kernel()
+        km, kc = yield start_new_async_kernel(kernel_name='signaltest')
+        # Ensure that shutdown_kernel and stop_channels are called at the end of the test.
+        # Note: we cannot use addCleanup(<func>) for these since it doesn't properly handle
+        # coroutines - which km.shutdown_kernel now is.
+        try:
+            is_alive = yield km.is_alive()
+            self.assertTrue(is_alive)
+            self.assertTrue(kc.is_alive())
+        finally:
+            yield km.shutdown_kernel(now=True)
+            kc.stop_channels()

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -152,14 +152,12 @@ class TestAsyncKernelManager(AsyncTestCase):
 
     async def _run_lifecycle(self, km):
         kid = await km.start_kernel(stdout=PIPE, stderr=PIPE)
-        is_alive = km.is_alive(kid)
-        self.assertTrue(is_alive)
+        self.assertTrue(await km.is_alive(kid))
         self.assertTrue(kid in km)
         self.assertTrue(kid in km.list_kernel_ids())
         self.assertEqual(len(km), 1)
         await km.restart_kernel(kid, now=True)
-        is_alive = km.is_alive(kid)
-        self.assertTrue(is_alive)
+        self.assertTrue(await km.is_alive(kid))
         self.assertTrue(kid in km.list_kernel_ids())
         await km.interrupt_kernel(kid)
         k = km.get_kernel(kid)


### PR DESCRIPTION
After a couple failed attempts due to API breakage and incompleteness as documented in PR #425, this PR takes an [approach using subclassing](https://github.com/jupyter/jupyter_client/pull/425#issuecomment-470033289) that @minrk had proposed.  As a result, I felt it best to start anew with the discussion and I will close #425, which will still be useful for background.  With this approach existing applications can continue using the synchronous classes, while applications that desire async kernel management can do so by setting the `kernel_manager_class` traitlet to the appropriate asynchronous form.  As a result, its a fairly clean separation.

`AsyncKernelManager` derives from `KernelManager` and uses async (gen.coroutine) methods where applicable.  Similarly, `AsyncMultiKernelManger` from `MultiKernelManager`.  `AsyncIOLoopKernelManager` derives from `AsyncKernelManger` instead of `IOLoopKernelManager`, otherwise it would not extend `AsyncKernelManager`.  And `AsyncIOLoopRestarter` dervices from `IOLoopRestarter` since the base `KernelRestarter` is an independent class.

I chose to continue the use of `@gen.coroutine` as opposed to `async def` for the following reasons...
1. I'm not sure how it works to cross the two - which would need to happen once Notebook starts using the async classes.
1. The notebook-based subsystems haven't switched to `async/await` and felt this could be done at that time.
1. I'm still (stubbornly) hoping that we can backport this to 5.x for python 2 users. :smile:

I'm marking this as a work-in-progress for now until a POC with Notebook and Enterprise Gateway can be completed.  

EDIT: Add class hierarchy diagram (darker classes are new).
![jupyter_client_kernel_manager_hierarchy](https://user-images.githubusercontent.com/22599560/54385154-2ea05480-4653-11e9-9cd7-9ee0dd130688.png)