### PR TITLE
Add tests to ensure MultiKernelManager subclass methods are called

### DIFF
--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -173,6 +173,7 @@ class TestKernelManagerShutDownGracefully:
 
         assert km._shutdown_status == expected
 
+    @pytest.mark.asyncio
     @pytest.mark.skipif(
         sys.platform == "win32", reason="Windows doesn't support signals"
     )

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -22,7 +22,7 @@ from subprocess import PIPE
 
 from ..manager import start_new_kernel, start_new_async_kernel
 from ..manager import _ShutdownStatus
-from .utils import test_env, SyncKernelManagerSubclass, AsyncKernelManagerSubclass, AsyncKernelManagerWithCleanup
+from .utils import test_env, SyncKMSubclass, AsyncKMSubclass, AsyncKernelManagerWithCleanup
 
 pjoin = os.path.join
 
@@ -106,7 +106,7 @@ def km(config):
 
 @pytest.fixture
 def km_subclass(config):
-    km = SyncKernelManagerSubclass(config=config)
+    km = SyncKMSubclass(config=config)
     return km
 
 
@@ -118,7 +118,7 @@ def zmq_context():
     ctx.term()
 
 
-@pytest.fixture(params=[AsyncKernelManager, AsyncKernelManagerSubclass, AsyncKernelManagerWithCleanup])
+@pytest.fixture(params=[AsyncKernelManager, AsyncKMSubclass, AsyncKernelManagerWithCleanup])
 def async_km(request, config):
     km = request.param(config=config)
     return km
@@ -126,7 +126,7 @@ def async_km(request, config):
 
 @pytest.fixture
 def async_km_subclass(config):
-    km = AsyncKernelManagerSubclass(config=config)
+    km = AsyncKMSubclass(config=config)
     return km
 
 
@@ -453,7 +453,7 @@ class TestAsyncKernelManager:
         ])
         assert keys == expected
 
-    async def test_subclasses(self, async_km):
+    async def test_subclass_deprecations(self, async_km):
         await async_km.start_kernel(stdout=PIPE, stderr=PIPE)
         is_alive = await async_km.is_alive()
         assert is_alive
@@ -465,7 +465,7 @@ class TestAsyncKernelManager:
 
         if isinstance(async_km, AsyncKernelManagerWithCleanup):
             assert async_km.which_cleanup == "cleanup"
-        elif isinstance(async_km, AsyncKernelManagerSubclass):
+        elif isinstance(async_km, AsyncKMSubclass):
             assert async_km.which_cleanup == "cleanup_resources"
         else:
             assert hasattr(async_km, "which_cleanup") is False

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -9,9 +9,9 @@ from subprocess import PIPE
 from unittest import TestCase
 from tornado.testing import AsyncTestCase, gen_test
 from traitlets.config.loader import Config
-from jupyter_client import KernelManager, AsyncKernelManager
+from jupyter_client import KernelManager
 from jupyter_client.multikernelmanager import MultiKernelManager, AsyncMultiKernelManager
-from .utils import skip_win32, SyncMKMSubclass, AsyncMKMSubclass, SyncKernelManagerSubclass, AsyncKernelManagerSubclass
+from .utils import skip_win32, SyncMKMSubclass, AsyncMKMSubclass, SyncKMSubclass, AsyncKMSubclass
 from ..localinterfaces import localhost
 
 TIMEOUT = 30
@@ -165,7 +165,7 @@ class TestKernelManager(TestCase):
         km.reset_counts()
         kid = km.start_kernel(stdout=PIPE, stderr=PIPE)
         assert km.call_count('start_kernel') == 1
-        assert isinstance(km.get_kernel(kid), SyncKernelManagerSubclass)
+        assert isinstance(km.get_kernel(kid), SyncKMSubclass)
         assert km.get_kernel(kid).call_count('start_kernel') == 1
         assert km.get_kernel(kid).call_count('_launch_kernel') == 1
 
@@ -200,7 +200,7 @@ class TestKernelManager(TestCase):
         km.get_kernel(kid).reset_counts()
         km.reset_counts()
         k = km.get_kernel(kid)
-        assert isinstance(k, SyncKernelManagerSubclass)
+        assert isinstance(k, SyncKMSubclass)
         assert km.call_count('get_kernel') == 1
 
         km.get_kernel(kid).reset_counts()
@@ -422,7 +422,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         mkm.reset_counts()
         kid = await mkm.start_kernel(stdout=PIPE, stderr=PIPE)
         assert mkm.call_count('start_kernel') == 1
-        assert isinstance(mkm.get_kernel(kid), AsyncKernelManagerSubclass)
+        assert isinstance(mkm.get_kernel(kid), AsyncKMSubclass)
         assert mkm.get_kernel(kid).call_count('start_kernel') == 1
         assert mkm.get_kernel(kid).call_count('_launch_kernel') == 1
 
@@ -457,7 +457,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         mkm.get_kernel(kid).reset_counts()
         mkm.reset_counts()
         k = mkm.get_kernel(kid)
-        assert isinstance(k, AsyncKernelManagerSubclass)
+        assert isinstance(k, AsyncKMSubclass)
         assert mkm.call_count('get_kernel') == 1
 
         mkm.get_kernel(kid).reset_counts()

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -42,6 +42,7 @@ class test_env(object):
     def __exit__(self, *exc_info):
         self.stop()
 
+
 def execute(code='', kc=None, **kwargs):
     """wrapper for doing common steps for validating an execution request"""
     from .test_message_spec import validate_message
@@ -62,6 +63,17 @@ def execute(code='', kc=None, **kwargs):
     return msg_id, reply['content']
 
 
+def subclass_recorder(f):
+    def wrapped(self, *args, **kwargs):
+        # record this call
+        self.record(f.__name__)
+        method = getattr(super(self.__class__, self), f.__name__)
+        # call the superclass method
+        r = method(*args, **kwargs)
+        return r
+    return wrapped
+
+
 class RecordCallMixin:
     method_calls: Dict[str, int]
 
@@ -80,50 +92,50 @@ class RecordCallMixin:
         return self.method_calls[method_name]
 
     def reset_counts(self) -> None:
-        for record in self.method_calls.keys():
+        for record in self.method_calls:
             self.method_calls[record] = 0
 
 
-class SyncKernelManagerSubclass(RecordCallMixin, KernelManager):
+class SyncKMSubclass(RecordCallMixin, KernelManager):
 
+    @subclass_recorder
     def start_kernel(self, **kw):
-        self.record('start_kernel')
-        return super().start_kernel(**kw)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def shutdown_kernel(self, now=False, restart=False):
-        self.record('shutdown_kernel')
-        return super().shutdown_kernel(now=now, restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def restart_kernel(self, now=False, **kw):
-        self.record('restart_kernel')
-        return super().restart_kernel(now=now, **kw)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def interrupt_kernel(self):
-        self.record('interrupt_kernel')
-        return super().interrupt_kernel()
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def request_shutdown(self, restart=False):
-        self.record('request_shutdown')
-        return super().request_shutdown(restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def finish_shutdown(self, waittime=None, pollinterval=0.1):
-        self.record('finish_shutdown')
-        return super().finish_shutdown(waittime=waittime, pollinterval=pollinterval)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def _launch_kernel(self, kernel_cmd, **kw):
-        self.record('_launch_kernel')
-        return super()._launch_kernel(kernel_cmd, **kw)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def _kill_kernel(self):
-        self.record('_kill_kernel')
-        return super()._kill_kernel()
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def cleanup_resources(self, restart=False):
-        self.record('cleanup_resources')
-        super().cleanup_resources(restart=restart)
+        """ Record call and defer to superclass """
 
 
-class AsyncKernelManagerSubclass(RecordCallMixin, AsyncKernelManager):
+class AsyncKMSubclass(RecordCallMixin, AsyncKernelManager):
     """Used to test subclass hierarchies to ensure methods are called when expected.
 
        This class is also used to test deprecation "routes" that are determined by superclass'
@@ -133,37 +145,37 @@ class AsyncKernelManagerSubclass(RecordCallMixin, AsyncKernelManager):
     """
     which_cleanup = ""  # cleanup deprecation testing
 
+    @subclass_recorder
     async def start_kernel(self, **kw):
-        self.record('start_kernel')
-        return await super().start_kernel(**kw)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def shutdown_kernel(self, now=False, restart=False):
-        self.record('shutdown_kernel')
-        return await super().shutdown_kernel(now=now, restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def restart_kernel(self, now=False, **kw):
-        self.record('restart_kernel')
-        return await super().restart_kernel(now=now, **kw)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def interrupt_kernel(self):
-        self.record('interrupt_kernel')
-        return await super().interrupt_kernel()
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def request_shutdown(self, restart=False):
-        self.record('request_shutdown')
-        return super().request_shutdown(restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def finish_shutdown(self, waittime=None, pollinterval=0.1):
-        self.record('finish_shutdown')
-        return await super().finish_shutdown(waittime=waittime, pollinterval=pollinterval)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def _launch_kernel(self, kernel_cmd, **kw):
-        self.record('_launch_kernel')
-        return await super()._launch_kernel(kernel_cmd, **kw)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def _kill_kernel(self):
-        self.record('_kill_kernel')
-        return await super()._kill_kernel()
+        """ Record call and defer to superclass """
 
     def cleanup(self, connection_file=True):
         self.record('cleanup')
@@ -191,47 +203,47 @@ class AsyncKernelManagerWithCleanup(AsyncKernelManager):
 class SyncMKMSubclass(RecordCallMixin, MultiKernelManager):
 
     def _kernel_manager_class_default(self):
-        return 'jupyter_client.tests.utils.SyncKernelManagerSubclass'
+        return 'jupyter_client.tests.utils.SyncKMSubclass'
 
+    @subclass_recorder
     def get_kernel(self, kernel_id):
-        self.record('get_kernel')
-        return super().get_kernel(kernel_id)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def remove_kernel(self, kernel_id):
-        self.record('remove_kernel')
-        return super().remove_kernel(kernel_id)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def start_kernel(self, kernel_name=None, **kwargs):
-        self.record('start_kernel')
-        return super().start_kernel(kernel_name=kernel_name, **kwargs)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def shutdown_kernel(self, kernel_id, now=False, restart=False):
-        self.record('shutdown_kernel')
-        return super().shutdown_kernel(kernel_id, now=now, restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def restart_kernel(self, kernel_id, now=False):
-        self.record('restart_kernel')
-        return super().restart_kernel(kernel_id, now=now)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def interrupt_kernel(self, kernel_id):
-        self.record('interrupt_kernel')
-        return super().interrupt_kernel(kernel_id)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def request_shutdown(self, kernel_id, restart=False):
-        self.record('request_shutdown')
-        return super().request_shutdown(kernel_id, restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def finish_shutdown(self, kernel_id, waittime=None, pollinterval=0.1):
-        self.record('finish_shutdown')
-        return super().finish_shutdown(kernel_id, waittime=waittime, pollinterval=pollinterval)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def cleanup_resources(self, kernel_id, restart=False):
-        self.record('cleanup_resources')
-        super().cleanup_resources(kernel_id, restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def shutdown_all(self, now=False):
-        self.record('shutdown_all')
-        return super().shutdown_all(now=now)
+        """ Record call and defer to superclass """
 
 
 class AsyncMKMSubclass(RecordCallMixin, AsyncMultiKernelManager):
@@ -243,44 +255,44 @@ class AsyncMKMSubclass(RecordCallMixin, AsyncMultiKernelManager):
        This class represents a current subclass that overrides "interesting" methods of AsyncKernelManager.
     """
     def _kernel_manager_class_default(self):
-        return 'jupyter_client.tests.utils.AsyncKernelManagerSubclass'
+        return 'jupyter_client.tests.utils.AsyncKMSubclass'
 
+    @subclass_recorder
     def get_kernel(self, kernel_id):
-        self.record('get_kernel')
-        return super().get_kernel(kernel_id)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def remove_kernel(self, kernel_id):
-        self.record('remove_kernel')
-        return super().remove_kernel(kernel_id)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def start_kernel(self, kernel_name=None, **kwargs):
-        self.record('start_kernel')
-        return await super().start_kernel(kernel_name=kernel_name, **kwargs)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def shutdown_kernel(self, kernel_id, now=False, restart=False):
-        self.record('shutdown_kernel')
-        return await super().shutdown_kernel(kernel_id, now=now, restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def restart_kernel(self, kernel_id, now=False):
-        self.record('restart_kernel')
-        return await super().restart_kernel(kernel_id, now=now)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def interrupt_kernel(self, kernel_id):
-        self.record('interrupt_kernel')
-        return await super().interrupt_kernel(kernel_id)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def request_shutdown(self, kernel_id, restart=False):
-        self.record('request_shutdown')
-        return super().request_shutdown(kernel_id, restart=restart)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def finish_shutdown(self, kernel_id, waittime=None, pollinterval=0.1):
-        self.record('finish_shutdown')
-        return await super().finish_shutdown(kernel_id, waittime=waittime, pollinterval=pollinterval)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     async def shutdown_all(self, now=False):
-        self.record('shutdown_all')
-        return await super().shutdown_all(now=now)
+        """ Record call and defer to superclass """
 
+    @subclass_recorder
     def cleanup_resources(self, kernel_id, restart=False):
-        self.record('cleanup_resources')
-        super().cleanup_resources(kernel_id, restart=restart)
+        """ Record call and defer to superclass """


### PR DESCRIPTION
This is a follow-on to #626 to check subclass call sequences relative to the MultiKernelManager base classes.

Also found that CI was skipping the async tests of the recently added `TestKernelManagerShutDownGracefully` resulting in these warnings:
```
jupyter_client/tests/test_kernelmanager.py::TestKernelManagerShutDownGracefully::test_async_signal_kernel_subprocesses[signaltest-_install_kernel-_ShutdownStatus.ShutdownRequest]
jupyter_client/tests/test_kernelmanager.py::TestKernelManagerShutDownGracefully::test_async_signal_kernel_subprocesses[signaltest-no-shutdown-install_kernel_dont_shutdown-_ShutdownStatus.SigtermRequest]
jupyter_client/tests/test_kernelmanager.py::TestKernelManagerShutDownGracefully::test_async_signal_kernel_subprocesses[signaltest-no-terminate-install_kernel_dont_terminate-_ShutdownStatus.SigkillRequest]
  /Users/runner/hostedtoolcache/Python/3.7.10/x64/lib/python3.7/site-packages/_pytest/python.py:172: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))
``` 
which was addressed by adding the `@pytest.mark.asyncio` decorator.