### PR TITLE
Lay foundation to pass notebook names to kernel at startup.

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -34,6 +34,17 @@ from jupyter_client import KernelClient
 from jupyter_client import kernelspec
 
 
+# Name of the env variable that contains the name of the current session associated
+# with the kernel we are launching.
+# Frontends can decide to set this session name to the name of the file when
+# when the kernel is started.
+# This is useful in notebook context to find which notebook we are working with
+# though we might not be working with a notebook, we could be working with a
+# markdown file, or python file.
+# as with other Jupyter Related Env variable with use the JPY prefix.
+JPY_KERNEL_SESSION_NAME = 'JPY_SESSION_NAME'
+
+
 class _ShutdownStatus(Enum):
     """
 
@@ -332,6 +343,7 @@ class KernelManager(ConnectionFileMixin):
 
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)
+        kw.pop('session_name', None)
         await ensure_async(self._launch_kernel(kernel_cmd, **kw))
         await ensure_async(self.post_start_kernel(**kw))
 

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -151,6 +151,9 @@ class MultiKernelManager(LoggingConfigurable):
         constructor_kwargs = {}
         if self.kernel_spec_manager:
             constructor_kwargs["kernel_spec_manager"] = self.kernel_spec_manager
+
+        if 'session_name' in kwargs:
+            constructor_kwargs['session_name'] = kwargs.copy().pop('session_name')
         km = self.kernel_manager_factory(
             connection_file=os.path.join(self.connection_dir, "kernel-%s.json" % kernel_id),
             parent=self,

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -139,6 +139,7 @@ class LocalProvisioner(KernelProvisionerBase):
 
         # This should be considered temporary until a better division of labor can be defined.
         km = self.parent
+        extra_arguments = kwargs.pop('extra_arguments', [])
         if km:
             if km.transport == 'tcp' and not is_local_ip(km.ip):
                 raise RuntimeError(
@@ -149,7 +150,6 @@ class LocalProvisioner(KernelProvisionerBase):
                     "Currently valid addresses are: %s" % (km.ip, local_ips())
                 )
             # build the Popen cmd
-            extra_arguments = kwargs.pop('extra_arguments', [])
 
             # write connection file / get default ports
             # TODO - change when handshake pattern is adopted
@@ -169,7 +169,6 @@ class LocalProvisioner(KernelProvisionerBase):
                 extra_arguments=extra_arguments
             )  # This needs to remain here for b/c
         else:
-            extra_arguments = kwargs.pop('extra_arguments', [])
             kernel_cmd = self.kernel_spec.argv + extra_arguments
 
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -16,6 +16,16 @@ from traitlets.config import Unicode
 
 from ..connect import KernelConnectionInfo
 
+# Name of the env variable that contains the name of the current session associated
+# with the kernel we are launching.
+# Frontends can decide to set this session name to the name of the file when
+# when the kernel is started.
+# This is useful in notebook context to find which notebook we are working with
+# though we might not be working with a notebook, we could be working with a
+# markdown file, or python file.
+# as with other Jupyter Related Env variable with use the JPY prefix.
+JPY_SESSION_NAME = 'JPY_SESSION_NAME'
+
 
 class KernelProvisionerMeta(ABCMeta, type(LoggingConfigurable)):  # type: ignore
     pass
@@ -160,6 +170,8 @@ class KernelProvisionerBase(ABC, LoggingConfigurable, metaclass=KernelProvisione
         :meth:`launch_kernel()`.
         """
         env = kwargs.pop('env', os.environ).copy()
+        if 'session_name' in kwargs:
+            env.update({JPY_SESSION_NAME: kwargs['session_name']})
         env.update(self.__apply_env_substitutions(env))
         self._finalize_env(env)
         kwargs['env'] = env


### PR DESCRIPTION
This has been a controversial topic from some time:

https://github.com/jupyter/notebook/issues/1000
https://forums.databricks.com/questions/21390/is-there-any-way-to-get-the-current-notebook-name.html
https://stackoverflow.com/questions/12544056/how-do-i-get-the-current-ipython-jupyter-notebook-name
https://ask.sagemath.org/question/36873/access-notebook-filename-from-jupyter-with-sagemath-kernel/

This is also sometime critical to linter, and tab completion to know
current name.

Of course current answer is that the question is ill-defined,
there might not be a file associated with the current kernel, there
might be multiple files, files might not be on the same system, it could
change through the execution and many other gotchas.

This suggest to add an JPY_ASSOCIATED_FILE env variable which is not
too visible, but give an escape hatch which should mostly be correct
unless the notebook is renamed or kernel attached to a new one.

Do do so this handles the new associated_file parameters in a few
function of the kernel manager. On jupyter_server this one line change
make the notebook name available using typical local installs:

    --- a/jupyter_server/services/sessions/sessionmanager.py
    +++ b/jupyter_server/services/sessions/sessionmanager.py
    @@ -96,7 +96,12 @@ class SessionManager(LoggingConfigurable):
             """Start a new kernel for a given session."""
             # allow contents manager to specify kernels cwd
             kernel_path = self.contents_manager.get_kernel_path(path=path)
    -        kernel_id = await self.kernel_manager.start_kernel(path=kernel_path, kernel_name=kernel_name)
    +
    +        kernel_id = await self.kernel_manager.start_kernel(
    +            path=kernel_path, kernel_name=kernel_name, associated_file=name
    +        )
             return kernel_id

Of course only launchers that will pass forward this value will allow
the env variable to be set.

I'm thinking that various kernels may use this and expose it in
different ways. like __notebook_name__ if it ends with `.ipynb` in
ipykernel.