### PR TITLE
Fix test_session with msgpack-1

### DIFF
--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -304,7 +304,7 @@ class TestSession(SessionTestCase):
 
         session = ss.Session(
             pack=msgpack.packb,
-            unpack=lambda buf: msgpack.unpackb(buf, encoding='utf8'),
+            unpack=lambda buf: msgpack.unpackb(buf, raw=False),
         )
         self._datetime_test(session)
 


### PR DESCRIPTION
Replace the encoding parameter with raw=False to fix test_session
with msgpack-1.0.0+.  The encoding parameter was already deprecated
in msgpack-0.6.2, and raw=False is compatible with that version too.