### PR TITLE
[backport #456 to 5.x] call _create_connected_socket to instantiate _control_socket in KernelManager

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -207,7 +207,7 @@ class KernelManager(ConnectionFileMixin):
 
     def _connect_control_socket(self):
         if self._control_socket is None:
-            self._control_socket = self.connect_control()
+            self._control_socket = self._create_connected_socket('control')
             self._control_socket.linger = 100
 
     def _close_control_socket(self):


### PR DESCRIPTION
I had to solve conflicts so the commit is not the same as the one on master. Let me know if this is a problem, and how I can fix it.