### PR TITLE
Avoid kernel failures with multiple processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
     - "3.7-dev"
     - 3.6
     - 3.5
-    - 3.4
     - 2.7
 sudo: false
 install:

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -51,7 +51,7 @@ class KernelClient(ConnectionFileMixin):
     # The PyZMQ Context to use for communication with the kernel.
     context = Instance(zmq.Context)
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     # The classes to use for the various channels
     shell_channel_class = Type(ChannelABC)

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ name = 'jupyter_client'
 import sys
 
 v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,4)):
-    error = "ERROR: %s requires Python version 2.7 or 3.4 or above." % name
+if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 5)):
+    error = "ERROR: %s requires Python version 2.7 or 3.5 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -94,10 +94,9 @@ setup_args = dict(
         'entrypoints',
         'tornado>=4.1',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     extras_require   = {
-        'test': ['ipykernel', 'ipython', 'mock'],
-        'test:(python_version >= "3.4" or python_version == "2.7")': ['pytest'],
+        'test': ['ipykernel', 'ipython', 'mock', 'pytest'],
     },
     cmdclass         = {
         'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,


### PR DESCRIPTION
This PR adds several new tests which ensure that kernels can be used when started and operated in a multiprocessing context.

Before this change, if the global ZMQ context was initialized before the processed forked, then the child processes _might_ fail. This is easy to do accidentally – run some kernel first in the current process, to check if it works, then farm that same function out to a pool of processes, and things will go poorly. I think this is because ZMQ contexts are not safe after fork. However, switching from using the global ZMQ context to a single ZMQ context per client eliminates the failures.

One could argue that kernels should never be used in multiprocessing contexts, because they are run in a subprocess anyhow, so multiprocessing doesn't provide a better way to escape the gil. However, I can't think of a way to detect that case and raise an error without waiting for a timeout, and the error returned there has to be pretty generic (it is currently `RuntimeError: Kernel didn't respond in 30 seconds`).

Sorry to drop this PR in without opening an issue, but the issue itself is hard enough to reproduce that a minimal reproduction was easiest in the context of the test suite. Most of the code here is adding various combinations of parallel execution to the test suite and ensuring that they work.

We discovered this problem when @mseal and I tried to get parallel uses of papermill running during pycon sprints. The original papermill issue is nteract/papermill#329. The ability to run kernels in parallel without surprising results is also helpful for nbconvert (see jupyter/nbconvert#1018)