### PR TITLE
Use python 3 super syntax

### DIFF
--- a/jupyter_client/asynchronous/channels.py
+++ b/jupyter_client/asynchronous/channels.py
@@ -26,7 +26,7 @@ class ZMQSocketChannel(object):
         loop
             Unused here, for other implementations
         """
-        super(ZMQSocketChannel, self).__init__()
+        super().__init__()
 
         self.socket = socket
         self.session = session

--- a/jupyter_client/blocking/channels.py
+++ b/jupyter_client/blocking/channels.py
@@ -32,7 +32,7 @@ class ZMQSocketChannel(object):
         loop
             Unused here, for other implementations
         """
-        super(ZMQSocketChannel, self).__init__()
+        super().__init__()
 
         self.socket = socket
         self.session = session

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -58,7 +58,7 @@ class HBChannel(Thread):
         address : zmq url
             Standard (ip, port) tuple that the kernel is listening on.
         """
-        super(HBChannel, self).__init__()
+        super().__init__()
         self.daemon = True
 
         self.loop = loop

--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -344,4 +344,4 @@ class JupyterConsoleApp(ConnectionFileMixin):
 class IPythonConsoleApp(JupyterConsoleApp):
     def __init__(self, *args, **kwargs):
         warnings.warn("IPythonConsoleApp is deprecated. Use JupyterConsoleApp")
-        super(IPythonConsoleApp, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)

--- a/jupyter_client/kernelapp.py
+++ b/jupyter_client/kernelapp.py
@@ -29,7 +29,7 @@ class KernelApp(JupyterApp):
     ).tag(config=True)
 
     def initialize(self, argv=None):
-        super(KernelApp, self).initialize(argv)
+        super().initialize(argv)
         
         cf_basename = 'kernel-%s.json' % uuid.uuid4()
         self.config.setdefault('KernelManager', {}).setdefault('connection_file', os.path.join(self.runtime_dir, cf_basename))

--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -119,7 +119,7 @@ class InstallKernelSpec(JupyterApp):
             }
 
     def parse_command_line(self, argv):
-        super(InstallKernelSpec, self).parse_command_line(argv)
+        super().parse_command_line(argv)
         # accept positional arg as profile name
         if self.extra_args:
             self.sourcedir = self.extra_args[0]
@@ -168,7 +168,7 @@ class RemoveKernelSpec(JupyterApp):
     flags.update(JupyterApp.flags)
 
     def parse_command_line(self, argv):
-        super(RemoveKernelSpec, self).parse_command_line(argv)
+        super().parse_command_line(argv)
         # accept positional arg as profile name
         if self.extra_args:
             self.spec_names = sorted(set(self.extra_args)) # remove duplicates

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -57,7 +57,7 @@ class MultiKernelManager(LoggingConfigurable):
     )
 
     def __init__(self, *args, **kwargs):
-        super(MultiKernelManager, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Cache all the currently used ports
         self.currently_used_ports = set()

--- a/jupyter_client/runapp.py
+++ b/jupyter_client/runapp.py
@@ -59,14 +59,14 @@ class RunApp(JupyterApp, JupyterConsoleApp):
     )
 
     def parse_command_line(self, argv=None):
-        super(RunApp, self).parse_command_line(argv)
+        super().parse_command_line(argv)
         self.build_kernel_argv(self.extra_args)
         self.filenames_to_run = self.extra_args[:]
 
     @catch_config_error
     def initialize(self, argv=None):
         self.log.debug("jupyter run: initialize...")
-        super(RunApp, self).initialize(argv)
+        super().initialize(argv)
         JupyterConsoleApp.initialize(self)
         signal.signal(signal.SIGINT, self.handle_sigint)
         self.init_kernel_info()
@@ -97,7 +97,7 @@ class RunApp(JupyterApp, JupyterConsoleApp):
 
     def start(self):
         self.log.debug("jupyter run: starting...")
-        super(RunApp, self).start()
+        super().start()
         if self.filenames_to_run:
             for filename in self.filenames_to_run:
                 self.log.debug("jupyter run: executing `%s`" % filename)

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -184,7 +184,7 @@ class SessionFactory(LoggingConfigurable):
         return IOLoop.current()
 
     def __init__(self, **kwargs):
-        super(SessionFactory, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if self.session is None:
             # construct the session
@@ -486,7 +486,7 @@ class Session(Configurable):
             The file containing a key.  If this is set, `key` will be
             initialized to the contents of the file.
         """
-        super(Session, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._check_packers()
         self.none = self.pack({})
         # ensure self._session_default() if necessary, so bsession is defined:

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -22,7 +22,7 @@ class SignalTestKernel(Kernel):
 
     def __init__(self, **kwargs):
         kwargs.pop('user_ns', None)
-        super(SignalTestKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.children = []
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None,
@@ -59,7 +59,7 @@ class SignalTestKernel(Kernel):
 
         triggers slow-response code in KernelClient.wait_for_ready
         """
-        return super(SignalTestKernel, self).kernel_info_request(*args, **kwargs)
+        return super().kernel_info_request(*args, **kwargs)
 
 
 class SignalTestApp(IPKernelApp):

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -73,11 +73,11 @@ class AsyncKernelManagerSubclass(AsyncKernelManager):
     """
 
     def cleanup(self, connection_file=True):
-        super(AsyncKernelManagerSubclass, self).cleanup(connection_file=connection_file)
+        super().cleanup(connection_file=connection_file)
         self.which_cleanup = 'cleanup'
 
     def cleanup_resources(self, restart=False):
-        super(AsyncKernelManagerSubclass, self).cleanup_resources(restart=restart)
+        super().cleanup_resources(restart=restart)
         self.which_cleanup = 'cleanup_resources'
 
 class AsyncKernelManagerWithCleanup(AsyncKernelManager):

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -36,7 +36,7 @@ class ThreadedZMQSocketChannel(object):
         loop
             A pyzmq ioloop to connect the socket to using a ZMQStream
         """
-        super(ThreadedZMQSocketChannel, self).__init__()
+        super().__init__()
 
         self.socket = socket
         self.session = session
@@ -151,7 +151,7 @@ class IOLoopThread(Thread):
     ioloop = None
 
     def __init__(self):
-        super(IOLoopThread, self).__init__()
+        super().__init__()
         self.daemon = True
 
     @staticmethod
@@ -236,7 +236,7 @@ class ThreadedKernelClient(KernelClient):
         if shell:
             self.shell_channel._inspect = self._check_kernel_info_reply
 
-        super(ThreadedKernelClient, self).start_channels(shell, iopub, stdin, hb, control)
+        super().start_channels(shell, iopub, stdin, hb, control)
 
     def _check_kernel_info_reply(self, msg):
         """This is run in the ioloop thread when the kernel info reply is received
@@ -246,7 +246,7 @@ class ThreadedKernelClient(KernelClient):
             self.shell_channel._inspect = None
 
     def stop_channels(self):
-        super(ThreadedKernelClient, self).stop_channels()
+        super().stop_channels()
         if self.ioloop_thread.is_alive():
             self.ioloop_thread.stop()
 


### PR DESCRIPTION
This PR replaces the use of `super(_class_name_, self)` with `super()` - which is the standard way to access the inheritance tree on Python 3.