### PR TITLE
Clean up AsyncMKM's shutdown_all

### DIFF
--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -3,6 +3,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import asyncio
 import os
 import uuid
 import socket
@@ -453,6 +454,12 @@ class AsyncMultiKernelManager(MultiKernelManager):
         """
     )
 
+    _starting_kernels = Dict()
+
+    async def _add_kernel_when_ready(self, kernel_id, km, kernel_awaitable):
+        await kernel_awaitable
+        self._kernels[kernel_id] = km
+
     async def start_kernel(self, kernel_name=None, **kwargs):
         """Start a new kernel.
 
@@ -465,8 +472,16 @@ class AsyncMultiKernelManager(MultiKernelManager):
         if not isinstance(km, AsyncKernelManager):
             self.log.warning("Kernel manager class ({km_class}) is not an instance of 'AsyncKernelManager'!".
                              format(km_class=self.kernel_manager_class.__class__))
-        await km.start_kernel(**kwargs)
-        self._kernels[kernel_id] = km
+        fut = asyncio.ensure_future(
+            self._add_kernel_when_ready(
+                kernel_id,
+                km,
+                km.start_kernel(**kwargs)
+            )
+        )
+        self._starting_kernels[kernel_id] = fut
+        await fut
+        del self._starting_kernels[kernel_id]
         return kernel_id
 
     async def shutdown_kernel(self, kernel_id, now=False, restart=False):
@@ -543,12 +558,17 @@ class AsyncMultiKernelManager(MultiKernelManager):
         await km.restart_kernel(now)
         self.log.info("Kernel restarted: %s" % kernel_id)
 
+    async def _shutdown_starting_kernel(self, kid, now):
+        if kid in self._starting_kernels:
+            await self._starting_kernels[kid]
+        await self.shutdown_kernel(kid, now=now)
+
     async def shutdown_all(self, now=False):
         """Shutdown all kernels."""
         kids = self.list_kernel_ids()
-        for kid in kids:
-            self.request_shutdown(kid)
-        for kid in kids:
-            await self.finish_shutdown(kid)
-            self.cleanup_resources(kid)
-            self.remove_kernel(kid)
+        futs = [self.shutdown_kernel(kid, now=now) for kid in kids]
+        futs += [
+            self._shutdown_starting_kernel(kid, now=now)
+            for kid in self._starting_kernels.keys()
+        ]
+        await asyncio.gather(*futs)

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -879,7 +879,7 @@ class Session(Configurable):
         if n_to_cull >= current:
             self.digest_history = set()
             return
-        to_cull = random.sample(self.digest_history, n_to_cull)
+        to_cull = random.sample(tuple(sorted(self.digest_history)), n_to_cull)
         self.digest_history.difference_update(to_cull)
 
     def deserialize(self, msg_list, content=True, copy=True):

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -249,7 +249,7 @@ class TestAsyncKernelManager(AsyncTestCase):
     @gen_test(timeout=20)
     async def test_shutdown_all_while_starting(self):
         km = self._get_tcp_km()
-        kid_future = km.start_kernel(stdout=PIPE, stderr=PIPE)
+        kid_future = asyncio.ensure_future(km.start_kernel(stdout=PIPE, stderr=PIPE))
         # This is relying on the ordering of the asyncio queue, not sure if guaranteed or not:
         kid, _ = await asyncio.gather(kid_future, km.shutdown_all())
         self.assertNotIn(kid, km)

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -185,7 +185,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         assert kid in km.list_kernel_ids()
         assert len(km) == 1, f'{len(km)} != {1}'
         await km.restart_kernel(kid, now=True)
-        assert km.is_alive(kid)
+        assert await km.is_alive(kid)
         assert kid in km.list_kernel_ids()
         await km.interrupt_kernel(kid)
         k = km.get_kernel(kid)
@@ -230,7 +230,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         # shutdown again is okay, because we have no kernels
         await km.shutdown_all()
 
-    @gen_test
+    @gen_test(timeout=20)
     async def test_use_after_shutdown_all(self):
         km = self._get_tcp_km()
         kid = await km.start_kernel(stdout=PIPE, stderr=PIPE)

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -308,6 +308,12 @@ class TestAsyncKernelManager(AsyncTestCase):
         km = cls._get_tcp_km()
         await cls._run_lifecycle(km, test_kid=test_kid)
 
+    # static so picklable for multiprocessing on Windows
+    @classmethod
+    def raw_tcp_lifecycle_sync(cls, test_kid=None):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(cls.raw_tcp_lifecycle(test_kid=test_kid))
+
     @gen_test
     async def test_start_parallel_thread_kernels(self):
         await self.raw_tcp_lifecycle()
@@ -327,7 +333,7 @@ class TestAsyncKernelManager(AsyncTestCase):
 
         thread = threading.Thread(target=self.tcp_lifecycle_with_loop)
         # Windows tests needs this target to be picklable:
-        proc = mp.Process(target=self.raw_tcp_lifecycle)
+        proc = mp.Process(target=self.raw_tcp_lifecycle_sync)
 
         try:
             thread.start()

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -312,6 +312,10 @@ class TestAsyncKernelManager(AsyncTestCase):
     @classmethod
     def raw_tcp_lifecycle_sync(cls, test_kid=None):
         loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # Forked MP, make new loop
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         loop.run_until_complete(cls.raw_tcp_lifecycle(test_kid=test_kid))
 
     @gen_test


### PR DESCRIPTION
This enables the manager to be reused after shutdown_all by:
- Making sure all the cleanup that happens in shutdown_kernel gets called.
- Making sure to await any starting kernels, and also shut them down

Partially addresses #616.