### PR TITLE
use load_connection_info(info) when constructing a blocking client

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -448,9 +448,8 @@ class ConnectionFileMixin(LoggingConfigurable):
     def blocking_client(self):
         """Make a blocking client connected to my kernel"""
         info = self.get_connection_info()
-        info["parent"] = self
-        bc = self.blocking_class(**info)
-        bc.session.key = self.session.key
+        bc = self.blocking_class(parent=self)
+        bc.load_connection_info(info)
         return bc
 
     def cleanup_connection_file(self) -> None:


### PR DESCRIPTION
passing connection_info to constructor passes Session args (key, scheme) to the Client, which trigger warnings for unrecognized arguments

We could also add logic in `ConnectionFileMixin.__init__` to explicitly support all the fields of a connection file in the constructor, which might be nice. But we have the load_info method already.
