### PR TITLE
PR: Don't block on exit

### DIFF
--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -105,7 +105,7 @@ class HBChannel(Thread):
 
         self.poller.register(self.socket, zmq.POLLIN)
 
-    def _poll(self, start_time: float) -> t.List[t.Any]:
+    def _poll(self) -> t.List[t.Any]:
         """poll for heartbeat replies until we reach self.time_to_dead.
 
         Ignores interrupts, and returns the result of poll(), which
@@ -113,9 +113,7 @@ class HBChannel(Thread):
         or the event tuple if there is a message to receive.
         """
         # Wait until timeout
-        until_dead = self.time_to_dead - (time.time() - start_time)
-        if until_dead > 0:
-            self._exit.wait(until_dead)
+        self._exit.wait(self.time_to_dead)
         if not self._exit.is_set():
             # 0 means return immediately.
             # http://api.zeromq.org/2-1:zmq-poll
@@ -145,7 +143,7 @@ class HBChannel(Thread):
             # either a recv or connect, which cannot be followed by EFSM
             await self.socket.send(b"ping")
             request_time = time.time()
-            ready = self._poll(request_time)
+            ready = self._poll()
             if ready:
                 self._beating = True
                 # the poll above guarantees we have something to recv

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -137,7 +137,7 @@ class HBChannel(Thread):
                 else:
                     raise
             else:
-                if events or self._exit.isSet():
+                if events or self._exit.is_set():
                     break
                 elif self.time_to_dead - (time.time() - start_time) < 0:
                     break

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -161,7 +161,7 @@ class HBChannel(Thread):
                 if remainder > 0:
                     self._exit.wait(remainder)
                 continue
-            else:
+            elif not self._exit.is_set():
                 # nothing was received within the time limit, signal heart failure
                 self._beating = False
                 since_last_heartbeat = time.time() - request_time

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -121,7 +121,7 @@ class HBChannel(Thread):
         events = []
         while True:
             try:
-                events = self.poller.poll(int(1000 * until_dead))
+                events = self.poller.poll(1)
             except ZMQError as e:
                 if e.errno == errno.EINTR:
                     # ignore interrupts during heartbeat
@@ -137,7 +137,10 @@ class HBChannel(Thread):
                 else:
                     raise
             else:
-                break
+                if events or self._exit.isSet():
+                    break
+                elif self.time_to_dead - (time.time() - start_time) < 0:
+                    break
         return events
 
     def run(self) -> None:

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -3,7 +3,6 @@
 # Distributed under the terms of the Modified BSD License.
 import asyncio
 import atexit
-import errno
 import time
 import typing as t
 from queue import Empty
@@ -11,7 +10,6 @@ from threading import Event
 from threading import Thread
 
 import zmq.asyncio
-from zmq import ZMQError
 
 from .channelsabc import HBChannelABC
 from .session import Session

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -121,7 +121,7 @@ class HBChannel(Thread):
         events = []
         while True:
             try:
-                events = self.poller.poll(1)
+                events = self.poller.poll(100)
             except ZMQError as e:
                 if e.errno == errno.EINTR:
                     # ignore interrupts during heartbeat


### PR DESCRIPTION
If the code tries to exit while calling `self.poller.poll`, the app will freeze until `until_dead` seconds have elapsed. This avoids that outcome.