### PR TITLE
Handle inaccessible kernel directories more gracefully

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -201,13 +201,12 @@ class KernelSpecManager(LoggingConfigurable):
 
     def _find_spec_directory(self, kernel_name):
         """Find the resource directory of a named kernel spec"""
-        for kernel_dir in self.kernel_dirs:
-            if os.path.isdir(kernel_dir):
-                files = os.listdir(kernel_dir)
-                for f in files:
-                    path = pjoin(kernel_dir, f)
-                    if f.lower() == kernel_name and _is_kernel_dir(path):
-                        return path
+        for kernel_dir in [kd for kd in self.kernel_dirs if os.path.isdir(kd)]:
+            files = os.listdir(kernel_dir)
+            for f in files:
+                path = pjoin(kernel_dir, f)
+                if f.lower() == kernel_name and _is_kernel_dir(path):
+                    return path
 
         if kernel_name == NATIVE_KERNEL_NAME:
             try:

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -202,16 +202,12 @@ class KernelSpecManager(LoggingConfigurable):
     def _find_spec_directory(self, kernel_name):
         """Find the resource directory of a named kernel spec"""
         for kernel_dir in self.kernel_dirs:
-            try:
+            if os.path.isdir(kernel_dir):
                 files = os.listdir(kernel_dir)
-            except OSError as e:
-                if e.errno in (errno.ENOTDIR, errno.ENOENT):
-                    continue
-                raise
-            for f in files:
-                path = pjoin(kernel_dir, f)
-                if f.lower() == kernel_name and _is_kernel_dir(path):
-                    return path
+                for f in files:
+                    path = pjoin(kernel_dir, f)
+                    if f.lower() == kernel_name and _is_kernel_dir(path):
+                        return path
 
         if kernel_name == NATIVE_KERNEL_NAME:
             try:


### PR DESCRIPTION
In looking into (and reproducing) the issue described in #591, I noticed that `jupyter kernelspec list` didn't produce any `EACCES` issues despite the fact that its list of kernel directories contained a directory in which access was denied.  I found this was because it uses `os.path.isdir()` to _validate_ the directory.  `isdir()` not only handles `EACCES`, but also `ENOTDIR` and `ENOENT` as well.  Since these latter two exceptions were being ignored in `_find_spec_directory()` and given we needed to better handle `EACCES`, it seemed cleaner to also use `os.path.isdir()` here and forgo the additional exception handling altogether.

Fixes #591