### PR TITLE
Temporary revert install --pre

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools pip
-        pip install --upgrade --upgrade-strategy eager --pre -e .[test] pytest-cov codecov 'coverage<5'
+        pip install --upgrade --upgrade-strategy eager -e .[test] pytest-cov codecov 'coverage<5'
         pip freeze
     - name: Run the tests
       run: py.test --cov jupyter_client -v jupyter_client


### PR DESCRIPTION
Recent ipykernel changed the behavior of comms channels and make CI
fail. Remove --pre until this get fixed.