### PR TITLE
readthedocs: install with pip

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=1.3.6
+sphinx_rtd_theme
+sphinxcontrib_github_alt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,12 @@
-name: jupyter_client
-type: sphinx
-conda:
-    file: docs/environment.yml
+version: 2
+name: jupyter-client
+sphinx:
+  configuration: docs/conf.py
 python:
-  version: 3
-  pip_install: true
+  version: 3.7
+  install:
+    # install docs requirements
+    - requirements: docs/requirements.txt
+    # install jupyter-client itself
+    - method: pip
+      path: .


### PR DESCRIPTION
docs haven't been building for a few days because installs from conda-forge regularly fail on rtd with out of memory errors these days.

We've no need for conda-only dependencies on rtd for this repo, so might as well use lighter, simpler pip.