### PR TITLE
Secure core import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ python:
     - 2.7
 sudo: false
 install:
-  - |
-    # install pip 10 on python 3.3
-    # to get requires_python support
-    if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then
-      pip install pip==10.*
-    fi
   - pip install --upgrade setuptools pip
   - pip install --upgrade --upgrade-strategy eager --pre -e .[test] pytest-cov pytest-warnings codecov
   - pip freeze

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup_args = dict(
     ],
     install_requires = [
         'traitlets',
-        'jupyter_core',
+        'jupyter_core>=4.5.0',
         'pyzmq>=13',
         'python-dateutil>=2.1',
         'tornado>=4.1',

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup_args = dict(
     ],
     install_requires = [
         'traitlets',
-        'jupyter_core>=4.5.0',
+        'jupyter_core>=4.6.0',
         'pyzmq>=13',
         'python-dateutil>=2.1',
         'tornado>=4.1',


### PR DESCRIPTION
Bug fixes for windows issues are going into jupyter_core for secure_write -- we can move to depending on that location to pick up fixes.

@kevin-bates We can bump the setup requirement to 4.5.1 once https://github.com/jupyter/jupyter_core/pull/166 merges and releases.