### PR TITLE
[WIP] Remove async send_signal method, defer to subclass

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -642,9 +642,9 @@ class AsyncKernelManager(KernelManager):
             # TerminateProcess() on Win32).
             try:
                 if hasattr(signal, 'SIGKILL'):
-                    await self.signal_kernel(signal.SIGKILL)
+                    self.signal_kernel(signal.SIGKILL)
                 else:
-                    await self.kernel.kill()
+                    self.kernel.kill()
             except OSError as e:
                 # In Windows, we will get an Access Denied error if the process
                 # has already terminated. Ignore it.
@@ -686,7 +686,7 @@ class AsyncKernelManager(KernelManager):
                     from .win_interrupt import send_interrupt
                     send_interrupt(self.kernel.win32_interrupt_event)
                 else:
-                    await self.signal_kernel(signal.SIGINT)
+                    self.signal_kernel(signal.SIGINT)
 
             elif interrupt_mode == 'message':
                 msg = self.session.msg("interrupt_request", content={})
@@ -694,26 +694,6 @@ class AsyncKernelManager(KernelManager):
                 self.session.send(self._control_socket, msg)
         else:
             raise RuntimeError("Cannot interrupt kernel. No kernel is running!")
-
-    async def signal_kernel(self, signum):
-        """Sends a signal to the process group of the kernel (this
-        usually includes the kernel and any subprocesses spawned by
-        the kernel).
-
-        Note that since only SIGTERM is supported on Windows, this function is
-        only useful on Unix systems.
-        """
-        if self.has_kernel:
-            if hasattr(os, "getpgid") and hasattr(os, "killpg"):
-                try:
-                    pgid = os.getpgid(self.kernel.pid)
-                    os.killpg(pgid, signum)
-                    return
-                except OSError:
-                    pass
-            self.kernel.send_signal(signum)
-        else:
-            raise RuntimeError("Cannot signal kernel. No kernel is running!")
 
     async def is_alive(self):
         """Is the kernel process still running?"""


### PR DESCRIPTION
After validating the downstream modules that can use async kernel
management (notebook and enterprise-gateway) it was found that
the async send_signal method was not warranted since it doesn't
return an awaitable and deferring to the subclass's sync version is fine.

I'm fairly certain this is the last of the "touch-ups" for the async kernel management changes.  Thanks for your patience.