### PR TITLE
call _create_connected_socket to instantiate _control_socket in Kerne…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ __pycache__
 .coverage
 .cache
 absolute.json
-*.swp
 
 # Sphinx documentation
 _build

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -196,7 +196,7 @@ class KernelManager(ConnectionFileMixin):
 
     def _connect_control_socket(self):
         if self._control_socket is None:
-            self._control_socket = self.connect_control()
+            self._control_socket = self._create_connected_socket('control')
             self._control_socket.linger = 100
 
     def _close_control_socket(self):


### PR DESCRIPTION
…lManager

This PR fixes a bug introduced with #447; now that `IOLoopKernelManager` exposes a decorator of `connect_control`, this method is wrongly called by the KernelManager when creating its internal control socket: https://github.com/jupyter/jupyter_client/blob/master/jupyter_client/manager.py#L199.

This results in creating a `ZMQStream` instead of a regular `ZMQSocket` as it was the case before, when `connect_control` of `ConnectionFileMixin` was directly called. I'm not familiar with pyzmq but this prevents the `shutdown_request` message to reach the kernel, leading to always send a signal to kill it.

cc @SylvainCorlay @rgbkrk 



