### PR TITLE
Remove more py2/3 compat code

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -24,7 +24,7 @@ from traitlets.config import LoggingConfigurable
 from .localinterfaces import localhost
 from ipython_genutils.path import filefind
 from ipython_genutils.py3compat import (
-    bytes_to_str, cast_bytes, cast_bytes_py2,
+    bytes_to_str, cast_bytes,
 )
 from traitlets import (
     Bool, Integer, Unicode, CaselessStrEnum, Instance, Type, observe
@@ -266,7 +266,7 @@ def tunnel_to_kernel(connection_info, sshserver, sshkey=None):
     if tunnel.try_passwordless_ssh(sshserver, sshkey):
         password=False
     else:
-        password = getpass("SSH Password for %s: " % cast_bytes_py2(sshserver))
+        password = getpass("SSH Password for %s: " % sshserver)
 
     for lp,rp in zip(lports, rports):
         tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)

--- a/jupyter_client/jsonutil.py
+++ b/jupyter_client/jsonutil.py
@@ -11,7 +11,6 @@ import warnings
 from dateutil.parser import parse as _dateutil_parse
 from dateutil.tz import tzlocal
 
-from ipython_genutils import py3compat
 next_attr_name = '__next__' # Not sure what downstream library uses this, but left it to be safe
 
 #-----------------------------------------------------------------------------

--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -8,7 +8,6 @@ import sys
 from subprocess import Popen, PIPE
 
 from ipython_genutils.encoding import getdefaultencoding
-from ipython_genutils.py3compat import cast_bytes_py2
 from traitlets.log import get_logger
 
 
@@ -81,10 +80,7 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None, env=None,
 
     # Spawn a kernel.
     if sys.platform == 'win32':
-        # Popen on Python 2 on Windows cannot handle unicode args or cwd
-        cmd = [ cast_bytes_py2(c, encoding) for c in cmd ]
         if cwd:
-            cwd = cast_bytes_py2(cwd, sys.getfilesystemencoding() or 'ascii')
             kwargs['cwd'] = cwd
 
         from .win_interrupt import create_interrupt_event

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -14,7 +14,6 @@ from ipython_genutils.importstring import import_item
 from traitlets import (
     Any, Bool, Dict, DottedObjectName, Instance, Unicode, default, observe
 )
-from ipython_genutils.py3compat import unicode_type
 
 from .kernelspec import NATIVE_KERNEL_NAME, KernelSpecManager
 from .manager import KernelManager, AsyncKernelManager
@@ -442,7 +441,7 @@ class MultiKernelManager(LoggingConfigurable):
         :param kwargs:
         :return: string-ized version 4 uuid
         """
-        return unicode_type(uuid.uuid4())
+        return str(uuid.uuid4())
 
 
 class AsyncMultiKernelManager(MultiKernelManager):

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -45,8 +45,7 @@ from zmq.eventloop.zmqstream import ZMQStream
 from traitlets.config.configurable import Configurable, LoggingConfigurable
 from ipython_genutils.importstring import import_item
 from jupyter_client.jsonutil import extract_dates, squash_dates, date_default
-from ipython_genutils.py3compat import (str_to_bytes, str_to_unicode, unicode_type,
-                                     iteritems)
+from ipython_genutils.py3compat import str_to_bytes, str_to_unicode
 from traitlets import (
     CBytes, Unicode, Bool, Any, Instance, Set, DottedObjectName, CUnicode,
     Dict, Integer, TraitError, observe
@@ -65,12 +64,12 @@ def squash_unicode(obj):
     if isinstance(obj,dict):
         for key in obj.keys():
             obj[key] = squash_unicode(obj[key])
-            if isinstance(key, unicode_type):
+            if isinstance(key, str):
                 obj[squash_unicode(key)] = obj.pop(key)
     elif isinstance(obj, list):
         for i,v in enumerate(obj):
             obj[i] = squash_unicode(v)
-    elif isinstance(obj, unicode_type):
+    elif isinstance(obj, str):
         obj = obj.encode('utf8')
     return obj
 
@@ -199,14 +198,14 @@ class Message(object):
 
     def __init__(self, msg_dict):
         dct = self.__dict__
-        for k, v in iteritems(dict(msg_dict)):
+        for k, v in dict(msg_dict).items():
             if isinstance(v, dict):
                 v = Message(v)
             dct[k] = v
 
     # Having this iterator lets dict(msg_obj) work out of the box.
     def __iter__(self):
-        return iter(iteritems(self.__dict__))
+        return self.__dict__.items()
 
     def __repr__(self):
         return repr(self.__dict__)
@@ -636,7 +635,7 @@ class Session(Configurable):
         elif isinstance(content, bytes):
             # content is already packed, as in a relayed message
             pass
-        elif isinstance(content, unicode_type):
+        elif isinstance(content, str):
             # should be bytes, but JSON often spits out unicode
             content = content.encode('utf8')
         else:

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -9,7 +9,6 @@ from subprocess import PIPE
 from unittest import TestCase
 from tornado.testing import AsyncTestCase, gen_test
 from traitlets.config.loader import Config
-from ipython_genutils.py3compat import unicode_type
 from jupyter_client import KernelManager, AsyncKernelManager
 from jupyter_client.multikernelmanager import MultiKernelManager, AsyncMultiKernelManager
 from .utils import skip_win32
@@ -75,7 +74,7 @@ class TestKernelManager(TestCase):
 
     def test_tcp_lifecycle_with_kernel_id(self):
         km = self._get_tcp_km()
-        self._run_lifecycle(km, test_kid=unicode_type(uuid.uuid4()))
+        self._run_lifecycle(km, test_kid=str(uuid.uuid4()))
 
     def test_shutdown_all(self):
         km = self._get_tcp_km()
@@ -203,7 +202,7 @@ class TestAsyncKernelManager(AsyncTestCase):
 
     @gen_test
     async def test_tcp_lifecycle_with_kernel_id(self):
-        await self.raw_tcp_lifecycle(test_kid=unicode_type(uuid.uuid4()))
+        await self.raw_tcp_lifecycle(test_kid=str(uuid.uuid4()))
 
     @gen_test
     async def test_shutdown_all(self):

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -23,8 +23,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 from jupyter_client import session as ss
 from jupyter_client import jsonutil
 
-from ipython_genutils.py3compat import string_types
-
 def _bad_packer(obj):
     raise TypeError("I don't work")
 
@@ -58,8 +56,8 @@ class TestSession(SessionTestCase):
         self.assertTrue(isinstance(msg['metadata'],dict))
         self.assertTrue(isinstance(msg['header'],dict))
         self.assertTrue(isinstance(msg['parent_header'],dict))
-        self.assertTrue(isinstance(msg['msg_id'], string_types))
-        self.assertTrue(isinstance(msg['msg_type'], string_types))
+        self.assertTrue(isinstance(msg['msg_id'], str))
+        self.assertTrue(isinstance(msg['msg_type'], str))
         self.assertEqual(msg['header']['msg_type'], 'execute')
         self.assertEqual(msg['msg_type'], 'execute')
 
@@ -294,8 +292,8 @@ class TestSession(SessionTestCase):
         self.assertEqual(msg['parent_header'], msg2['parent_header'])
         assert isinstance(msg['content']['t'], datetime)
         assert isinstance(msg['metadata']['t'], datetime)
-        assert isinstance(msg2['content']['t'], string_types)
-        assert isinstance(msg2['metadata']['t'], string_types)
+        assert isinstance(msg2['content']['t'], str)
+        assert isinstance(msg2['metadata']['t'], str)
         self.assertEqual(msg['content'], jsonutil.extract_dates(msg2['content']))
         self.assertEqual(msg['content'], jsonutil.extract_dates(msg2['content']))
 


### PR DESCRIPTION
- replace use of compat iteritems(dict) with dict.items()
- remove use of no-op cast_bytes_py2 on python 3
- remove use of unicode_type and string_types

FTR, here's the compat module from `ipython_genutils`