### PR TITLE
Remove extra_env and corresponding test

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -268,10 +268,8 @@ class KernelManager(ConnectionFileMixin):
             # If kernel_cmd has been set manually, don't refer to a kernel spec.
             # Environment variables from kernel spec are added to os.environ.
             env.update(self._get_env_substitutions(self.kernel_spec.env, env))
-        elif self.extra_env:
-            env.update(self._get_env_substitutions(self.extra_env, env))
-        kw['env'] = env
 
+        kw['env'] = env
         return kernel_cmd, kw
 
     def _get_env_substitutions(self, templated_env, substitution_values):

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -76,27 +76,6 @@ def start_kernel():
 
 
 @pytest.fixture
-def start_kernel_w_env():
-    kernel_cmd = [sys.executable,
-                  '-m', 'jupyter_client.tests.signalkernel',
-                  '-f', '{connection_file}']
-    extra_env = {'TEST_VARS': '${TEST_VARS}:test_var_2'}
-
-    km = KernelManager(kernel_name='signaltest')
-    km.kernel_cmd = kernel_cmd
-    km.extra_env = extra_env
-    km.start_kernel()
-    kc = km.client()
-    kc.start_channels()
-
-    kc.wait_for_ready(timeout=60)
-
-    yield km, kc
-    kc.stop_channels()
-    km.shutdown_kernel()
-
-
-@pytest.fixture
 def km(config):
     km = KernelManager(config=config)
     return km
@@ -205,13 +184,6 @@ class TestKernelManager:
 
     def test_templated_kspec_env(self, install_kernel, start_kernel):
         km, kc = start_kernel
-        assert km.is_alive()
-        assert kc.is_alive()
-        assert km.context.closed is False
-        self._env_test_body(kc)
-
-    def test_templated_extra_env(self, install_kernel, start_kernel_w_env):
-        km, kc = start_kernel_w_env
         assert km.is_alive()
         assert kc.is_alive()
         assert km.context.closed is False


### PR DESCRIPTION
As mentioned [here](https://github.com/jupyter/jupyter_client/issues/580#issuecomment-691509741), the use of `extra_env` is essentially _rogue code_ that came into existence as part of future work that later was removed from master (or something like that).  These changes remove its use since its existence interferes with the use of the long-deprecated `kernel_cmd` trait.

Fixes #580