### PR TITLE
Build docs with Python 3.7 on conda

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 - pyzmq
-- python==3.5
+- python==3.7
 - traitlets>=4.1
 - jupyter_core
 - sphinx>=1.3.6


### PR DESCRIPTION
This might fix some failures to build on RTD, where Sphinx is failing to import something from the typing module.

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-client/conda/latest/bin/sphinx-build", line 6, in <module>
    from sphinx.cmd.build import main
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-client/conda/latest/lib/python3.5/site-packages/sphinx/cmd/build.py", line 22, in <module>
    from sphinx.application import Sphinx
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-client/conda/latest/lib/python3.5/site-packages/sphinx/application.py", line 34, in <module>
    from sphinx.project import Project
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-client/conda/latest/lib/python3.5/site-packages/sphinx/project.py", line 12, in <module>
    from typing import TYPE_CHECKING
ImportError: cannot import name 'TYPE_CHECKING'
```