### PR TITLE
Address syntax warning for use of "is" against a string literal

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -79,7 +79,7 @@ class KernelManager(ConnectionFileMixin):
 
     @property
     def kernel_spec(self):
-        if self._kernel_spec is None and self.kernel_name is not '':
+        if self._kernel_spec is None and self.kernel_name != '':
             self._kernel_spec = self.kernel_spec_manager.get_kernel_spec(self.kernel_name)
         return self._kernel_spec
 


### PR DESCRIPTION
Currently throws this during [tests against 3.8](
https://travis-ci.org/jupyter/jupyter_client/jobs/654391576?utm_medium=notification&utm_source=github_status):

```
/home/travis/build/jupyter/jupyter_client/jupyter_client/manager.py:82: 
SyntaxWarning: "is not" with a literal. Did you mean "!="?

  if self._kernel_spec is None and self.kernel_name is not '':
```

Sure, just a warning, but...

- blocked by #518 