### PR TITLE
Use py3 metaclass syntax

### DIFF
--- a/jupyter_client/channelsabc.py
+++ b/jupyter_client/channelsabc.py
@@ -5,10 +5,8 @@
 
 import abc
 
-from ipython_genutils.py3compat import with_metaclass
 
-
-class ChannelABC(with_metaclass(abc.ABCMeta, object)):
+class ChannelABC(object, metaclass=abc.ABCMeta):
     """A base class for all channel ABCs."""
 
     @abc.abstractmethod

--- a/jupyter_client/clientabc.py
+++ b/jupyter_client/clientabc.py
@@ -13,13 +13,12 @@
 
 import abc
 
-from ipython_genutils.py3compat import with_metaclass
 
 #-----------------------------------------------------------------------------
 # Main kernel client class
 #-----------------------------------------------------------------------------
 
-class KernelClientABC(with_metaclass(abc.ABCMeta, object)):
+class KernelClientABC(object, metaclass=abc.ABCMeta):
     """KernelManager ABC.
 
     The docstrings for this class can be found in the base implementation:

--- a/jupyter_client/managerabc.py
+++ b/jupyter_client/managerabc.py
@@ -5,10 +5,8 @@
 
 import abc
 
-from ipython_genutils.py3compat import with_metaclass
 
-
-class KernelManagerABC(with_metaclass(abc.ABCMeta, object)):
+class KernelManagerABC(object, metaclass=abc.ABCMeta):
     """KernelManager ABC.
 
     The docstrings for this class can be found in the base implementation:


### PR DESCRIPTION
This PR replaces the use of `with_metaclass` with the `metaclass=` kwarg - which is the standard way to set metaclass when defining classes on Python 3. The `with_metaclass` imports have been removed from the modules.

Note that this PR doesn't fix any specific issue that I am aware of. This is just a drive-by cleanup.