### PR TITLE
Interrupt and sigterm before sigkill kernel.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,13 @@
 Changes in Jupyter Client
 =========================
 
+dev
+===
+
+- Shutdown request sequence has been modified to be more graceful, it now is
+  preceded by interrupt, and will also send a ``SIGTERM`` before forcibly
+  killing the kernel. :ghpull:`620`
+
 6.1.11
 ======
 - Move jedi pinning to test requirements (:ghpull:`599`)

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -32,6 +32,13 @@ from .managerabc import (
 )
 
 class _ShutdownStatus(Enum):
+    """
+
+    This is so far used only for testing in order to track the internal state of
+    the shutdown logic, and verifying which path is taken for which
+    missbehavior.
+
+    """
     Unset = None
     ShutdownRequest = "ShutdownRequest"
     SigtermRequest = "SigtermRequest"

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -35,7 +35,7 @@ class _ShutdownStatus(Enum):
     Unset = None
     ShutdownRequest = "ShutdownRequest"
     SigtermRequest = "SigtermRequest"
-    SigKillRequest = "SigKillRequest"
+    SigkillRequest = "SigkillRequest"
 
 
 class KernelManager(ConnectionFileMixin):
@@ -378,7 +378,7 @@ class KernelManager(ConnectionFileMixin):
                 # OK, we've waited long enough.
                 if self.has_kernel:
                     self.log.debug("Kernel is taking too long to finish, killing")
-                    self._shutdown_status = _ShutdownStatus.SigKillRequest
+                    self._shutdown_status = _ShutdownStatus.SigkillRequest
                     self._kill_kernel()
 
     def cleanup_resources(self, restart=False):
@@ -663,7 +663,7 @@ class AsyncKernelManager(KernelManager):
 
         except asyncio.TimeoutError:
             self.log.debug("Kernel is taking too long to finish, killing")
-            self._shutdown_status = _ShutdownStatus.SigKillRequest
+            self._shutdown_status = _ShutdownStatus.SigkillRequest
             await self._kill_kernel()
         else:
             # Process is no longer alive, wait and clear

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -45,6 +45,7 @@ class KernelManager(ConnectionFileMixin):
     """
 
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._shutdown_status = _ShutdownStatus.Unset
 
     _created_context = Bool(False)

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -13,7 +13,6 @@ from ipykernel.displayhook import ZMQDisplayHook
 from ipykernel.kernelbase import Kernel
 from ipykernel.kernelapp import IPKernelApp
 
-
 class SignalTestKernel(Kernel):
     """Kernel for testing subprocess signaling"""
     implementation = 'signaltest'
@@ -24,6 +23,13 @@ class SignalTestKernel(Kernel):
         kwargs.pop('user_ns', None)
         super().__init__(**kwargs)
         self.children = []
+
+    # @gen.coroutine
+    # def shutdown_request(self, stream, ident, parent):
+    #    if os.environ.get("NO_SHUTDOWN_REPLY"):
+    #        pass
+    #    else:
+    #        return super().shutdown_request(stream, ident, parent)
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None,
                    allow_stdin=False):

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -143,7 +143,7 @@ class TestKernelManagerShutDownGracefully:
             (
                 "signaltest-no-terminate",
                 install_kernel_dont_terminate,
-                _ShutdownStatus.SigKillRequest,
+                _ShutdownStatus.SigkillRequest,
             ),
         ],
     )

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -131,10 +131,7 @@ async def start_async_kernel():
 
 
 class TestKernelManagerShutDownGracefully:
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="Windows doesn't support signals"
-    )
-    @pytest.mark.parametrize(
+    parameters = (
         "name, install, expected",
         [
             ("signaltest", _install_kernel, _ShutdownStatus.ShutdownRequest),
@@ -150,6 +147,11 @@ class TestKernelManagerShutDownGracefully:
             ),
         ],
     )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Windows doesn't support signals"
+    )
+    @pytest.mark.parametrize(*parameters)
     def test_signal_kernel_subprocesses(self, name, install, expected):
         install()
         km, kc = start_new_kernel(kernel_name=name)
@@ -161,22 +163,10 @@ class TestKernelManagerShutDownGracefully:
 
         assert km._shutdown_status == expected
 
-    @pytest.mark.parametrize(
-        "name, install, expected",
-        [
-            ("signaltest", _install_kernel, _ShutdownStatus.ShutdownRequest),
-            (
-                "signaltest-no-shutdown",
-                install_kernel_dont_shutdown,
-                _ShutdownStatus.SigtermRequest,
-            ),
-            (
-                "signaltest-no-terminate",
-                install_kernel_dont_terminate,
-                _ShutdownStatus.SigKillRequest,
-            ),
-        ],
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Windows doesn't support signals"
     )
+    @pytest.mark.parametrize(*parameters)
     async def test_async_signal_kernel_subprocesses(self, name, install, expected):
         install()
         km, kc = await start_new_async_kernel(kernel_name=name)


### PR DESCRIPTION
This implements the discussion in #618, to try to more progressively stop
the kernels.

1) this always sends and interrupt before any shutdown requests;
  goal being to stop any processing happening that may block any event
  loop.

2) sends the shutdown_requests (no changes here).

3) wait 50% of the wait time, and sends a "terminate" in quote as this
depends on your platform/os, and the type of kernel you have.
    - if subprocess.Popen calls `.terminate()` which is SIGTERM on unix; the same as
    `.kill()` on windows; if not a Popen instance send SIGTERM.

4) wait the other 50% and kills, (same as before).

This does this both on the sync client and async client.

TBD: write tests and docs; and test more properly;