### PR TITLE
Revert "Pin jedi<=0.17.2"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup_args = dict(
     ],
     python_requires  = '>=3.5',
     extras_require   = {
-        'test': ['jedi<=0.17.2', 'ipykernel', 'ipython', 'mock', 'pytest', 'pytest-asyncio', 'async_generator', 'pytest-timeout'],
+        'test': ['ipykernel', 'ipython', 'mock', 'pytest', 'pytest-asyncio', 'async_generator', 'pytest-timeout'],
         'doc': open('docs/requirements.txt').read().splitlines(),
     },
     cmdclass         = {


### PR DESCRIPTION
Reverts jupyter/jupyter_client#596 , a short-term hotfix while waiting for a fixed IPython release (7.20, due out shortly).

closes #597 
closes #600
