### PR TITLE
Backport PR #437: Avoid kernel failures with multiple processes

### DIFF
--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -51,7 +51,7 @@ class KernelClient(ConnectionFileMixin):
     # The PyZMQ Context to use for communication with the kernel.
     context = Instance(zmq.Context)
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     # The classes to use for the various channels
     shell_channel_class = Type(ChannelABC)


### PR DESCRIPTION
**Note**: This might fail, since python versions 3.3 and 3.4 were dropped before this commit – if the tests pass, then backporting might be okay, but if they fail, I'll need some additional advice.