### PR TITLE
Backport PR #490 and #492

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -18,7 +18,8 @@ import zmq
 from ipython_genutils.importstring import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
-    Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName
+    Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName,
+    default
 )
 from jupyter_client import (
     launch_kernel,
@@ -99,6 +100,12 @@ class KernelManager(ConnectionFileMixin):
     def _kernel_cmd_changed(self, name, old, new):
         warnings.warn("Setting kernel_cmd is deprecated, use kernel_spec to "
                       "start different kernels.")
+
+    cache_ports = Bool(help='True if the MultiKernelManager should cache ports for this KernelManager instance')
+
+    @default('cache_ports')
+    def _default_cache_ports(self):
+        return self.transport == 'tcp'
 
     @property
     def ipykernel(self):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -14,7 +14,7 @@ import zmq
 from traitlets.config.configurable import LoggingConfigurable
 from ipython_genutils.importstring import import_item
 from traitlets import (
-    Instance, Dict, Unicode, Any, DottedObjectName, observe, default
+    Any, Bool, Dict, DottedObjectName, Instance, Unicode, default, observe
 )
 from ipython_genutils.py3compat import unicode_type
 
@@ -78,7 +78,7 @@ class MultiKernelManager(LoggingConfigurable):
         def create_kernel_manager(*args, **kwargs):
             km = kernel_manager_ctor(*args, **kwargs)
 
-            if km.transport == 'tcp':
+            if km.cache_ports:
                 km.shell_port = self._find_available_port(km.ip)
                 km.iopub_port = self._find_available_port(km.ip)
                 km.stdin_port = self._find_available_port(km.ip)
@@ -168,17 +168,17 @@ class MultiKernelManager(LoggingConfigurable):
         """
         self.log.info("Kernel shutdown: %s" % kernel_id)
 
-        kernel = self.get_kernel(kernel_id)
+        km = self.get_kernel(kernel_id)
 
         ports = (
-            kernel.shell_port, kernel.iopub_port, kernel.stdin_port,
-            kernel.hb_port, kernel.control_port
+            km.shell_port, km.iopub_port, km.stdin_port,
+            km.hb_port, km.control_port
         )
 
-        kernel.shutdown_kernel(now=now, restart=restart)
+        km.shutdown_kernel(now=now, restart=restart)
         self.remove_kernel(kernel_id)
 
-        if not restart and kernel.transport == 'tcp':
+        if km.cache_ports and not restart:
             for port in ports:
                 self.currently_used_ports.remove(port)
 


### PR DESCRIPTION
Prevent two kernels to have the same ports assigned in MultiKernelManager
Only cache ports if the cache_ports flag is set to True