### PR TITLE
add pypy-3.7 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,7 @@ jobs:
           pip freeze
 
       - name: Check types
+        if: matrix.python-version != 'pypy-3.7'
         run: mypy jupyter_client --exclude '\/tests|kernelspecapp|ioloop|runapp' --install-types --non-interactive
 
       - name: Run the tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,8 +71,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.7]
         exclude:
-        - os: windows-latest
-          python-version: pypy-3.7
+          - os: windows-latest
+            python-version: pypy-3.7
     env:
       OS: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.7]
+        exclude:
+        - os: windows-latest
+          python-version: pypy-3.7
     env:
       OS: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
     if: ${{ needs.check_duplicate_runs.outputs.should_skip != 'true' }}
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -59,7 +59,9 @@ class LocalProvisioner(KernelProvisionerBase):
                 await asyncio.sleep(0.1)
 
             # Process is no longer alive, wait and clear
-            ret = self.process.wait()
+            # Popen.__exit__ cleans up resources such as pipes
+            with self.process:
+                ret = self.process.wait()
             self.process = None  # allow has_process to now return False
         return ret
 

--- a/jupyter_client/tests/signalkernel.py
+++ b/jupyter_client/tests/signalkernel.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 import signal
+import sys
 import time
 from subprocess import PIPE
 from subprocess import Popen
@@ -40,7 +41,20 @@ class SignalTestKernel(Kernel):
             "user_expressions": {},
         }
         if code == "start":
-            child = Popen(["bash", "-i", "-c", "sleep 30"], stderr=PIPE)
+            child = Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    '; '.join(
+                        [
+                            "import signal, time",
+                            "signal.signal(signal.SIGINT, signal.SIG_DFL)",
+                            "time.sleep(30)",
+                        ]
+                    ),
+                ],
+                stderr=PIPE,
+            )
             self.children.append(child)
             reply["user_expressions"]["pid"] = self.children[-1].pid
         elif code == "check":

--- a/jupyter_client/tests/test_kernelapp.py
+++ b/jupyter_client/tests/test_kernelapp.py
@@ -1,10 +1,11 @@
 import os
-import shutil
 import sys
 import time
+from queue import Empty
+from queue import Queue
 from subprocess import PIPE
 from subprocess import Popen
-from tempfile import mkdtemp
+from threading import Thread
 
 
 def _launch(extra_env):
@@ -21,44 +22,80 @@ WAIT_TIME = 10
 POLL_FREQ = 10
 
 
-def test_kernelapp_lifecycle():
+def test_kernelapp_lifecycle(request, tmpdir):
     # Check that 'jupyter kernel' starts and terminates OK.
-    runtime_dir = mkdtemp()
-    startup_dir = mkdtemp()
+    runtime_dir = str(tmpdir.join("runtime").mkdir())
+    startup_dir = str(tmpdir.join("startup").mkdir())
     started = os.path.join(startup_dir, "started")
-    try:
-        p = _launch(
-            {
-                "JUPYTER_RUNTIME_DIR": runtime_dir,
-                "JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE": started,
-            }
-        )
-        # Wait for start
-        for _ in range(WAIT_TIME * POLL_FREQ):
-            if os.path.isfile(started):
-                break
-            time.sleep(1 / POLL_FREQ)
-        else:
-            raise AssertionError("No started file created in {} seconds".format(WAIT_TIME))
+    p = _launch(
+        {
+            "JUPYTER_RUNTIME_DIR": runtime_dir,
+            "JUPYTER_CLIENT_TEST_RECORD_STARTUP_PRIVATE": started,
+        }
+    )
+    request.addfinalizer(p.terminate)
 
-        # Connection file should be there by now
-        for _ in range(WAIT_TIME * POLL_FREQ):
-            files = os.listdir(runtime_dir)
-            if files:
-                break
-            time.sleep(1 / POLL_FREQ)
-        else:
-            raise AssertionError("No connection file created in {} seconds".format(WAIT_TIME))
-        assert len(files) == 1
-        cf = files[0]
-        assert cf.startswith("kernel")
-        assert cf.endswith(".json")
+    # Wait for start
+    for _ in range(WAIT_TIME * POLL_FREQ):
+        if os.path.isfile(started):
+            break
+        time.sleep(1 / POLL_FREQ)
+    else:
+        raise AssertionError("No started file created in {} seconds".format(WAIT_TIME))
 
-        # Send SIGTERM to shut down
-        time.sleep(1)
+    # Connection file should be there by now
+    for _ in range(WAIT_TIME * POLL_FREQ):
+        files = os.listdir(runtime_dir)
+        if files:
+            break
+        time.sleep(1 / POLL_FREQ)
+    else:
+        raise AssertionError("No connection file created in {} seconds".format(WAIT_TIME))
+
+    assert len(files) == 1
+    cf = files[0]
+    assert cf.startswith("kernel")
+    assert cf.endswith(".json")
+
+    # pexpect-style wait-for-text with timeout
+    # use blocking background thread to read output
+    # so this works on Windows
+    t = time.perf_counter()
+    deadline = t + WAIT_TIME
+    remaining = WAIT_TIME
+
+    stderr = ""
+    q = Queue()
+
+    def _readlines():
+        while True:
+            line = p.stderr.readline()
+            q.put(line.decode("utf8", "replace"))
+            if not line:
+                break
+
+    stderr_thread = Thread(target=_readlines, daemon=True)
+    stderr_thread.start()
+
+    while remaining >= 0 and p.poll() is None:
+        try:
+            line = q.get(timeout=remaining)
+        except Empty:
+            break
+        stderr += line
+        if cf in stderr:
+            break
+        remaining = deadline - time.perf_counter()
+
+    if p.poll() is None:
         p.terminate()
-        _, stderr = p.communicate(timeout=WAIT_TIME)
-        assert cf in stderr.decode("utf-8", "replace")
-    finally:
-        shutil.rmtree(runtime_dir)
-        shutil.rmtree(startup_dir)
+
+    # finish reading stderr
+    stderr_thread.join()
+    while True:
+        try:
+            line = q.get_nowait()
+        except Empty:
+            break
+        stderr += line
+    assert cf in stderr

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -459,7 +459,7 @@ class TestAsyncKernelManager:
         )
         assert keys == expected
 
-    @pytest.mark.timeout(10)
+    @pytest.mark.timeout(20)
     @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't support signals")
     async def test_signal_kernel_subprocesses(self, install_kernel, start_async_kernel):
 
@@ -499,7 +499,7 @@ class TestAsyncKernelManager:
         # wait up to 5s for subprocesses to handle signal
         for i in range(50):
             reply = await execute("check")
-            if reply["user_expressions"]["poll"] != [-signal.SIGINT] * N:
+            if any(status is None for status in reply["user_expressions"]["poll"]):
                 await asyncio.sleep(0.1)
             else:
                 break

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -420,6 +420,7 @@ class TestParallel:
         km.restart_kernel(now=True)
         assert km.is_alive()
         execute("check")
+        kc.stop_channels()
 
         km.shutdown_kernel()
         assert km.context.closed

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -69,6 +69,7 @@ class TestKernelManager(TestCase):
         assert isinstance(k, KernelManager)
         km.shutdown_kernel(kid, now=True)
         assert kid not in km, f"{kid} not in {km}"
+        km.context.term()
 
     def _run_cinfo(self, km, transport, ip):
         kid = km.start_kernel(stdout=PIPE, stderr=PIPE)
@@ -87,6 +88,7 @@ class TestKernelManager(TestCase):
         stream = km.connect_hb(kid)
         stream.close()
         km.shutdown_kernel(kid, now=True)
+        km.context.term()
 
     # static so picklable for multiprocessing on Windows
     @classmethod
@@ -106,6 +108,7 @@ class TestKernelManager(TestCase):
         self.assertNotIn(kid, km)
         # shutdown again is okay, because we have no kernels
         km.shutdown_all()
+        km.context.term()
 
     def test_tcp_cinfo(self):
         km = self._get_tcp_km()
@@ -217,6 +220,7 @@ class TestKernelManager(TestCase):
         assert km.call_count("cleanup_resources") == 0
 
         assert kid not in km, f"{kid} not in {km}"
+        km.context.term()
 
 
 class TestAsyncKernelManager(AsyncTestCase):
@@ -263,6 +267,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         assert isinstance(k, AsyncKernelManager)
         await km.shutdown_kernel(kid, now=True)
         assert kid not in km, f"{kid} not in {km}"
+        km.context.term()
 
     async def _run_cinfo(self, km, transport, ip):
         kid = await km.start_kernel(stdout=PIPE, stderr=PIPE)
@@ -282,6 +287,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         stream.close()
         await km.shutdown_kernel(kid, now=True)
         self.assertNotIn(kid, km)
+        km.context.term()
 
     @gen_test
     async def test_tcp_lifecycle(self):
@@ -316,6 +322,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         self.assertNotIn(kid, km)
         # shutdown again is okay, because we have no kernels
         await km.shutdown_all()
+        km.context.term()
 
     @gen_test(timeout=20)
     async def test_shutdown_all_while_starting(self):
@@ -333,6 +340,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         self.assertNotIn(kid, km)
         # shutdown again is okay, because we have no kernels
         await km.shutdown_all()
+        km.context.term()
 
     @gen_test
     async def test_tcp_cinfo(self):
@@ -466,3 +474,4 @@ class TestAsyncKernelManager(AsyncTestCase):
         assert mkm.call_count("cleanup_resources") == 0
 
         assert kid not in mkm, f"{kid} not in {mkm}"
+        mkm.context.term()

--- a/jupyter_client/tests/test_session.py
+++ b/jupyter_client/tests/test_session.py
@@ -171,16 +171,13 @@ class TestSession(SessionTestCase):
         s.copy_threshold = 1
         ZMQStream(a)
         msg = s.send(a, "hello", track=False)
-        self.assertTrue(msg["tracker"] is ss.DONE)
+        assert msg["tracker"] is ss.DONE
         msg = s.send(a, "hello", track=True)
-        self.assertTrue(isinstance(msg["tracker"], zmq.MessageTracker))
+        assert isinstance(msg["tracker"], zmq.MessageTracker)
         M = zmq.Message(b"hi there", track=True)
         msg = s.send(a, "hello", buffers=[M], track=True)
         t = msg["tracker"]
-        self.assertTrue(isinstance(t, zmq.MessageTracker))
-        self.assertRaises(zmq.NotDone, t.wait, 0.1)
-        del M
-        t.wait(1)  # this will raise
+        assert t is not ss.DONE
 
     def test_unique_msg_ids(self):
         """test that messages receive unique ids"""

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ ipykernel
 ipython
 jedi<0.18; python_version<="3.6"
 mock
-mypy
+mypy; implementation_name == "cpython"
 pre-commit
 pytest
 pytest-asyncio


### PR DESCRIPTION
Investigating downstream errors:

- https://github.com/ipython/ipykernel/pull/700

> Seeing if this test fail is spurious/azure/cosmic rays: 

```
=================================== FAILURES ===================================
________________________________ test_shutdown _________________________________

    def test_shutdown():
        """Kernel exits after polite shutdown_request"""
        with new_kernel() as kc:
            km = kc.parent
            execute('a = 1', kc=kc)
            wait_for_idle(kc)
            kc.shutdown()
            for i in range(300): # 30s timeout
                if km.is_alive():
                    time.sleep(.1)
                else:
                    break
>           assert not km.is_alive()
E           assert not True
E            +  where True = <bound method KernelManager.is_alive of <jupyter_client.manager.KernelManager object at 0x000055773df9b0c0>>()
E            +    where <bound method KernelManager.is_alive of <jupyter_client.manager.KernelManager object at 0x000055773df9b0c0>> = <jupyter_client.manager.KernelManager object at 0x000055773df9b0c0>.is_alive

../_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/site-packages/ipykernel/tests/test_kernel.py:373: AssertionError

```

> from https://github.com/conda-forge/ipykernel-feedstock/pull/84#issuecomment-871402127

