### PR TITLE
Backport #488 5.x zmq context isolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
     - 3.6
     - 3.5
-    - 3.4
-    - 3.3
     - 2.7
 sudo: false
 install:

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -39,7 +39,7 @@ class KernelManager(ConnectionFileMixin):
     # The PyZMQ Context to use for communication with the kernel.
     context = Instance(zmq.Context)
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     # the class to create with our `client` method
     client_class = DottedObjectName('jupyter_client.blocking.BlockingKernelClient')

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -47,7 +47,7 @@ class MultiKernelManager(LoggingConfigurable):
     )
 
     kernel_spec_manager = Instance(KernelSpecManager, allow_none=True)
-    
+
     kernel_manager_class = DottedObjectName(
         "jupyter_client.ioloop.IOLoopKernelManager", config=True,
         help="""The kernel manager class.  This is configurable to allow
@@ -63,7 +63,7 @@ class MultiKernelManager(LoggingConfigurable):
 
     context = Instance('zmq.Context')
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     connection_dir = Unicode('')
 

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -186,7 +186,7 @@ class SessionFactory(LoggingConfigurable):
     # not configurable:
     context = Instance('zmq.Context')
     def _context_default(self):
-        return zmq.Context.instance()
+        return zmq.Context()
 
     session = Instance('jupyter_client.session.Session',
                        allow_none=True)
@@ -300,10 +300,10 @@ class Session(Configurable):
     """
 
     debug = Bool(False, config=True, help="""Debug output in the Session""")
-    
+
     check_pid = Bool(True, config=True,
         help="""Whether to check PID to protect against calls after fork.
-        
+
         This check can be disabled if fork-safety is handled elsewhere.
         """)
 
@@ -387,9 +387,9 @@ class Session(Configurable):
     digest_mod = Any()
     def _digest_mod_default(self):
         return hashlib.sha256
-    
+
     auth = Instance(hmac.HMAC, allow_none=True)
-    
+
     def _new_auth(self):
         if self.key:
             self.auth = hmac.HMAC(self.key, digestmod=self.digest_mod)

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -83,7 +83,7 @@ class TestSession(SessionTestCase):
         self.assertIsInstance(self.session.auth, hmac.HMAC)
 
     def test_send(self):
-        ctx = zmq.Context.instance()
+        ctx = zmq.Context()
         A = ctx.socket(zmq.PAIR)
         B = ctx.socket(zmq.PAIR)
         A.bind("inproc://test")
@@ -316,7 +316,7 @@ class TestSession(SessionTestCase):
         self._datetime_test(session)
 
     def test_send_raw(self):
-        ctx = zmq.Context.instance()
+        ctx = zmq.Context()
         A = ctx.socket(zmq.PAIR)
         B = ctx.socket(zmq.PAIR)
         A.bind("inproc://test")

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ name = 'jupyter_client'
 import sys
 
 v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
-    error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
+if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 5)):
+    error = "ERROR: %s requires Python version 2.7 or 3.5 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -93,11 +93,9 @@ setup_args = dict(
         'python-dateutil>=2.1',
         'tornado>=4.1',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     extras_require   = {
-        'test': ['ipykernel', 'ipython', 'mock'],
-        'test:python_version == "3.3"': ['pytest<3.3.0'],
-        'test:(python_version >= "3.4" or python_version == "2.7")': ['pytest'],
+        'test': ['ipykernel', 'ipython', 'mock', 'pytest'],
     },
     cmdclass         = {
         'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,


### PR DESCRIPTION
For some reason this backport didn't get auto-generated. #448 Was merged as is to master already.