### PR TITLE
Changed zmqContext to not reuse instances

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -38,7 +38,7 @@ class KernelManager(ConnectionFileMixin):
     # The PyZMQ Context to use for communication with the kernel.
     context = Instance(zmq.Context)
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     # the class to create with our `client` method
     client_class = DottedObjectName('jupyter_client.blocking.BlockingKernelClient')

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -47,7 +47,7 @@ class MultiKernelManager(LoggingConfigurable):
     )
 
     kernel_spec_manager = Instance(KernelSpecManager, allow_none=True)
-    
+
     kernel_manager_class = DottedObjectName(
         "jupyter_client.ioloop.IOLoopKernelManager", config=True,
         help="""The kernel manager class.  This is configurable to allow
@@ -63,7 +63,7 @@ class MultiKernelManager(LoggingConfigurable):
 
     context = Instance('zmq.Context')
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     connection_dir = Unicode('')
 

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -186,7 +186,7 @@ class SessionFactory(LoggingConfigurable):
     # not configurable:
     context = Instance('zmq.Context')
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     session = Instance('jupyter_client.session.Session',
                        allow_none=True)
@@ -300,10 +300,10 @@ class Session(Configurable):
     """
 
     debug = Bool(False, config=True, help="""Debug output in the Session""")
-    
+
     check_pid = Bool(True, config=True,
         help="""Whether to check PID to protect against calls after fork.
-        
+
         This check can be disabled if fork-safety is handled elsewhere.
         """)
 
@@ -387,9 +387,9 @@ class Session(Configurable):
     digest_mod = Any()
     def _digest_mod_default(self):
         return hashlib.sha256
-    
+
     auth = Instance(hmac.HMAC, allow_none=True)
-    
+
     def _new_auth(self):
         if self.key:
             self.auth = hmac.HMAC(self.key, digestmod=self.digest_mod)

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -83,7 +83,7 @@ class TestSession(SessionTestCase):
         self.assertIsInstance(self.session.auth, hmac.HMAC)
 
     def test_send(self):
-        ctx = zmq.Context.instance()
+        ctx = zmq.Context()
         A = ctx.socket(zmq.PAIR)
         B = ctx.socket(zmq.PAIR)
         A.bind("inproc://test")
@@ -316,7 +316,7 @@ class TestSession(SessionTestCase):
         self._datetime_test(session)
 
     def test_send_raw(self):
-        ctx = zmq.Context.instance()
+        ctx = zmq.Context()
         A = ctx.socket(zmq.PAIR)
         B = ctx.socket(zmq.PAIR)
         A.bind("inproc://test")


### PR DESCRIPTION
Followup to https://github.com/jupyter/jupyter_client/pull/438 to provide the same thread / process safety as the kernel manager used by nbconvert. This has a small memory overhead to avoid parent processes from deadlocking when operating with concurrency.