### PR TITLE
[BugFix] [Resource Leak] Gracefully Close ZMQ Context upon kernel shutdown

### DIFF
--- a/jupyter_client/kernelapp.py
+++ b/jupyter_client/kernelapp.py
@@ -77,7 +77,7 @@ class KernelApp(JupyterApp):
             self.setup_signals()
             self.loop.start()
         finally:
-            self.km.cleanup()
+            self.km.cleanup_resources()
 
 
 main = KernelApp.launch_instance

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -605,8 +605,6 @@ class AsyncKernelManager(KernelManager):
             # most 1s, checking every 0.1s.
             await self.finish_shutdown()
 
-        self.cleanup(connection_file=not restart)
-
         from . import __version__
         from distutils.version import LooseVersion
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -341,12 +341,14 @@ class KernelManager(ConnectionFileMixin):
         """Clean up resources when the kernel is shut down"""
         if not restart:
             self.cleanup_connection_file()
-            # shutdown ZMQ context as we no longer using this kernel
-            self.context.destroy(linger=100)
 
         self.cleanup_ipc_files()
         self._close_control_socket()
         self.session.parent = None
+
+        # shutdown ZMQ context as we no longer using this kernel
+        if not restart:
+            self.context.destroy(linger=100)
 
     def cleanup(self, connection_file=True):
         """Clean up resources when the kernel is shut down"""

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -339,15 +339,12 @@ class KernelManager(ConnectionFileMixin):
 
     def cleanup_resources(self, restart=False):
         """Clean up resources when the kernel is shut down"""
-        if not restart:
-            self.cleanup_connection_file()
-
         self.cleanup_ipc_files()
         self._close_control_socket()
         self.session.parent = None
 
-        # shutdown ZMQ context as we no longer using this kernel
         if not restart:
+            self.cleanup_connection_file()
             self.context.destroy(linger=100)
 
     def cleanup(self, connection_file=True):

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -355,7 +355,7 @@ class KernelManager(ConnectionFileMixin):
     def cleanup(self, connection_file=True):
         """Clean up resources when the kernel is shut down"""
         warnings.warn("Method cleanup(connection_file=True) is deprecated, use cleanup_resources(restart=False).",
-                      DeprecationWarning)
+                      FutureWarning)
         self.cleanup_resources(restart=not connection_file)
 
     def shutdown_kernel(self, now=False, restart=False):

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -377,6 +377,9 @@ class KernelManager(ConnectionFileMixin):
             self.finish_shutdown()
 
         self.cleanup(connection_file=not restart)
+        # shutdown ZMQ context as we no longer using this kernel
+        if not restart:
+            self.context.destroy(linger=100)
 
     def restart_kernel(self, now=False, newports=False, **kw):
         """Restarts a kernel with the arguments that were used to launch it.
@@ -592,6 +595,9 @@ class AsyncKernelManager(KernelManager):
             await self.finish_shutdown()
 
         self.cleanup(connection_file=not restart)
+        # shutdown ZMQ context as we no longer using this kernel
+        if not restart:
+            self.context.destroy(linger=100)
 
     async def restart_kernel(self, now=False, newports=False, **kw):
         """Restarts a kernel with the arguments that were used to launch it.

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -512,5 +512,5 @@ class AsyncMultiKernelManager(MultiKernelManager):
             self.request_shutdown(kid)
         for kid in kids:
             await self.finish_shutdown(kid)
-            self.cleanup(kid)
+            self.cleanup_resources(kid)
             self.remove_kernel(kid)

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -198,7 +198,7 @@ class MultiKernelManager(LoggingConfigurable):
         self.log.info("Kernel shutdown: %s" % kernel_id)
 
     @kernel_method
-    def cleanup(self, kernel_id, connection_file=True):
+    def cleanup(self, kernel_id, restart=False):
         """Clean up a kernel's resources"""
 
     def remove_kernel(self, kernel_id):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -129,7 +129,12 @@ class MultiKernelManager(LoggingConfigurable):
             if self.log:
                 self.log.debug("Destroying zmq context for %s", self)
             self.context.destroy()
-        super().__del__()
+        try:
+            super_del = super().__del__
+        except AttributeError:
+            pass
+        else:
+            super_del()
 
     connection_dir = Unicode('')
 

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -198,7 +198,11 @@ class MultiKernelManager(LoggingConfigurable):
         self.log.info("Kernel shutdown: %s" % kernel_id)
 
     @kernel_method
-    def cleanup(self, kernel_id, restart=False):
+    def cleanup(self, kernel_id, connection_file=True):
+        """Clean up a kernel's resources"""
+
+    @kernel_method
+    def cleanup_resources(self, kernel_id, restart=False):
         """Clean up a kernel's resources"""
 
     def remove_kernel(self, kernel_id):

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -197,6 +197,28 @@ class TestKernelManager(TestCase):
 
         self._env_test_body(kc)
 
+    def test_cleanup_context(self):
+        km = KernelManager()
+        self.assertIsNotNone(km.context)
+
+        km.cleanup_resources(restart=False)
+
+        self.assertTrue(km.context.closed)
+
+    def test_no_cleanup_shared_context(self):
+        """kernel manager does not terminate shared context"""
+        import zmq
+        ctx = zmq.Context()
+        km = KernelManager(context=ctx)
+        self.assertEquals(km.context, ctx)
+        self.assertIsNotNone(km.context)
+
+        km.cleanup_resources(restart=False)
+        self.assertFalse(km.context.closed)
+        self.assertFalse(ctx.closed)
+
+        ctx.term()
+
 
 class TestParallel:
 

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -67,6 +67,7 @@ class TestKernelManager(TestCase):
         km.interrupt_kernel()
         self.assertTrue(isinstance(km, KernelManager))
         km.shutdown_kernel(now=True)
+        self.assertTrue(km.context.closed)
 
     def test_tcp_lifecycle(self):
         km = self._get_tcp_km()
@@ -135,6 +136,7 @@ class TestKernelManager(TestCase):
 
         self.assertTrue(km.is_alive())
         self.assertTrue(kc.is_alive())
+        self.assertFalse(km.context.closed)
 
     def _env_test_body(self, kc):
 
@@ -157,6 +159,7 @@ class TestKernelManager(TestCase):
 
         self.assertTrue(km.is_alive())
         self.assertTrue(kc.is_alive())
+        self.assertFalse(km.context.closed)
 
         self._env_test_body(kc)
 
@@ -190,6 +193,7 @@ class TestKernelManager(TestCase):
 
         self.assertTrue(km.is_alive())
         self.assertTrue(kc.is_alive())
+        self.assertFalse(km.context.closed)
 
         self._env_test_body(kc)
 
@@ -307,6 +311,7 @@ class TestParallel:
         execute('check')
 
         km.shutdown_kernel()
+        assert km.context.closed
 
 
 class TestAsyncKernelManager(AsyncTestCase):
@@ -351,6 +356,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         self.assertTrue(isinstance(km, AsyncKernelManager))
         await km.shutdown_kernel(now=True)
         self.assertFalse(await km.is_alive())
+        self.assertTrue(km.context.closed)
 
     @gen_test
     async def test_tcp_lifecycle(self):
@@ -417,6 +423,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         finally:
             await km.shutdown_kernel(now=True)
             kc.stop_channels()
+            self.assertTrue(km.context.closed)
 
     @gen_test(timeout=10.0)
     async def test_start_new_async_kernel(self):
@@ -431,3 +438,4 @@ class TestAsyncKernelManager(AsyncTestCase):
         finally:
             await km.shutdown_kernel(now=True)
             kc.stop_channels()
+            self.assertTrue(km.context.closed)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup_args = dict(
         'pyzmq>=13',
         'python-dateutil>=2.1',
         'tornado>=4.1',
-        'deprecated',
     ],
     python_requires  = '>=3.5',
     extras_require   = {

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup_args = dict(
         'pyzmq>=13',
         'python-dateutil>=2.1',
         'tornado>=4.1',
+        'deprecated',
     ],
     python_requires  = '>=3.5',
     extras_require   = {


### PR DESCRIPTION
As part of kernel manager instance creation, we create new context of ZMQ.
This kernel manager are responsible for managing lifecycle of kernel process.
At the end of kernel process lifecycle we are just simply killing kernel process and not closing ZMQ context. This leaked ZMQ contexts holds sockets and end up exhausting system resources

This PR fixes this by gracefully shutting down ZMQ context during kernel shutdown process


### Tests
- Enhanced existing tests to track zmq context checks

### Manual Tests Steps:
1. start jupyter server
2. run kernel_lifecycle.sh script 3 times
3. record socket usage


#### kernel_lifecycle.sh
```
kernel_id=$(curl --silent --show-error  -X POST 'localhost:8888/api/kernels' | jq .id | tr -d '"')
echo $kernel_id
read -n 2 -p 'Stop?'
echo 'stopping '
curl -X DELETE "localhost:8888/api/kernels/$kernel_id"
```

#### Track socket usage using following cmd
```
macos:   lsof -p <pid of jupyter> | grep unix | wc -l
linux:   lsof -p <pid of jupyter> | grep event | wc -l
```


### Local Macbook Test Runs:
After 3 executions of kernel_lifecycle script, socket usage
- without fix
```
$ lsof -p 17207 | grep unix | wc -l 
      21
```


- with fix
```
$ lsof -p 16076 | grep unix | wc -l 
       3
```


