### PR TITLE
Rename trait to allowed_kernelspecs

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -229,7 +229,7 @@ class KernelSpecManager(LoggingConfigurable):
                 self.log.warning("Native kernel (%s) is not available", NATIVE_KERNEL_NAME)
 
         if self.allowed_kernel_names:
-            # filter if there's a whitelist
+            # filter if there's an allow list
             d = {name: spec for name, spec in d.items() if name in self.allowed_kernel_names}
         return d
         # TODO: Caching?

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -152,7 +152,7 @@ class KernelSpecManager(LoggingConfigurable):
         help="""Deprecated, use `KernelSpecManager.allowed_kernelspecs`
         """,
     )
-    allowed_kernel_names = Set(
+    allowed_kernelspecs = Set(
         config=True,
         help="""List of allowed kernel names.
 

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -154,7 +154,7 @@ class KernelSpecManager(LoggingConfigurable):
     )
     allowed_kernel_names = Set(
         config=True,
-        help="""Whitelist of allowed kernel names.
+        help="""List of allowed kernel names.
 
         By default, all installed kernels are allowed.
         """,

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -230,7 +230,7 @@ class KernelSpecManager(LoggingConfigurable):
 
         if self.allowed_kernel_names:
             # filter if there's an allow list
-            d = {name: spec for name, spec in d.items() if name in self.allowed_kernel_names}
+            d = {name: spec for name, spec in d.items() if name in self.allowed_kernelspecs}
         return d
         # TODO: Caching?
 

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -228,7 +228,7 @@ class KernelSpecManager(LoggingConfigurable):
             except ImportError:
                 self.log.warning("Native kernel (%s) is not available", NATIVE_KERNEL_NAME)
 
-        if self.allowed_kernel_names:
+        if self.allowed_kernelspecs:
             # filter if there's an allow list
             d = {name: spec for name, spec in d.items() if name in self.allowed_kernelspecs}
         return d

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -164,7 +164,7 @@ class KernelSpecManager(LoggingConfigurable):
     )
 
     _deprecated_aliases = {
-        "whitelist": ("allowed_kernel_names", "7.0"),
+        "whitelist": ("allowed_kernelspecs", "7.0"),
     }
 
     # Method copied from

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -149,7 +149,7 @@ class KernelSpecManager(LoggingConfigurable):
 
     whitelist = Set(
         config=True,
-        help="""Deprecated, use `KernelSpecManager.allowed_kernel_names`
+        help="""Deprecated, use `KernelSpecManager.allowed_kernelspecs`
         """,
     )
     allowed_kernel_names = Set(

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -61,7 +61,7 @@ class KernelSpecTests(unittest.TestCase):
 
     def test_allowed_kernel_names(self):
         ksm = kernelspec.KernelSpecManager()
-        ksm.allowed_kernel_names = ["foo"]
+        ksm.allowed_kernelspecs = ["foo"]
         kernels = ksm.find_kernel_specs()
         assert not len(kernels)
 

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -59,6 +59,18 @@ class KernelSpecTests(unittest.TestCase):
         kernels = self.ksm.find_kernel_specs()
         self.assertEqual(kernels["sample"], self.sample_kernel_dir)
 
+    def test_allowed_kernel_names(self):
+        ksm = kernelspec.KernelSpecManager()
+        ksm.allowed_kernel_names = ["foo"]
+        kernels = ksm.find_kernel_specs()
+        assert not len(kernels)
+
+    def test_deprecated_whitelist(self):
+        ksm = kernelspec.KernelSpecManager()
+        ksm.whitelist = ["bar"]
+        kernels = ksm.find_kernel_specs()
+        assert not len(kernels)
+
     def test_get_kernel_spec(self):
         ks = self.ksm.get_kernel_spec("SAMPLE")  # Case insensitive
         self.assertEqual(ks.resource_dir, self.sample_kernel_dir)


### PR DESCRIPTION
Partially addresses jupyter/jupyter_client#642 by deprecating `KernelSpecManager.whitelist` in favor of the more descriptive and inclusive `KernelSpecManager.allowed_kernelspecs`.