### PR TITLE
Avoid trying to set the sticky bit of a regular file

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -167,7 +167,7 @@ def write_connection_file(
     if hasattr(stat, "S_ISVTX"):
         # set the sticky bit on the file and its parent directory
         # to avoid periodic cleanup
-        paths = [fname]
+        paths = []
         runtime_dir = os.path.dirname(fname)
         if runtime_dir:
             paths.append(runtime_dir)


### PR DESCRIPTION
As it is , the paths list starts with the saved .json file, subsequently setting the sticky bit of its directory. There is no need to set the sticky bit of a regular file, it only generates otherwise a harmless message. No modern UNIX(-like) OS supports sticky bit functionality now, as far as I am aware.