### PR TITLE
Fallback to the old ipykernel "json_clean" if we are not able to serialize a JSON message

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -102,18 +102,21 @@ def json_packer(obj):
         ).encode("utf8")
     except ValueError as e:
         # Fallback to trying to clean the json before serializing
+        packed = json.dumps(
+            json_clean(obj),
+            default=json_default,
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf8")
+
         warnings.warn(
             f"Message serialization failed with:\n{e}\n"
             "Supporting this message is deprecated in jupyter-client 7, please make "
             "sure your message is JSON-compliant",
             stacklevel=2,
         )
-        return json.dumps(
-            json_clean(obj),
-            default=json_default,
-            ensure_ascii=False,
-            allow_nan=False,
-        ).encode("utf8")
+
+        return packed
 
 
 def json_unpacker(s):

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -104,7 +104,7 @@ def json_packer(obj):
         # Fallback to trying to clean the json before serializing
         warnings.warn(
             f"Message serialization failed with:\n{e}\n"
-            "Supporting this message is deprecated, please make "
+            "Supporting this message is deprecated in jupyter-client 7, please make "
             "sure your message is JSON-compliant",
             stacklevel=2,
         )


### PR DESCRIPTION
As discussed in https://github.com/jupyter/jupyter_client/pull/706#discussion_r719308921

Fix https://github.com/jupyter-widgets/pythreejs/issues/366 and fix https://github.com/jupyter/jupyter_client/issues/701