### PR TITLE
[Release 7.0] Remove deprecations in kernel manager

### DIFF
--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -273,10 +273,6 @@ class MultiKernelManager(LoggingConfigurable):
         self.log.info("Kernel shutdown: %s" % kernel_id)
 
     @kernel_method
-    def cleanup(self, kernel_id: str, connection_file: bool = True) -> None:
-        """Clean up a kernel's resources"""
-
-    @kernel_method
     def cleanup_resources(self, kernel_id: str, restart: bool = False) -> None:
         """Clean up a kernel's resources"""
 

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -19,7 +19,6 @@ from traitlets.config.loader import Config
 from ..manager import _ShutdownStatus
 from ..manager import start_new_async_kernel
 from ..manager import start_new_kernel
-from .utils import AsyncKernelManagerWithCleanup
 from .utils import AsyncKMSubclass
 from .utils import SyncKMSubclass
 from .utils import test_env
@@ -123,7 +122,7 @@ def zmq_context():
     ctx.term()
 
 
-@pytest.fixture(params=[AsyncKernelManager, AsyncKMSubclass, AsyncKernelManagerWithCleanup])
+@pytest.fixture(params=[AsyncKernelManager, AsyncKMSubclass])
 def async_km(request, config):
     km = request.param(config=config)
     return km
@@ -466,23 +465,6 @@ class TestAsyncKernelManager:
             ]
         )
         assert keys == expected
-
-    async def test_subclass_deprecations(self, async_km):
-        await async_km.start_kernel(stdout=PIPE, stderr=PIPE)
-        is_alive = await async_km.is_alive()
-        assert is_alive
-        assert isinstance(async_km, AsyncKernelManager)
-        await async_km.shutdown_kernel(now=True)
-        is_alive = await async_km.is_alive()
-        assert is_alive is False
-        assert async_km.context.closed
-
-        if isinstance(async_km, AsyncKernelManagerWithCleanup):
-            assert async_km.which_cleanup == "cleanup"
-        elif isinstance(async_km, AsyncKMSubclass):
-            assert async_km.which_cleanup == "cleanup_resources"
-        else:
-            assert hasattr(async_km, "which_cleanup") is False
 
     @pytest.mark.timeout(10)
     @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't support signals")

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -147,41 +147,15 @@ class KMSubclass(RecordCallMixin):
 
 
 class SyncKMSubclass(KMSubclass, KernelManager):
+    """Used to test subclass hierarchies to ensure methods are called when expected."""
+
     _superclass = KernelManager
 
 
 class AsyncKMSubclass(KMSubclass, AsyncKernelManager):
-    """Used to test subclass hierarchies to ensure methods are called when expected.
-
-    This class is also used to test deprecation "routes" that are determined by superclass'
-    detection of methods.
-
-    This class represents a current subclass that overrides "interesting" methods of
-    AsyncKernelManager.
-    """
+    """Used to test subclass hierarchies to ensure methods are called when expected."""
 
     _superclass = AsyncKernelManager
-    which_cleanup = ""  # cleanup deprecation testing
-
-    @subclass_recorder
-    def cleanup(self, connection_file=True):
-        self.which_cleanup = "cleanup"
-
-    @subclass_recorder
-    def cleanup_resources(self, restart=False):
-        self.which_cleanup = "cleanup_resources"
-
-
-class AsyncKernelManagerWithCleanup(AsyncKernelManager):
-    """Used to test deprecation "routes" that are determined by superclass' detection of methods.
-
-    This class represents the older subclass that overrides cleanup().  We should find that
-    cleanup() is called on these instances via TestAsyncKernelManagerWithCleanup.
-    """
-
-    def cleanup(self, connection_file=True):
-        super().cleanup(connection_file=connection_file)
-        self.which_cleanup = "cleanup"
 
 
 class MKMSubclass(RecordCallMixin):


### PR DESCRIPTION
This change removes the 7-year deprecation of the `kernel_cmd` trait and last year's deprecation of the `cleanup()` method which was replaced with `cleanup_resources()`. 

This is part of #642.