### PR TITLE
Update test kernel with native coroutine, remove async_generator dependency

### DIFF
--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -10,7 +10,6 @@ from subprocess import Popen
 from ipykernel.displayhook import ZMQDisplayHook
 from ipykernel.kernelapp import IPKernelApp
 from ipykernel.kernelbase import Kernel
-from tornado.web import gen
 
 
 class SignalTestKernel(Kernel):
@@ -28,10 +27,9 @@ class SignalTestKernel(Kernel):
         if os.environ.get("NO_SIGTERM_REPLY", None) == "1":
             signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
-    @gen.coroutine
-    def shutdown_request(self, stream, ident, parent):
+    async def shutdown_request(self, stream, ident, parent):
         if os.environ.get("NO_SHUTDOWN_REPLY") != "1":
-            yield gen.maybe_future(super().shutdown_request(stream, ident, parent))
+            await super().shutdown_request(stream, ident, parent)
 
     def do_execute(
         self, code, silent, store_history=True, user_expressions=None, allow_stdin=False

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ setup_args = dict(
     python_requires='>=3.6.1',
     extras_require={
         'test': [
-            'async_generator',
             'ipykernel',
             'ipython',
             'jedi<0.18; python_version<="3.6"',


### PR DESCRIPTION
While updating the Kernel Provisioning PR with all of the recent changes, I ran into a couple of general issues that appear related to some recent updates to ipykernel (`6.0a5`).  Since we're using the `--pre` option to install test dependencies, I thought I'd add these changes to the primary branch since, in all likelihood, the next PR will encounter them.

1. This updates the test kernel subclass `SignalTestKernel` to use a native coroutine that is used in `TestKernelManagerShutDownGracefully`.
2. The return of the tuple from the previously required `async_generator`-decorated method has been removed (as has `yield_`) since we no longer support Python 3.5.
3. I had to conditionally skip the `TestKernelManagerShutDownGracefully` tests that use `shutdown_request` on Python 3.6 since the `ipykernel` updates are not available in that Python release.  These changes are essentially mutually exclusive to those in item 1, so this PR errs on the side of Python 3.7+.