### PR TITLE
Fix NaN and Inf serialization

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -12,7 +12,6 @@ Sessions.
 # Distributed under the terms of the Modified BSD License.
 import hashlib
 import hmac
-import json
 import logging
 import os
 import pickle
@@ -27,6 +26,7 @@ from hmac import (
     compare_digest,
 )  # We are using compare_digest to limit the surface of timing attacks
 
+import simplejson as json
 import zmq
 from traitlets import Any  # type: ignore
 from traitlets import Bool
@@ -96,7 +96,7 @@ def json_packer(obj):
         obj,
         default=json_default,
         ensure_ascii=False,
-        allow_nan=False,
+        ignore_nan=True,
     ).encode("utf8")
 
 

--- a/jupyter_client/tests/test_jsonutil.py
+++ b/jupyter_client/tests/test_jsonutil.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 import datetime
 import json
+import math
 import numbers
 from datetime import timedelta
 from unittest import mock
@@ -12,6 +13,7 @@ from dateutil.tz import tzlocal
 from dateutil.tz import tzoffset
 
 from jupyter_client import jsonutil
+from jupyter_client.session import json_packer
 from jupyter_client.session import utcnow
 
 REFERENCE_DATETIME = datetime.datetime(2013, 7, 3, 16, 34, 52, 249482, tzlocal())
@@ -128,3 +130,9 @@ def test_json_default():
         out = json.loads(json.dumps(val, default=jsonutil.json_default))
         # validate our cleanup
         assert out == jval
+
+
+def test_json_packer():
+    assert json_packer(math.nan) == b'null'
+    assert json_packer(math.inf) == b'null'
+    assert json_packer(-math.inf) == b'null'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ jupyter_core>=4.6.0
 nest-asyncio>=1.5
 python-dateutil>=2.1
 pyzmq>=13
+simplejson
 tornado>=4.1
 traitlets


### PR DESCRIPTION
cc. @SylvainCorlay @minrk 

This is fixing serialization of `math.nan` and `math.inf`, preventing: `ValueError: Out of range float values are not JSON compliant`

We used to clean NaNs and Inf in `json_clean` from ipykernel before serializing them, but since https://github.com/ipython/ipykernel/pull/708 we need to take care of them