### PR TITLE
Reduce count of warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 .coverage
 .cache
 absolute.json
+htmlcov/
 
 # Sphinx documentation
 _build

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -29,7 +29,7 @@ from ipython_genutils.py3compat import (
     bytes_to_str, cast_bytes, cast_bytes_py2, string_types,
 )
 from traitlets import (
-    Bool, Integer, Unicode, CaselessStrEnum, Instance, Type,
+    Bool, Integer, Unicode, CaselessStrEnum, Instance, Type, observe
 )
 from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir
 
@@ -323,8 +323,9 @@ class ConnectionFileMixin(LoggingConfigurable):
         else:
             return localhost()
 
-    def _ip_changed(self, name, old, new):
-        if new == '*':
+    @observe('ip')
+    def _ip_changed(self, change):
+        if change['new'] == '*':
             self.ip = '0.0.0.0'
 
     # protected traits

--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import
 
-from zmq.eventloop import ioloop
+from tornado import ioloop
 from zmq.eventloop.zmqstream import ZMQStream
 
 from traitlets import (

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -17,7 +17,8 @@ import zmq
 from ipython_genutils.importstring import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
-    Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName, Dict
+    Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName, Dict,
+    observe
 )
 from jupyter_client import (
     launch_kernel,
@@ -46,8 +47,9 @@ class KernelManager(ConnectionFileMixin):
     def _client_factory_default(self):
         return import_item(self.client_class)
 
-    def _client_class_changed(self, name, old, new):
-        self.client_factory = import_item(str(new))
+    @observe('client_class')
+    def _client_class_changed(self, change):
+        self.client_factory = import_item(str(change['new']))
 
     # The kernel process with which the KernelManager is communicating.
     # generally a Popen instance
@@ -68,9 +70,10 @@ class KernelManager(ConnectionFileMixin):
 
     kernel_name = Unicode(kernelspec.NATIVE_KERNEL_NAME)
 
-    def _kernel_name_changed(self, name, old, new):
+    @observe('kernel_name')
+    def _kernel_name_changed(self, change):
         self._kernel_spec = None
-        if new == 'python':
+        if change['new'] == 'python':
             self.kernel_name = kernelspec.NATIVE_KERNEL_NAME
 
     _kernel_spec = None

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -13,7 +13,7 @@ import zmq
 from traitlets.config.configurable import LoggingConfigurable
 from ipython_genutils.importstring import import_item
 from traitlets import (
-    Instance, Dict, List, Unicode, Any, DottedObjectName
+    Instance, Dict, Unicode, Any, DottedObjectName, observe
 )
 from ipython_genutils.py3compat import unicode_type
 
@@ -54,8 +54,10 @@ class MultiKernelManager(LoggingConfigurable):
         subclassing of the KernelManager for customized behavior.
         """
     )
-    def _kernel_manager_class_changed(self, name, old, new):
-        self.kernel_manager_factory = import_item(new)
+
+    @observe('kernel_manager_class')
+    def _kernel_manager_class_changed(self, change):
+        self.kernel_manager_factory = import_item(change['new'])
 
     kernel_manager_factory = Any(help="this is kernel_manager_class after import")
     def _kernel_manager_factory_default(self):

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -61,9 +61,9 @@ from ipython_genutils.importstring import import_item
 from jupyter_client.jsonutil import extract_dates, squash_dates, date_default
 from ipython_genutils.py3compat import (str_to_bytes, str_to_unicode, unicode_type,
                                      iteritems)
-from traitlets import (CBytes, Unicode, Bool, Any, Instance, Set,
-                                        DottedObjectName, CUnicode, Dict, Integer,
-                                        TraitError,
+from traitlets import (
+    CBytes, Unicode, Bool, Any, Instance, Set, DottedObjectName, CUnicode,
+    Dict, Integer, TraitError, observe
 )
 from jupyter_client import protocol_version
 from jupyter_client.adapter import adapt
@@ -180,8 +180,10 @@ class SessionFactory(LoggingConfigurable):
     """
 
     logname = Unicode('')
-    def _logname_changed(self, name, old, new):
-        self.log = logging.getLogger(new)
+
+    @observe('logname')
+    def _logname_changed(self, change):
+        self.log = logging.getLogger(change['new'])
 
     # not configurable:
     context = Instance('zmq.Context')
@@ -311,7 +313,10 @@ class Session(Configurable):
             help="""The name of the packer for serializing messages.
             Should be one of 'json', 'pickle', or an import name
             for a custom callable serializer.""")
-    def _packer_changed(self, name, old, new):
+
+    @observe('packer')
+    def _packer_changed(self, change):
+        new = change['new']
         if new.lower() == 'json':
             self.pack = json_packer
             self.unpack = json_unpacker
@@ -326,7 +331,10 @@ class Session(Configurable):
     unpacker = DottedObjectName('json', config=True,
         help="""The name of the unpacker for unserializing messages.
         Only used with custom functions for `packer`.""")
-    def _unpacker_changed(self, name, old, new):
+
+    @observe('unpacker')
+    def _unpacker_changed(self, change):
+        new = change['new']
         if new.lower() == 'json':
             self.pack = json_packer
             self.unpack = json_unpacker
@@ -345,7 +353,8 @@ class Session(Configurable):
         self.bsession = u.encode('ascii')
         return u
 
-    def _session_changed(self, name, old, new):
+    @observe('session')
+    def _session_changed(self, change):
         self.bsession = self.session.encode('ascii')
 
     # bsession is the session as bytes
@@ -368,13 +377,17 @@ class Session(Configurable):
     def _key_default(self):
         return new_id_bytes()
 
-    def _key_changed(self):
+    @observe('key')
+    def _key_changed(self, change):
         self._new_auth()
 
     signature_scheme = Unicode('hmac-sha256', config=True,
         help="""The digest scheme used to construct the message signatures.
         Must have the form 'hmac-HASH'.""")
-    def _signature_scheme_changed(self, name, old, new):
+
+    @observe('signature_scheme')
+    def _signature_scheme_changed(self, change):
+        new = change['new']
         if not new.startswith('hmac-'):
             raise TraitError("signature_scheme must start with 'hmac-', got %r" % new)
         hash_name = new.split('-', 1)[1]
@@ -406,8 +419,10 @@ class Session(Configurable):
 
     keyfile = Unicode('', config=True,
         help="""path to file containing execution key.""")
-    def _keyfile_changed(self, name, old, new):
-        with open(new, 'rb') as f:
+
+    @observe('keyfile')
+    def _keyfile_changed(self, change):
+        with open(change['new'], 'rb') as f:
             self.key = f.read().strip()
 
     # for protecting against sends from forks
@@ -416,13 +431,19 @@ class Session(Configurable):
     # serialization traits:
 
     pack = Any(default_packer) # the actual packer function
-    def _pack_changed(self, name, old, new):
+
+    @observe('pack')
+    def _pack_changed(self, change):
+        new = change['new']
         if not callable(new):
             raise TypeError("packer must be callable, not %s"%type(new))
 
     unpack = Any(default_unpacker) # the actual packer function
-    def _unpack_changed(self, name, old, new):
+
+    @observe('unpack')
+    def _unpack_changed(self, change):
         # unpacker is not checked - it is assumed to be
+        new = change['new']
         if not callable(new):
             raise TypeError("unpacker must be callable, not %s"%type(new))
 

--- a/jupyter_client/tests/test_jsonutil.py
+++ b/jupyter_client/tests/test_jsonutil.py
@@ -14,14 +14,33 @@ except ImportError:
     # py2
     import mock
 
+import pytest
 from dateutil.tz import tzlocal, tzoffset
 from jupyter_client import jsonutil
 from jupyter_client.session import utcnow
 
 
+REFERENCE_DATETIME = datetime.datetime(
+    2013, 7, 3, 16, 34, 52, 249482, tzlocal()
+)
+
+
+def test_extract_date_from_naive():
+    ref = REFERENCE_DATETIME
+    timestamp = '2013-07-03T16:34:52.249482'
+
+    with pytest.deprecated_call(match='Interpreting naive datetime as local'):
+        extracted = jsonutil.extract_dates(timestamp)
+
+    assert isinstance(extracted, datetime.datetime)
+    assert extracted.tzinfo is not None
+    assert extracted.tzinfo.utcoffset(ref) == tzlocal().utcoffset(ref)
+    assert extracted == ref
+
+
 def test_extract_dates():
+    ref = REFERENCE_DATETIME
     timestamps = [
-        '2013-07-03T16:34:52.249482',
         '2013-07-03T16:34:52.249482Z',
         '2013-07-03T16:34:52.249482-0800',
         '2013-07-03T16:34:52.249482+0800',
@@ -29,17 +48,16 @@ def test_extract_dates():
         '2013-07-03T16:34:52.249482+08:00',
     ]
     extracted = jsonutil.extract_dates(timestamps)
-    ref = extracted[0]
     for dt in extracted:
         assert isinstance(dt, datetime.datetime)
-        assert dt.tzinfo != None
+        assert dt.tzinfo is not None
 
-    assert extracted[0].tzinfo.utcoffset(ref) == tzlocal().utcoffset(ref)
-    assert extracted[1].tzinfo.utcoffset(ref) == timedelta(0)
-    assert extracted[2].tzinfo.utcoffset(ref) == timedelta(hours=-8)
-    assert extracted[3].tzinfo.utcoffset(ref) == timedelta(hours=8)
-    assert extracted[4].tzinfo.utcoffset(ref) == timedelta(hours=-8)
-    assert extracted[5].tzinfo.utcoffset(ref) == timedelta(hours=8)
+    assert extracted[0].tzinfo.utcoffset(ref) == timedelta(0)
+    assert extracted[1].tzinfo.utcoffset(ref) == timedelta(hours=-8)
+    assert extracted[2].tzinfo.utcoffset(ref) == timedelta(hours=8)
+    assert extracted[3].tzinfo.utcoffset(ref) == timedelta(hours=-8)
+    assert extracted[4].tzinfo.utcoffset(ref) == timedelta(hours=8)
+
 
 def test_parse_ms_precision():
     base = '2013-07-03T16:34:52'
@@ -56,14 +74,14 @@ def test_parse_ms_precision():
             assert isinstance(parsed, str)
 
 
-
 def test_date_default():
     naive = datetime.datetime.now()
     local = tzoffset('Local', -8 * 3600)
     other = tzoffset('Other', 2 * 3600)
     data = dict(naive=naive, utc=utcnow(), withtz=naive.replace(tzinfo=other))
     with mock.patch.object(jsonutil, 'tzlocal', lambda : local):
-        jsondata = json.dumps(data, default=jsonutil.date_default)
+        with pytest.deprecated_call(match='Please add timezone info'):
+            jsondata = json.dumps(data, default=jsonutil.date_default)
     assert "Z" in jsondata
     assert jsondata.count("Z") == 1
     extracted = jsonutil.extract_dates(json.loads(jsondata))

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -131,7 +131,7 @@ class TestKernelManager(TestCase):
         self.assertTrue(km.is_alive())
         self.assertTrue(kc.is_alive())
 
-@pytest.mark.parallel
+
 class TestParallel:
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Hello,

Hope you'll find this PR useful.

This PR fixes warnings like these:
 - PytestUnknownMarkWarning: Unknown pytest.mark.parallel - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
 - DeprecationWarning: Session._key_changed is deprecated in traitlets 4.1: use @observe and @unobserve instead.
 - DeprecationWarning: Interpreting naive datetime as local 2013-07-03 16:34:52.249482. Please add timezone info to timestamps.
 - DeprecationWarning: zmq.eventloop.ioloop is deprecated in pyzmq 17. pyzmq now works with default tornado and asyncio eventloops.

Best regards!