### PR TITLE
Remove dependency on ipython_genutils.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,18 @@ dev
 
 - Shutdown request sequence has been modified to be more graceful, it now is
   preceded by interrupt, and will also send a ``SIGTERM`` before forcibly
-  killing the kernel. :ghpull:`620`
+  killing the kernel. (:ghpull:`620`)
+
+- Removal of ``ipython_genutils`` as a dependency. It was implicit before; but
+  required by at least traitlets thus avoiding issues. We are working on
+  completely removing it from all jupyter dependencies; as it might lead to
+  issues packaging for Python 3.10, and was mostly used for compatibility with
+  python 2.  (:ghpull:`620`, :ghpull:`605`)
+
+- Address a race condition between ``shutdown_kernel`` and restarter.
+  (:ghpull:`607`.)
+
+See the `full list of pull-requests<https://github.com/jupyter/jupyter_client/milestone/24?closed=1>`_
 
 6.1.11
 ======

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -22,12 +22,12 @@ import zmq
 
 from traitlets.config import LoggingConfigurable
 from .localinterfaces import localhost
-from ipython_genutils.path import filefind
-from ipython_genutils.py3compat import cast_bytes
 from traitlets import (
     Bool, Integer, Unicode, CaselessStrEnum, Instance, Type, observe
 )
 from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
+
+from .utils import filefind
 
 
 def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0,
@@ -515,8 +515,13 @@ class ConnectionFileMixin(LoggingConfigurable):
                 # not overridden by config or cl_args
                 setattr(self, name, info[name])
 
-        if 'key' in info:
-            self.session.key = cast_bytes(info['key'])
+        if "key" in info:
+            key = info["key"]
+            if isinstance(key, str):
+                key = key.encode()
+            assert isinstance(key, bytes)
+
+            self.session.key = key
         if 'signature_scheme' in info:
             self.session.signature_scheme = info['signature_scheme']
 

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -27,7 +27,7 @@ from traitlets import (
 )
 from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
 
-from .utils import filefind
+from .utils import _filefind
 
 
 def write_connection_file(fname=None, shell_port=0, iopub_port=0, stdin_port=0, hb_port=0,
@@ -195,7 +195,7 @@ def find_connection_file(filename='kernel-*.json', path=None, profile=None):
 
     try:
         # first, try explicit name
-        return filefind(filename, path)
+        return _filefind(filename, path)
     except IOError:
         pass
 

--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -16,7 +16,6 @@ import warnings
 
 
 from traitlets.config.application import boolean_flag
-from ipython_genutils.path import filefind
 from traitlets import (
     Dict, List, Unicode, CUnicode, CBool, Any, Type
 )
@@ -32,6 +31,7 @@ from .session import Session
 ConnectionFileMixin = connect.ConnectionFileMixin
 
 from .localinterfaces import localhost
+from .utils import filefind
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags

--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -31,7 +31,7 @@ from .session import Session
 ConnectionFileMixin = connect.ConnectionFileMixin
 
 from .localinterfaces import localhost
-from .utils import filefind
+from .utils import _filefind
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags
@@ -186,7 +186,9 @@ class JupyterConsoleApp(ConnectionFileMixin):
                     cf = self.connection_file
                 self.connection_file = cf
         try:
-            self.connection_file = filefind(self.connection_file, ['.', self.runtime_dir])
+            self.connection_file = _filefind(
+                self.connection_file, [".", self.runtime_dir]
+            )
         except IOError:
             self.log.debug("Connection File not found: %s", self.connection_file)
             return

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -16,12 +16,12 @@ from enum import Enum
 
 import zmq
 
-from .utils import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
     Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName,
     default, observe, observe_compat
 )
+from traitlets.utils.importstring import import_item
 from jupyter_client import (
     launch_kernel,
     kernelspec,

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -16,7 +16,7 @@ from enum import Enum
 
 import zmq
 
-from ipython_genutils.importstring import import_item
+from .utils import import_item
 from .localinterfaces import is_local_ip, local_ips
 from traitlets import (
     Any, Float, Instance, Unicode, List, Bool, Type, DottedObjectName,

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -11,13 +11,13 @@ import socket
 import zmq
 
 from traitlets.config.configurable import LoggingConfigurable
+from traitlets.utils.importstring import import_item
 from traitlets import (
     Any, Bool, Dict, DottedObjectName, Instance, Unicode, default, observe
 )
 
 from .kernelspec import NATIVE_KERNEL_NAME, KernelSpecManager
 from .manager import KernelManager, AsyncKernelManager
-from .utils import import_item
 
 
 class DuplicateKernelError(Exception):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -11,13 +11,13 @@ import socket
 import zmq
 
 from traitlets.config.configurable import LoggingConfigurable
-from ipython_genutils.importstring import import_item
 from traitlets import (
     Any, Bool, Dict, DottedObjectName, Instance, Unicode, default, observe
 )
 
 from .kernelspec import NATIVE_KERNEL_NAME, KernelSpecManager
 from .manager import KernelManager, AsyncKernelManager
+from .utils import import_item
 
 
 class DuplicateKernelError(Exception):

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -21,14 +21,15 @@ import pickle
 import pprint
 import random
 import warnings
+
 from datetime import datetime
+from datetime import timezone
 
 PICKLE_PROTOCOL = pickle.DEFAULT_PROTOCOL
 
 # We are using compare_digest to limit the surface of timing attacks
 from hmac import compare_digest
 
-from datetime import timezone
 utc = timezone.utc
 
 import zmq
@@ -36,17 +37,18 @@ from zmq.utils import jsonapi
 from zmq.eventloop.ioloop import IOLoop
 from zmq.eventloop.zmqstream import ZMQStream
 
-from traitlets.config.configurable import Configurable, LoggingConfigurable
+
 from jupyter_client.jsonutil import extract_dates, squash_dates, date_default
+from jupyter_client import protocol_version
+from jupyter_client.adapter import adapt
+
 from traitlets import (
     CBytes, Unicode, Bool, Any, Instance, Set, DottedObjectName, CUnicode,
     Dict, Integer, TraitError, observe
 )
-from jupyter_client import protocol_version
-from jupyter_client.adapter import adapt
 from traitlets.log import get_logger
-
-from .utils import import_item
+from traitlets.utils.importstring import import_item
+from traitlets.config.configurable import Configurable, LoggingConfigurable
 
 #-----------------------------------------------------------------------------
 # utility functions

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -37,7 +37,6 @@ from zmq.eventloop.ioloop import IOLoop
 from zmq.eventloop.zmqstream import ZMQStream
 
 from traitlets.config.configurable import Configurable, LoggingConfigurable
-from ipython_genutils.importstring import import_item
 from jupyter_client.jsonutil import extract_dates, squash_dates, date_default
 from traitlets import (
     CBytes, Unicode, Bool, Any, Instance, Set, DottedObjectName, CUnicode,
@@ -47,6 +46,7 @@ from jupyter_client import protocol_version
 from jupyter_client.adapter import adapt
 from traitlets.log import get_logger
 
+from .utils import import_item
 
 #-----------------------------------------------------------------------------
 # utility functions

--- a/jupyter_client/tests/test_connect.py
+++ b/jupyter_client/tests/test_connect.py
@@ -14,11 +14,31 @@ from traitlets.config import Config
 from jupyter_core.application import JupyterApp
 from jupyter_core.paths import jupyter_runtime_dir
 from tempfile import TemporaryDirectory
-from ipython_genutils.tempdir import TemporaryWorkingDirectory
 from jupyter_client import connect, KernelClient
 from jupyter_client.consoleapp import JupyterConsoleApp
 from jupyter_client.session import Session
 from jupyter_client.connect import secure_write
+
+
+class TemporaryWorkingDirectory(TemporaryDirectory):
+    """
+    Creates a temporary directory and sets the cwd to that directory.
+    Automatically reverts to previous cwd upon cleanup.
+    Usage example:
+
+        with TemporaryWorkingDirectory() as tmpdir:
+            ...
+    """
+
+    def __enter__(self):
+        self.old_wd = os.getcwd()
+        os.chdir(self.name)
+        return super().__enter__()
+
+    def __exit__(self, exc, value, tb):
+        os.chdir(self.old_wd)
+        return super().__exit__(exc, value, tb)
+
 
 
 class DummyConsoleApp(JupyterApp, JupyterConsoleApp):

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -5,36 +5,6 @@ Utils vendored from ipython_genutils that should be retired at some point.
 import os
 
 
-def import_item(name):
-    """Import and return ``bar`` given the string ``foo.bar``.
-
-    Calling ``bar = import_item("foo.bar")`` is the functional equivalent of
-    executing the code ``from foo import bar``.
-
-    Parameters
-    ----------
-    name : string
-      The fully qualified name of the module/package being imported.
-
-    Returns
-    -------
-    mod : module object
-       The module that was imported.
-    """
-
-    parts = name.rsplit(".", 1)
-    if len(parts) == 2:
-        # called with 'foo.bar....'
-        package, obj = parts
-        module = __import__(package, fromlist=[obj])
-        try:
-            pak = getattr(module, obj)
-        except AttributeError as e:
-            raise ImportError("No module named %s" % obj) from e
-        return pak
-    return __import__(parts[0])
-
-
 def filefind(filename, path_dirs=None):
     """Find a file by looking through a sequence of paths.
 

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -1,0 +1,114 @@
+"""
+Utils vendored from ipython_genutils that should be retired at some point.
+"""
+
+import os
+
+
+def import_item(name):
+    """Import and return ``bar`` given the string ``foo.bar``.
+
+    Calling ``bar = import_item("foo.bar")`` is the functional equivalent of
+    executing the code ``from foo import bar``.
+
+    Parameters
+    ----------
+    name : string
+      The fully qualified name of the module/package being imported.
+
+    Returns
+    -------
+    mod : module object
+       The module that was imported.
+    """
+
+    parts = name.rsplit(".", 1)
+    if len(parts) == 2:
+        # called with 'foo.bar....'
+        package, obj = parts
+        module = __import__(package, fromlist=[obj])
+        try:
+            pak = getattr(module, obj)
+        except AttributeError as e:
+            raise ImportError("No module named %s" % obj) from e
+        return pak
+    return __import__(parts[0])
+
+
+def filefind(filename, path_dirs=None):
+    """Find a file by looking through a sequence of paths.
+
+    This iterates through a sequence of paths looking for a file and returns
+    the full, absolute path of the first occurence of the file.  If no set of
+    path dirs is given, the filename is tested as is, after running through
+    :func:`expandvars` and :func:`expanduser`.  Thus a simple call::
+
+        filefind('myfile.txt')
+
+    will find the file in the current working dir, but::
+
+        filefind('~/myfile.txt')
+
+    Will find the file in the users home directory.  This function does not
+    automatically try any paths, such as the cwd or the user's home directory.
+
+    Parameters
+    ----------
+    filename : str
+        The filename to look for.
+    path_dirs : str, None or sequence of str
+        The sequence of paths to look for the file in.  If None, the filename
+        need to be absolute or be in the cwd.  If a string, the string is
+        put into a sequence and the searched.  If a sequence, walk through
+        each element and join with ``filename``, calling :func:`expandvars`
+        and :func:`expanduser` before testing for existence.
+
+    Returns
+    -------
+    Raises :exc:`IOError` or returns absolute path to file.
+    """
+
+    # If paths are quoted, abspath gets confused, strip them...
+    filename = filename.strip('"').strip("'")
+    # If the input is an absolute path, just check it exists
+    if os.path.isabs(filename) and os.path.isfile(filename):
+        return filename
+
+    if path_dirs is None:
+        path_dirs = ("",)
+    elif isinstance(path_dirs, str):
+        path_dirs = (path_dirs,)
+
+    for path in path_dirs:
+        if path == ".":
+            path = os.getcwd()
+        testname = expand_path(os.path.join(path, filename))
+        if os.path.isfile(testname):
+            return os.path.abspath(testname)
+
+    raise IOError(
+        "File {!r} does not exist in any of the search paths: {!r}".format(filename, path_dirs)
+    )
+
+
+def expand_path(s):
+    """Expand $VARS and ~names in a string, like a shell
+
+    :Examples:
+
+       In [2]: os.environ['FOO']='test'
+
+       In [3]: expand_path('variable FOO is $FOO')
+       Out[3]: 'variable FOO is test'
+    """
+    # This is a pretty subtle hack. When expand user is given a UNC path
+    # on Windows (\\server\share$\%username%), os.path.expandvars, removes
+    # the $ to get (\\server\share\%username%). I think it considered $
+    # alone an empty var. But, we need the $ to remains there (it indicates
+    # a hidden share).
+    if os.name == "nt":
+        s = s.replace("$\\", "IPYTHON_TEMP")
+    s = os.path.expandvars(os.path.expanduser(s))
+    if os.name == "nt":
+        s = s.replace("IPYTHON_TEMP", "$\\")
+    return s

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -5,7 +5,7 @@ Utils vendored from ipython_genutils that should be retired at some point.
 import os
 
 
-def filefind(filename, path_dirs=None):
+def _filefind(filename, path_dirs=None):
     """Find a file by looking through a sequence of paths.
 
     This iterates through a sequence of paths looking for a file and returns
@@ -52,7 +52,7 @@ def filefind(filename, path_dirs=None):
     for path in path_dirs:
         if path == ".":
             path = os.getcwd()
-        testname = expand_path(os.path.join(path, filename))
+        testname = _expand_path(os.path.join(path, filename))
         if os.path.isfile(testname):
             return os.path.abspath(testname)
 
@@ -61,7 +61,7 @@ def filefind(filename, path_dirs=None):
     )
 
 
-def expand_path(s):
+def _expand_path(s):
     """Expand $VARS and ~names in a string, like a shell
 
     :Examples:


### PR DESCRIPTION
IPython Genutils seem to start to be troublesome to package for some Linux
Ditributions because of Python2/3 compat. Get rid of it.

It was not in the dependencies anyway...