### PR TITLE
Expose control channel on AsyncKernelManager

### DIFF
--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -98,6 +98,7 @@ class AsyncIOLoopKernelManager(AsyncKernelManager):
                 self._restarter = None
 
     connect_shell = as_zmqstream(AsyncKernelManager.connect_shell)
+    connect_control = as_zmqstream(AsyncKernelManager.connect_control)
     connect_iopub = as_zmqstream(AsyncKernelManager.connect_iopub)
     connect_stdin = as_zmqstream(AsyncKernelManager.connect_stdin)
     connect_hb = as_zmqstream(AsyncKernelManager.connect_hb)


### PR DESCRIPTION
In reviving the async kernel management work in [Notebook](https://github.com/jupyter/notebook/pull/4479) after #428 was merged, I ran into an issue with the control socket since I hadn't applied the ioloop manager portion of #447 to the AsyncIOLoopKernelManager.  This change adds the appropriate `as_zmqstream` entry to the kernel manager and the Notebook issue is no longer present.