### PR TITLE
Silence kill_kernel when no process is present

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -464,7 +464,6 @@ class KernelManager(ConnectionFileMixin):
         This is a private method, callers should use shutdown_kernel(now=True).
         """
         if self.has_kernel:
-
             # Signal the kernel to terminate (sends SIGKILL on Unix and calls
             # TerminateProcess() on Win32).
             try:
@@ -488,8 +487,6 @@ class KernelManager(ConnectionFileMixin):
             # Block until the kernel terminates.
             self.kernel.wait()
             self.kernel = None
-        else:
-            raise RuntimeError("Cannot kill kernel. No kernel is running!")
 
     def interrupt_kernel(self):
         """Interrupts the kernel by sending it a signal.
@@ -714,8 +711,6 @@ class AsyncKernelManager(KernelManager):
                 if self.kernel is not None:
                     self.kernel.wait()
             self.kernel = None
-        else:
-            raise RuntimeError("Cannot kill kernel. No kernel is running!")
 
     async def interrupt_kernel(self):
         """Interrupts the kernel by sending it a signal.


### PR DESCRIPTION
During a kernel's shutdown, a race condition can occur between the kernel manager and the kernel restarter such that the restarter sees the kernel process has terminated, yet it's view of the kernel manager still thinks its managing an instance.  In such cases, the restarter initiates its restart sequence and, when attempting to kill the kernel, finds that there's now no kernel process being managed.  In such conditions, the kernel manager was raising an exception indicating there's no process to kill.  Instead, it should perform the same action as when there _is_ a process to kill, only to have the signaling fail because there is no longer any process - [which is to ignore that condition](https://github.com/jupyter/jupyter_client/blob/master/jupyter_client/manager.py#L476-L486).  This change essentially ignores the case when a _final_ kill request (i.e., `SIGKILL` vs. `SIGTERM`) finds that a process is no longer being managed (i.e., `self.has_kernel is None`).

Fixes #575