### PR TITLE
Allow use ~/ in the kernel's command or it's arguments

### DIFF
--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -128,6 +128,9 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None, env=None,
             env['JPY_PARENT_PID'] = str(os.getpid())
 
     try:
+        # Allow to use ~/ in the command or its arguments
+        cmd = list(map(os.path.expanduser, cmd))
+
         proc = Popen(cmd, **kwargs)
     except Exception as exc:
         msg = (


### PR DESCRIPTION
After this patch you'll be able to do this
in a kernel spec:

    {
        "argv": ["~/the-project/jupyter/kernel/run", "-f", "{connection_file}"],
        "display_name": "The Project (dev)",
        "language": "python"
    }

This can be useful when you are installing kernel with `--user` option
into `/home/my-name/.local/share/jupyter/kernels/` and having your jupyter
notebooks in different subdirectories of `~/the-project/` folder.

In this case kernel for each notebook is started in the notebook's
subdirectory and without `~/` in the spec Jupyter is unable to find a
file for running a custom kernel.