### PR TITLE
Some removal of IPython genutils.

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -23,9 +23,7 @@ import zmq
 from traitlets.config import LoggingConfigurable
 from .localinterfaces import localhost
 from ipython_genutils.path import filefind
-from ipython_genutils.py3compat import (
-    bytes_to_str, cast_bytes,
-)
+from ipython_genutils.py3compat import cast_bytes
 from traitlets import (
     Bool, Integer, Unicode, CaselessStrEnum, Instance, Type, observe
 )
@@ -127,7 +125,7 @@ def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, 
                 hb_port=hb_port,
               )
     cfg['ip'] = ip
-    cfg['key'] = bytes_to_str(key)
+    cfg['key'] = key.decode()
     cfg['transport'] = transport
     cfg['signature_scheme'] = signature_scheme
     cfg['kernel_name'] = kernel_name

--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -7,7 +7,6 @@ import os
 import sys
 from subprocess import Popen, PIPE
 
-from ipython_genutils.encoding import getdefaultencoding
 from traitlets.log import get_logger
 
 
@@ -67,7 +66,6 @@ def launch_kernel(cmd, stdin=None, stdout=None, stderr=None, env=None,
 
     env = env if (env is not None) else os.environ.copy()
 
-    encoding = getdefaultencoding(prefer_stream=False)
     kwargs = kw.copy()
     main_args = dict(
         stdin=_stdin,

--- a/jupyter_client/localinterfaces.py
+++ b/jupyter_client/localinterfaces.py
@@ -23,8 +23,6 @@ def _uniq_stable(elems):
 
     Return from an iterable, a list of all the unique elements in the input,
     maintaining the order in which they first appear.
-    
-    From ipython_genutils.data
     """
     seen = set()
     return [x for x in elems if x not in seen and not seen.add(x)]

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -39,7 +39,6 @@ from zmq.eventloop.zmqstream import ZMQStream
 from traitlets.config.configurable import Configurable, LoggingConfigurable
 from ipython_genutils.importstring import import_item
 from jupyter_client.jsonutil import extract_dates, squash_dates, date_default
-from ipython_genutils.py3compat import str_to_bytes, str_to_unicode
 from traitlets import (
     CBytes, Unicode, Bool, Any, Instance, Set, DottedObjectName, CUnicode,
     Dict, Integer, TraitError, observe
@@ -339,7 +338,8 @@ class Session(Configurable):
     # bsession is the session as bytes
     bsession = CBytes(b'')
 
-    username = Unicode(str_to_unicode(os.environ.get('USER', 'username')),
+    username = Unicode(
+        os.environ.get("USER", "username"),
         help="""Username for the Session. Default is your system username.""",
         config=True)
 
@@ -596,7 +596,7 @@ class Session(Configurable):
         h = self.auth.copy()
         for m in msg_list:
             h.update(m)
-        return str_to_bytes(h.hexdigest())
+        return h.hexdigest().encode()
 
     def serialize(self, msg, ident=None):
         """Serialize the message components to bytes.

--- a/jupyter_client/tests/test_connect.py
+++ b/jupyter_client/tests/test_connect.py
@@ -13,8 +13,8 @@ import shutil
 from traitlets.config import Config
 from jupyter_core.application import JupyterApp
 from jupyter_core.paths import jupyter_runtime_dir
-from ipython_genutils.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
-from ipython_genutils.py3compat import str_to_bytes
+from tempfile import TemporaryDirectory
+from ipython_genutils.tempdir import TemporaryWorkingDirectory
 from jupyter_client import connect, KernelClient
 from jupyter_client.consoleapp import JupyterConsoleApp
 from jupyter_client.session import Session
@@ -48,7 +48,7 @@ def test_write_connection_file():
         assert os.path.exists(cf)
         with open(cf, 'r') as f:
             info = json.load(f)
-    info['key'] = str_to_bytes(info['key'])
+    info["key"] = info["key"].encode()
     assert info == sample_info
 
 

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import join as pjoin
 from subprocess import Popen, PIPE, STDOUT
 from logging import StreamHandler
-from ipython_genutils.tempdir import TemporaryDirectory
+from tempfile import TemporaryDirectory
 from jupyter_client import kernelspec
 from jupyter_core import paths
 from .utils import test_env

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -5,10 +5,10 @@ import os
 pjoin = os.path.join
 import sys
 from unittest.mock import patch
+from tempfile import TemporaryDirectory
 
 import pytest
 from jupyter_client import AsyncKernelManager
-from ipython_genutils.tempdir import TemporaryDirectory
 
 
 skip_win32 = pytest.mark.skipif(sys.platform.startswith('win'), reason="Windows")


### PR DESCRIPTION
There was some request on ipython_genutils to drop nose-1 (for
packaging on openSUSE). In many cases I believe ipython_genutils can be
dropped as it was mostly helping with py2/3 compatibility.

This remove the trivial replacement with their equivalent when possible,
including one case where the assigned variable was unused, and ence was
removed.