### PR TITLE
remove unused sphinx import in test_kernelapp

### DIFF
--- a/jupyter_client/tests/test_kernelapp.py
+++ b/jupyter_client/tests/test_kernelapp.py
@@ -1,5 +1,4 @@
 import os
-import sphinx.util
 import sys
 import shutil
 import time


### PR DESCRIPTION
In working on https://github.com/conda-forge/jupyter_client-feedstock/pull/38 uncovered a new test dependency on `sphinx` which may be spurious... doesn't appear to be used, but figured PR is better than issue, if straightforward. 