### PR TITLE
Retain restarter instance on stop

### DIFF
--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -54,7 +54,6 @@ class IOLoopKernelManager(KernelManager):
         if self.autorestart:
             if self._restarter is not None:
                 self._restarter.stop()
-                self._restarter = None
 
     connect_shell = as_zmqstream(KernelManager.connect_shell)
     connect_control = as_zmqstream(KernelManager.connect_control)
@@ -95,7 +94,6 @@ class AsyncIOLoopKernelManager(AsyncKernelManager):
         if self.autorestart:
             if self._restarter is not None:
                 self._restarter.stop()
-                self._restarter = None
 
     connect_shell = as_zmqstream(AsyncKernelManager.connect_shell)
     connect_control = as_zmqstream(AsyncKernelManager.connect_control)


### PR DESCRIPTION
Since late February the js/services tests have been producing a single failure in one of its kernel auto-restart tests.  This issue was occurring on all notebook PRs irrespective to change - which implied a changed dependency.  Also in late February, we released jupyter_client 6.0.0.  This release consisted of commits more than two years ago.

In looking through the commit history (and knowing I might be a culprit :blush:) I began going through the commits that seemed possible candidates.  Fortunately, the first I picked was the culprit!

It turns out that commit 7a8394d was resetting the `self._restarter` attribute when stopping the restarter.  Although restarts continued working, _auto_ restarts may not have been getting properly performed.

This change retains the restarter instance across stop requests.  Since leaks are not commonly reported in normal circumstances, this probably isn't a big deal.  Its applications like Kernel or Enterprise Gateway, where large numbers of kernels can be active where this is more problematic.  However, since there hasn't been a lot of noise in the two years since that commit was made, I don't think its restoration is something to worry about.

Here's a history of the CI tests [(builds 78-87)](https://travis-ci.org/github/kevin-bates/notebook/builds) that first reproduce the issue, work with some proposed changes, then reproduce it again (upon restoring the issue to the test branch), then succeeding with this branch.  The two notebook PRs are completely unrelated, one involving server-side changes, the other invoving client-side changes.