### PR TITLE
retry kernel_info_requests in wait_for_ready

### DIFF
--- a/jupyter_client/asynchronous/client.py
+++ b/jupyter_client/asynchronous/client.py
@@ -126,14 +126,21 @@ class AsyncKernelClient(KernelClient):
 
         # Wait for kernel info reply on shell channel
         while True:
+            self.kernel_info()
             try:
                 msg = await self.shell_channel.get_msg(timeout=1)
             except Empty:
                 pass
             else:
                 if msg['msg_type'] == 'kernel_info_reply':
-                    self._handle_kernel_info_reply(msg)
-                    break
+                    # Checking that IOPub is connected. If it is not connected, start over.
+                    try:
+                        await self.iopub_channel.get_msg(timeout=0.2)
+                    except Empty:
+                        pass
+                    else:
+                        self._handle_kernel_info_reply(msg)
+                        break
 
             if not await self.is_alive():
                 raise RuntimeError('Kernel died before replying to kernel_info')

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -102,11 +102,10 @@ class KernelClient(ConnectionFileMixin):
         :meth:`start_kernel`. If the channels have been stopped and you
         call this, :class:`RuntimeError` will be raised.
         """
-        if shell:
-            self.shell_channel.start()
-            self.kernel_info()
         if iopub:
             self.iopub_channel.start()
+        if shell:
+            self.shell_channel.start()
         if stdin:
             self.stdin_channel.start()
             self.allow_stdin = True

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -54,13 +54,6 @@ class SignalTestKernel(Kernel):
             reply['traceback'] = ['no such command: %s' % code]
         return reply
 
-    def kernel_info_request(self, *args, **kwargs):
-        """Add delay to kernel_info_request
-
-        triggers slow-response code in KernelClient.wait_for_ready
-        """
-        return super().kernel_info_request(*args, **kwargs)
-
 
 class SignalTestApp(IPKernelApp):
     kernel_class = SignalTestKernel


### PR DESCRIPTION
This changes the logic of `wait_for_ready` to continue sending info request until there is some IOPub message as a response.