### PR TITLE
Document the handling of error in do_execute

### DIFF
--- a/docs/wrapperkernels.rst
+++ b/docs/wrapperkernels.rst
@@ -63,7 +63,10 @@ following methods and attributes:
 
      Your method should return a dict containing the fields described in
      :ref:`execution_results`. To display output, it can send messages
-     using :meth:`~ipykernel.kernelbase.Kernel.send_response`.
+     using :meth:`~ipykernel.kernelbase.Kernel.send_response`. If an error
+     occurs during execution, an message of type `error` should be sent
+     through :meth:`~ipykernel.kernelbase.Kernel.send_response`
+     in addition to an :ref:`execution_results` with an `status` of `error`.
      See :doc:`messaging` for details of the different message types.
 
 .. automethod:: ipykernel.kernelbase.Kernel.send_response


### PR DESCRIPTION
My customized kernel does something like the following to handle errors

```python
    def _do_execute(self,
                    code,
                    silent,
                    store_history=True,
                    user_expressions=None,
                    allow_stdin=True):
        try:
            # do stuff
        except Exception as e:
            return {
                'status': 'error',
                'ename': e.__class__.__name__,
                'evalue': str(e),
                'traceback': [],
                'execution_count': self._execution_count,
            }
```
which works fine during interactive data analysis or through `Run all cells`. However, papermill does not recognizes the error and returns `0` when it converts notebooks with my kernel. It turns out that a message of type `error` should be sent through `self.send_response` in addition to returning `execute_reply` with `status` of `error`. Although I believe the caller of this `do_execute` function should automatically do this, this PR documents the proper way of handling errors in this function, namely 


```python
    def _do_execute(self,
                    code,
                    silent,
                    store_history=True,
                    user_expressions=None,
                    allow_stdin=True):
        try:
            # do stuff
        except Exception as e:
            msg = {
                'status': 'error',
                'ename': e.__class__.__name__,
                'evalue': str(e),
                'traceback': [],
                'execution_count': self._execution_count,
            }
            self.send_response(self.iopub_channel, 'error', msg)
            return msg
```