### PR TITLE
Declare support for Python 2.7, 3.5, 3.6, and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+dist: xenial
 language: python
 python:
     - "nightly"
-    - "3.7-dev"
-    - 3.6
-    - 3.5
-    - 2.7
-sudo: false
+    - "3.8-dev"
+    - "3.7"
+    - "3.6"
+    - "3.5"
+    - "2.7"
 install:
   - pip install --upgrade setuptools pip
   - pip install --upgrade --upgrade-strategy eager --pre -e .[test] pytest-cov codecov 'coverage<5'

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,11 @@ setup_args = dict(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     install_requires = [
         'traitlets',


### PR DESCRIPTION
Hello,

The main goal of this PR is to clarify for the PyPI users which versions of Python are supported.

These changes also:
 - Enable testing for `3.8-dev`
 - Replace `3.7-dev` with `3.7` in `.travis.yml`
 - Make Travis CI use `xenial`
   https://docs.travis-ci.com/user/reference/xenial/
 - Remove obsolete `sudo: false`
   https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Regards!