### PR TITLE
Update link to documentation contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The last command runs the test suite to verify the setup. During development, yo
 
 ## Documentation
 
-The documentation of Jupyter Client is generated from the files in `docs/` using Sphinx. Instructions for setting up Sphinx with a selection of optional modules are in the [Documentation Guide](http://jupyter.readthedocs.io/en/latest/contrib_docs/index.html). You'll also need the `make` command.
+The documentation of Jupyter Client is generated from the files in `docs/` using Sphinx. Instructions for setting up Sphinx with a selection of optional modules are in the [Documentation Guide](https://jupyter.readthedocs.io/en/latest/contributing/docs-contributions/index.html). You'll also need the `make` command.
 For a minimal Sphinx installation to process the Jupyter Client docs, execute:
 
     pip install ipykernel sphinx sphinx_rtd_theme


### PR DESCRIPTION
I noticed the link to the contributor guides for docs wasn't resolving so I updated it to the right URL.