### PR TITLE
Address missing local-provisioner scenario

### DIFF
--- a/jupyter_client/tests/test_provisioning.py
+++ b/jupyter_client/tests/test_provisioning.py
@@ -210,7 +210,7 @@ def mock_get_all_provisioners() -> List[EntryPoint]:
     return result
 
 
-def mock_get_provisioner(name) -> EntryPoint:
+def mock_get_provisioner(factory, name) -> EntryPoint:
     if name == 'new-test-provisioner':
         return EntryPoint(
             'new-test-provisioner', 'jupyter_client.tests.test_provisioning', 'NewTestProvisioner'


### PR DESCRIPTION
There have been a few instances of users reporting that they can't run kernels due to the `local-provisioner` not being available.  However, this provisioner is registered in the current jupyter_client package, yet when the package searches for the default provisioner (i.e., `local-provisioner`) it is not found.

- https://discourse.jupyter.org/t/kernel-python-3-is-referencing-a-kernel-provisioner-local-provisioner-that-is-not-available-ensure-the-appropriate-package-has-been-installed-and-retry/10436
- https://github.com/Anaconda-Platform/nb_conda_kernels/issues/209

It turns out that in certain circumstances, which remain a mystery to me, there can be multiple _dist-info_ directories present related to `jupyter_client` - one representing the previous release (6.x - which does not include kernel provisioning and `local-provisioner`) and the current release, which is obviously running since its looking for the `local-provisioner`.  Since [entrypoints](https://github.com/takluyver/entrypoints) uses the first distribution it finds, it locates the 6.x _dist-info_ directory and deems `local-provisioner` as not available.

This pull request will detect this condition (i.e., `local-provisioner` is not available), issue a warning message alerting users to the situation instructing them what to do, but then constructs a local-provisioner entrypoint instance so that default behavior is experienced and kernels can be started.

Here's an example of the logged warning:
`[W 10:08:17.848 NotebookApp] Kernel Provisioning: The 'local-provisioner' is not found.  This is likely due to the presence of multiple jupyter_client distributions and a previous distribution is being used as the source for entrypoints - which does not include 'local-provisioner'.  That distribution should be removed such that only the version-appropriate distribution remains (version >= 7).  Until then, a 'local-provisioner' entrypoint will be automatically constructed and used.  `
`The candidate distribution locations are: ['/opt/anaconda3/envs/elyra-dev/lib/python3.8/site-packages/jupyter_client-6.1.12.dist-info', '/opt/anaconda3/envs/elyra-dev/lib/python3.8/site-packages/jupyter_client-7.0.2.dist-info']`

I think we should treat this as a HOTFIX since it appears to be occurring at a high enough frequency.

If anyone has ideas for what causes a previous distribution to remain, that would be helpful.