### PR TITLE
Address race condition between shutdown_kernel and restarter

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -127,6 +127,8 @@ class KernelManager(ConnectionFileMixin):
         help="""Should we autorestart the kernel if it dies."""
     )
 
+    shutting_down = False
+
     def __del__(self):
         self._close_control_socket()
         self.cleanup_connection_file()
@@ -246,6 +248,7 @@ class KernelManager(ConnectionFileMixin):
              keyword arguments that are passed down to build the kernel_cmd
              and launching the kernel (e.g. Popen kwargs).
         """
+        self.shutting_down = False
         if self.transport == 'tcp' and not is_local_ip(self.ip):
             raise RuntimeError("Can only launch a kernel on a local interface. "
                                "This one is not: %s."
@@ -381,6 +384,7 @@ class KernelManager(ConnectionFileMixin):
             Will this kernel be restarted after it is shutdown. When this
             is True, connection files will not be cleaned up.
         """
+        self.shutting_down = True  # Used by restarter to prevent race condition
         # Stop monitoring for restarting while we shutdown.
         self.stop_restarter()
 
@@ -612,6 +616,7 @@ class AsyncKernelManager(KernelManager):
             Will this kernel be restarted after it is shutdown. When this
             is True, connection files will not be cleaned up.
         """
+        self.shutting_down = True  # Used by restarter to prevent race condition
         # Stop monitoring for restarting while we shutdown.
         self.stop_restarter()
 

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -90,6 +90,9 @@ class KernelRestarter(LoggingConfigurable):
     def poll(self):
         if self.debug:
             self.log.debug('Polling kernel...')
+        if self.kernel_manager.shutting_down:
+            self.log.debug('Kernel shutdown in progress...')
+            return
         if not self.kernel_manager.is_alive():
             if self._restarting:
                 self._restart_count += 1


### PR DESCRIPTION
There is a window in which the auto-restarter logic (that detects unexpectedly terminated kernels) can restart a shutdown kernel - whose termination was intended.

Although rare, this has been seen when a Notebook server is terminated with running kernels, at which time it issues shutdown requests for each kernel - while, at the same time, but after the kernel process has terminated, the restarter detects the kernel process's absence and restarts the kernel.

By indicating that the kernel manager has started a (graceful) shutdown of the kernel, the restarter can better-determine the difference between an intended and unintended shutdown - skipping the kernel restart in case of the former.

Resolves #606