### PR TITLE
Fix ambiguous specification around execution_reply field

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1187,7 +1187,7 @@ Message type: ``error``::
 
     content = {
        # Similar content to the execute_reply messages for the 'error' case,
-       # except the 'status' field is omitted.
+       # except the 'status' and 'execution_count' fields are omitted.
     }
 
 .. versionchanged:: 5.0

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -305,6 +305,9 @@ All reply messages have a ``'status'`` field, which will have one of the followi
   but with no information about the error.
   No fields should be present other that `status`.
 
+As a special case, ``execute_reply`` messages (see :ref:`execution_results`)
+have an ``execution_count`` field regardless of their status.
+
 .. versionchanged:: 5.1
 
     ``status='abort'`` has not proved useful, and is considered deprecated.


### PR DESCRIPTION
This fixes #129 and #443. The resolutions are up for debate, but these are the choices that I believe will require the least code to change - see the issues for details of what I looked at.