### PR TITLE
Enable the macos tests for py3.8 and 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest,  windows-latest]
         python-version: [ 3.6, 3.7, 3.8, 3.9 ]
-        exclude:
-          - os: macos-latest
-            python-version: 3.8
-          - os: macos-latest
-            python-version: 3.9
     env:
         OS: ${{ matrix.os }}
         PYTHON: '3.9'


### PR DESCRIPTION
While troubleshooting CI issues on #617, I found that the excluded `macos-latest` builds were successful on python 3.8 and 3.9.  This update adds those platform/version combos back into the mix.