### PR TITLE
Exposes control channel in public API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 .coverage
 .cache
 absolute.json
+*.swp
 
 # Sphinx documentation
 _build

--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -57,6 +57,7 @@ class IOLoopKernelManager(KernelManager):
                 self._restarter = None
 
     connect_shell = as_zmqstream(KernelManager.connect_shell)
+    connect_control = as_zmqstream(KernelManager.connect_control)
     connect_iopub = as_zmqstream(KernelManager.connect_iopub)
     connect_stdin = as_zmqstream(KernelManager.connect_stdin)
     connect_hb = as_zmqstream(KernelManager.connect_hb)

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -285,6 +285,22 @@ class MultiKernelManager(LoggingConfigurable):
         """
 
     @kernel_method
+    def connect_control(self, kernel_id, identity=None):
+        """Return a zmq Socket connected to the control channel.
+
+        Parameters
+        ==========
+        kernel_id : uuid
+            The id of the kernel
+        identity : bytes (optional)
+            The zmq identity of the socket
+
+        Returns
+        =======
+        stream : zmq Socket or ZMQStream
+        """
+
+    @kernel_method
     def connect_stdin(self, kernel_id, identity=None):
         """Return a zmq Socket connected to the stdin channel.
 


### PR DESCRIPTION
This PR exposes the control channel in the public API, as required in https://github.com/jupyter/jupyter_client/issues/446. The `KernelClient` has not been updated to connect to the Control socket, it might be interesting to do it later.

EDIT: additional changes might be required in `KernelManager`to avoid having another socket trying to connect on the Control channel, but this is not clear to me for now.