### PR TITLE
perf: speedup date parsing using ciso8601

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
         pip install --upgrade --upgrade-strategy eager --pre -e .[test] pytest-cov codecov 'coverage<5'
         pip freeze
     - name: Run the tests
-      run: py.test --cov jupyter_client jupyter_client
+      run:  |
+        py.test --cov jupyter_client jupyter_client
+        pip install ciso8601
+        py.test --cov jupyter_client jupyter_client
     - name: Code coverage
       run: codecov

--- a/jupyter_client/jsonutil.py
+++ b/jupyter_client/jsonutil.py
@@ -6,6 +6,10 @@
 from datetime import datetime
 import re
 import warnings
+try:
+    import ciso8601
+except ImportError:
+    ciso8601 = None
 
 from dateutil.parser import parse as _dateutil_parse
 from dateutil.tz import tzlocal
@@ -50,6 +54,11 @@ def parse_date(s):
     """
     if s is None:
         return s
+    if ciso8601 is not None:
+        try:
+            return _ensure_tzinfo(ciso8601.parse_datetime(s))
+        except ValueError:
+            return s
     m = ISO8601_PAT.match(s)
     if m:
         dt = _dateutil_parse(s)

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -344,3 +344,21 @@ class TestSession(SessionTestCase):
         s._add_digest(digest)
         assert digest in s.digest_history
         assert digest not in s2.digest_history
+
+
+@pytest.mark.usefixtures('no_copy_threshold', 'benchmark')
+class TestPerformance(SessionTestCase):
+    @pytest.fixture(autouse=True)
+    def _request_benchmark(self, benchmark):
+        self.benchmark = benchmark
+
+    def test_deserialize_performance(self):
+        def run(data):
+            self.session.digest_history = []
+            self.session.deserialize(self.session.feed_identities(data)[1])
+        content = dict(t=ss.utcnow())
+        metadata = dict(t=ss.utcnow())
+        p = self.session.msg('msg')
+        msg = self.session.msg('msg', content=content, metadata=metadata, parent=p['header'])
+        data = self.session.serialize(msg)
+        self.benchmark(run, data)

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup_args = dict(
     ],
     python_requires  = '>=3.5',
     extras_require   = {
-        'test': ['ipykernel', 'ipython', 'mock', 'pytest', 'pytest-asyncio', 'async_generator', 'pytest-timeout'],
+        'test': ['ipykernel', 'ipython', 'mock', 'pytest', 'pytest-asyncio', 'async_generator', 'pytest-timeout', 'pytest-benchmark'],
         'doc': open('docs/requirements.txt').read().splitlines(),
     },
     cmdclass         = {


### PR DESCRIPTION
This is a cutout of running the profiler on voila, where it handles a single comm msg:
![image](https://user-images.githubusercontent.com/1765949/99387956-1e835280-28d5-11eb-83cb-ec3fa322ee92.png)

As can be seen, the green 'parse_date' is a significant part of the cpu usage.

With this PR, is shrinks this quite a bit:
![image](https://user-images.githubusercontent.com/1765949/99388155-6e621980-28d5-11eb-8fa4-fbe67af45d16.png)

This uses ciso8601 to do the datetime parsing, which is [significantly faster](https://github.com/closeio/ciso8601#benchmark)

Note that is not a requirements, it will only be used when installed. However, 1 test regarding timezones fails (it should fail to convert and it does not, I'm not sure how important that is)

# Running it in a benchmark
## Before:
```
--------------------------------------------------------- benchmark: 1 tests --------------------------------------------------------
Name (time in us)                     Min       Max      Mean   StdDev    Median      IQR  Outliers  OPS (Kops/s)  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------
test_deserialize_performance     226.2670  556.7280  272.2735  58.3634  249.3170  19.2865   291;378        3.6728    2251           1
-------------------------------------------------------------------------------------------------------------------------------------
```

## After:
```
-------------------------------------------------------- benchmark: 1 tests -------------------------------------------------------
Name (time in us)                    Min         Max     Mean   StdDev   Median     IQR  Outliers  OPS (Kops/s)  Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------
test_deserialize_performance     59.9780  4,237.0830  76.7926  60.7056  67.9120  4.8000   190;974       13.0221    5717           1
-----------------------------------------------------------------------------------------------------------------------------------
```