### PR TITLE
Session.msg_id optimization

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -527,10 +527,12 @@ class Session(Configurable):
         new_session.digest_history.update(self.digest_history)
         return new_session
 
+    message_count = 0
     @property
     def msg_id(self):
-        """always return new uuid"""
-        return new_id()
+        message_number = self.message_count
+        self.message_count += 1
+        return '{}_{}'.format(self.session, message_number)
 
     def _check_packers(self):
         """check packers for datetime support."""


### PR DESCRIPTION
I was benchmarking the ipyparallel code and discovered that the scripts where spending a lot of time acquiring msg_ids. 
The msg_id property of the Session class takes a while to run just to get a unique ID. 

To optimise this I changed the msg_id property function to use a message counter and to just return the session_id + message count. This also return a unique ID and runs much faster. 

Using timeit to compare the existing code with my implementation I got these runtimes for 1000 000 calls to session.msg_id: 

| function             | Runtime in seconds |
|----------------------|--------------------|
| Existing msg_id      | 3.2                |
| Reimplemented msg_id | 0.86               |