### PR TITLE
Use formal method names when called internally

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -373,7 +373,7 @@ class KernelManager(ConnectionFileMixin):
         except asyncio.TimeoutError:
             self.log.debug("Kernel is taking too long to finish, terminating")
             self._shutdown_status = _ShutdownStatus.SigtermRequest
-            await self._async_send_kernel_sigterm()
+            await ensure_async(self._send_kernel_sigterm())
 
         try:
             await asyncio.wait_for(
@@ -531,7 +531,7 @@ class KernelManager(ConnectionFileMixin):
             assert self.kernel_spec is not None
             interrupt_mode = self.kernel_spec.interrupt_mode
             if interrupt_mode == "signal":
-                await self._async_signal_kernel(signal.SIGINT)
+                await ensure_async(self.signal_kernel(signal.SIGINT))
 
             elif interrupt_mode == "message":
                 msg = self.session.msg("interrupt_request", content={})
@@ -574,7 +574,7 @@ class KernelManager(ConnectionFileMixin):
         # not alive.  If we find the process is no longer alive, complete
         # its cleanup via the blocking wait().  Callers are responsible for
         # issuing calls to wait() using a timeout (see _kill_kernel()).
-        while await self._async_is_alive():
+        while await ensure_async(self.is_alive()):
             await asyncio.sleep(pollinterval)
 
 

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -298,6 +298,7 @@ class TestKernelManager:
 
     def test_subclass_callables(self, km_subclass):
         km_subclass.reset_counts()
+
         km_subclass.start_kernel(stdout=PIPE, stderr=PIPE)
         assert km_subclass.call_count("start_kernel") == 1
         assert km_subclass.call_count("_launch_kernel") == 1
@@ -305,6 +306,7 @@ class TestKernelManager:
         is_alive = km_subclass.is_alive()
         assert is_alive
         km_subclass.reset_counts()
+
         km_subclass.restart_kernel(now=True)
         assert km_subclass.call_count("restart_kernel") == 1
         assert km_subclass.call_count("shutdown_kernel") == 1
@@ -313,26 +315,32 @@ class TestKernelManager:
         assert km_subclass.call_count("cleanup_resources") == 1
         assert km_subclass.call_count("start_kernel") == 1
         assert km_subclass.call_count("_launch_kernel") == 1
+        assert km_subclass.call_count("signal_kernel") == 1
 
         is_alive = km_subclass.is_alive()
         assert is_alive
-
+        assert km_subclass.call_count("is_alive") >= 1
         km_subclass.reset_counts()
+
         km_subclass.interrupt_kernel()
         assert km_subclass.call_count("interrupt_kernel") == 1
+        assert km_subclass.call_count("signal_kernel") == 1
 
         assert isinstance(km_subclass, KernelManager)
-
         km_subclass.reset_counts()
+
         km_subclass.shutdown_kernel(now=False)
         assert km_subclass.call_count("shutdown_kernel") == 1
         assert km_subclass.call_count("interrupt_kernel") == 1
         assert km_subclass.call_count("request_shutdown") == 1
         assert km_subclass.call_count("finish_shutdown") == 1
         assert km_subclass.call_count("cleanup_resources") == 1
+        assert km_subclass.call_count("signal_kernel") == 1
+        assert km_subclass.call_count("is_alive") >= 1
 
         is_alive = km_subclass.is_alive()
         assert is_alive is False
+        assert km_subclass.call_count("is_alive") >= 1
         assert km_subclass.context.closed
 
 
@@ -516,13 +524,16 @@ class TestAsyncKernelManager:
 
     async def test_subclass_callables(self, async_km_subclass):
         async_km_subclass.reset_counts()
+
         await async_km_subclass.start_kernel(stdout=PIPE, stderr=PIPE)
         assert async_km_subclass.call_count("start_kernel") == 1
         assert async_km_subclass.call_count("_launch_kernel") == 1
 
         is_alive = await async_km_subclass.is_alive()
         assert is_alive
+        assert async_km_subclass.call_count("is_alive") >= 1
         async_km_subclass.reset_counts()
+
         await async_km_subclass.restart_kernel(now=True)
         assert async_km_subclass.call_count("restart_kernel") == 1
         assert async_km_subclass.call_count("shutdown_kernel") == 1
@@ -531,24 +542,30 @@ class TestAsyncKernelManager:
         assert async_km_subclass.call_count("cleanup_resources") == 1
         assert async_km_subclass.call_count("start_kernel") == 1
         assert async_km_subclass.call_count("_launch_kernel") == 1
+        assert async_km_subclass.call_count("signal_kernel") == 1
 
         is_alive = await async_km_subclass.is_alive()
         assert is_alive
-
+        assert async_km_subclass.call_count("is_alive") >= 1
         async_km_subclass.reset_counts()
+
         await async_km_subclass.interrupt_kernel()
         assert async_km_subclass.call_count("interrupt_kernel") == 1
+        assert async_km_subclass.call_count("signal_kernel") == 1
 
         assert isinstance(async_km_subclass, AsyncKernelManager)
-
         async_km_subclass.reset_counts()
+
         await async_km_subclass.shutdown_kernel(now=False)
         assert async_km_subclass.call_count("shutdown_kernel") == 1
         assert async_km_subclass.call_count("interrupt_kernel") == 1
         assert async_km_subclass.call_count("request_shutdown") == 1
         assert async_km_subclass.call_count("finish_shutdown") == 1
         assert async_km_subclass.call_count("cleanup_resources") == 1
+        assert async_km_subclass.call_count("signal_kernel") == 1
+        assert async_km_subclass.call_count("is_alive") >= 1
 
         is_alive = await async_km_subclass.is_alive()
         assert is_alive is False
+        assert async_km_subclass.call_count("is_alive") >= 1
         assert async_km_subclass.context.closed

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -145,6 +145,18 @@ class KMSubclass(RecordCallMixin):
     def cleanup_resources(self, restart=False):
         """ Record call and defer to superclass """
 
+    @subclass_recorder
+    def signal_kernel(self, signum: int):
+        """ Record call and defer to superclass """
+
+    @subclass_recorder
+    def is_alive(self):
+        """ Record call and defer to superclass """
+
+    @subclass_recorder
+    def _send_kernel_sigterm(self, restart: bool = False):
+        """ Record call and defer to superclass """
+
 
 class SyncKMSubclass(KMSubclass, KernelManager):
     """Used to test subclass hierarchies to ensure methods are called when expected."""


### PR DESCRIPTION
Fixup a couple more instances where we were calling the internal method name rather than the "aliased" (for lack of a better term) name.  This prevented some lower-level method overrides in subclasses from being called.  The test which was introduced for this purpose has been extended accordingly.

See https://github.com/jupyter/jupyter_client/issues/682#issuecomment-902260179 for more information.

Resolves #682