### PR TITLE
Don't set event loop policy on Windows at import time

### DIFF
--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -1,15 +1,11 @@
 """
 utils:
-- provides utility wrapeprs to run asynchronous functions in a blocking environment.
+- provides utility wrappers to run asynchronous functions in a blocking environment.
 - vendor functions from ipython_genutils that should be retired at some point.
 """
 import asyncio
 import inspect
 import os
-import sys
-
-if os.name == "nt" and sys.version_info >= (3, 7):
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore
 
 
 def run_sync(coro):


### PR DESCRIPTION
Imports shouldn't have side effects like this.

I know it's annoying, but this kind of process initialization needs to be in *application* startup, not library import, otherwise you can end up overriding other code unintentionally.

Plus, with tornado 6.1 and pyzmq 22, the default proactor loop generally works anyway, even if selector is often a better fit for zmq-based applications.

Related to https://github.com/dask/distributed/issues/5272 I believe