### PR TITLE
Add support for pending kernels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,7 @@ jobs:
           pip freeze
 
       - name: Check types
+        if: ${{ matrix.python-version != '3.6' }}
         run: mypy jupyter_client --exclude '\/tests|kernelspecapp|ioloop|runapp' --install-types --non-interactive
 
       - name: Run the tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,6 @@ jobs:
           pip freeze
 
       - name: Check types
-        if: ${{ matrix.python-version != '3.6' }}
         run: mypy jupyter_client --exclude '\/tests|kernelspecapp|ioloop|runapp' --install-types --non-interactive
 
       - name: Run the tests

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -493,18 +493,21 @@ class KernelManager(ConnectionFileMixin):
             Any options specified here will overwrite those used to launch the
             kernel.
         """
+        if self._launch_args is None:
+            raise RuntimeError("Cannot restart the kernel. " "No previous call to 'start_kernel'.")
+
         if not self._ready.done():
-            raise RuntimeError("Cannot restart the kernel. " "Kernel has been not fully started.")
-        else:
-            # Stop currently running kernel.
-            await ensure_async(self.shutdown_kernel(now=now, restart=True))
+            raise RuntimeError("Cannot restart the kernel. " "Kernel has not fully started.")
 
-            if newports:
-                self.cleanup_random_ports()
+        # Stop currently running kernel.
+        await ensure_async(self.shutdown_kernel(now=now, restart=True))
 
-            # Start new kernel.
-            self._launch_args.update(kw)
-            await ensure_async(self.start_kernel(**self._launch_args))
+        if newports:
+            self.cleanup_random_ports()
+
+        # Start new kernel.
+        self._launch_args.update(kw)
+        await ensure_async(self.start_kernel(**self._launch_args))
 
     restart_kernel = run_sync(_async_restart_kernel)
 

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -188,6 +188,8 @@ class TestKernelManager:
     def test_lifecycle(self, km):
         km.start_kernel(stdout=PIPE, stderr=PIPE)
         assert km.is_alive()
+        is_done = km.ready.done()
+        assert is_done
         km.restart_kernel(now=True)
         assert km.is_alive()
         km.interrupt_kernel()
@@ -439,6 +441,8 @@ class TestAsyncKernelManager:
         await async_km.start_kernel(stdout=PIPE, stderr=PIPE)
         is_alive = await async_km.is_alive()
         assert is_alive
+        is_ready = async_km.ready.done()
+        assert is_ready
         await async_km.restart_kernel(now=True)
         is_alive = await async_km.is_alive()
         assert is_alive

--- a/jupyter_client/tests/test_kernelspec.py
+++ b/jupyter_client/tests/test_kernelspec.py
@@ -18,30 +18,18 @@ from tempfile import TemporaryDirectory
 import pytest
 from jupyter_core import paths
 
+from .utils import install_kernel
+from .utils import sample_kernel_json
 from .utils import test_env
 from jupyter_client import kernelspec
 
-sample_kernel_json = {
-    "argv": ["cat", "{connection_file}"],
-    "display_name": "Test kernel",
-}
-
 
 class KernelSpecTests(unittest.TestCase):
-    def _install_sample_kernel(self, kernels_dir):
-        """install a sample kernel in a kernels directory"""
-        sample_kernel_dir = pjoin(kernels_dir, "sample")
-        os.makedirs(sample_kernel_dir)
-        json_file = pjoin(sample_kernel_dir, "kernel.json")
-        with open(json_file, "w") as f:
-            json.dump(sample_kernel_json, f)
-        return sample_kernel_dir
-
     def setUp(self):
         self.env_patch = test_env()
         self.env_patch.start()
-        self.sample_kernel_dir = self._install_sample_kernel(
-            pjoin(paths.jupyter_data_dir(), "kernels")
+        self.sample_kernel_dir = install_kernel(
+            pjoin(paths.jupyter_data_dir(), "kernels"), name="sample"
         )
 
         self.ksm = kernelspec.KernelSpecManager()
@@ -87,7 +75,7 @@ class KernelSpecTests(unittest.TestCase):
     def test_kernel_spec_priority(self):
         td = TemporaryDirectory()
         self.addCleanup(td.cleanup)
-        sample_kernel = self._install_sample_kernel(td.name)
+        sample_kernel = install_kernel(td.name, name="sample")
         self.ksm.kernel_dirs.append(td.name)
         kernels = self.ksm.find_kernel_specs()
         self.assertEqual(kernels["sample"], self.sample_kernel_dir)

--- a/jupyter_client/tests/utils.py
+++ b/jupyter_client/tests/utils.py
@@ -1,6 +1,7 @@
 """Testing utils for jupyter_client tests
 
 """
+import json
 import os
 import sys
 from tempfile import TemporaryDirectory
@@ -17,6 +18,26 @@ from jupyter_client import MultiKernelManager
 pjoin = os.path.join
 
 skip_win32 = pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows")
+
+
+sample_kernel_json = {
+    "argv": ["cat", "{connection_file}"],
+    "display_name": "Test kernel",
+}
+
+
+def install_kernel(kernels_dir, argv=None, name="test", display_name=None):
+    """install a kernel in a kernels directory"""
+    kernel_dir = pjoin(kernels_dir, name)
+    os.makedirs(kernel_dir)
+    kernel_json = {
+        "argv": argv or sample_kernel_json["argv"],
+        "display_name": display_name or sample_kernel_json["display_name"],
+    }
+    json_file = pjoin(kernel_dir, "kernel.json")
+    with open(json_file, "w") as f:
+        json.dump(kernel_json, f)
+    return kernel_dir
 
 
 class test_env(object):


### PR DESCRIPTION
Add `MultiKernelManager.use_pending_kernels` to use a created kernel before the process has started, based on original discussion in [`jupyter_server`](https://github.com/jupyter-server/jupyter_server/issues/592).

Add a `KernelManager.ready` property to that resolves when the process has started for the first time.

Refuse to restart a kernel that has not been fully started - we could also decide to wait if it has been launched but not fully started.

Consumers using `use_pending_kernels` should wait for the `ready` future before attempting to communicate with the kernel.

This change will correspond to a change in [`jupyter_server`](https://github.com/jupyter-server/jupyter_server/pull/593), where the server will use the `ready` future before connecting the websocket.  

Web clients will have to be updated to handle errors on WebSocket startup and surface them to the user.

As a result, the use of `use_pending_kernels` will be opt-in for now.

- [x] Add `MultiKernelManager.use_pending_kernels`
- [x] Add `KernelManager.ready`
- [x] Make sure a kernel that died at startup can be handled in `MultiKernelManager.shutdown_all`
- [x] Add test for bad kernelspec causing startup errors
- [x] Make sure existing tests pass
- [x] Verify functionality in `jupyter_server` - https://github.com/jupyter-server/jupyter_server/pull/593
- [x] Verify functionality in `JupyterLab` - https://github.com/jupyterlab/jupyterlab/pull/11358
