### PR TITLE
Configure the connection_file if not already done

### DIFF
--- a/jupyter_client/kernelapp.py
+++ b/jupyter_client/kernelapp.py
@@ -30,10 +30,12 @@ class KernelApp(JupyterApp):
 
     def initialize(self, argv=None):
         super(KernelApp, self).initialize(argv)
+        
+        cf_basename = 'kernel-%s.json' % uuid.uuid4()
+        self.config.setdefault('KernelManager', {}).setdefault('connection_file', os.path.join(self.runtime_dir, cf_basename))
         self.km = KernelManager(kernel_name=self.kernel_name,
                                 config=self.config)
-        cf_basename = 'kernel-%s.json' % uuid.uuid4()
-        self.km.connection_file = os.path.join(self.runtime_dir, cf_basename)
+        
         self.loop = IOLoop.current()
         self.loop.add_callback(self._record_started)
 


### PR DESCRIPTION
Set the default connection_file such that it preserves an existing configuration. This fixes #381. 

This leaves the behavior the same if nothing is passed in for `--KernelManager.connection_file` and instead uses the `config` as the configuration mechanism for setting the default.