### PR TITLE
Improve restarter logic

### DIFF
--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -92,8 +92,13 @@ class AsyncIOLoopKernelRestarter(IOLoopKernelRestarter):
             # restarter. Therefore, we use "has been alive continuously for X time" as a
             # heuristic for a stable start up.
             # See https://github.com/jupyter/jupyter_client/pull/717 for details.
-            if self._initial_startup and self._last_dead - now >= self.stable_start_time:
+            stable_start_time = self.stable_start_time
+            if self.kernel_manager.provisioner:
+                stable_start_time = self.kernel_manager.provisioner.get_stable_start_time(
+                    recommended=stable_start_time
+                )
+            if self._initial_startup and self._last_dead - now >= stable_start_time:
                 self._initial_startup = False
-            if self._restarting and self._last_dead - now >= self.stable_start_time:
+            if self._restarting and self._last_dead - now >= stable_start_time:
                 self.log.debug("AsyncIOLoopKernelRestarter: restart apparently succeeded")
                 self._restarting = False

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -85,6 +85,13 @@ class AsyncIOLoopKernelRestarter(IOLoopKernelRestarter):
                 await self.kernel_manager.restart_kernel(now=True, newports=newports)
                 self._restarting = True
         else:
+            # Since `is_alive` only tests that the kernel process is alive, it does not
+            # indicate that the kernel has successfully completed startup. To solve this
+            # correctly, we would need to wait for a kernel info reply, but it is not
+            # necessarily appropriate to start a kernel client + channels in the
+            # restarter. Therefore, we use "has been alive continuously for X time" as a
+            # heuristic for a stable start up.
+            # See https://github.com/jupyter/jupyter_client/pull/717 for details.
             if self._initial_startup and self._last_dead - now >= self.stable_start_time:
                 self._initial_startup = False
             if self._restarting and self._last_dead - now >= self.stable_start_time:

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -206,12 +206,21 @@ class KernelProvisionerBase(ABC, LoggingConfigurable, metaclass=KernelProvisione
 
     def get_shutdown_wait_time(self, recommended: float = 5.0) -> float:
         """
-        Returns the time allowed for a complete shutdown.  This may vary by provisioner.
+        Returns the time allowed for a complete shutdown. This may vary by provisioner.
 
         This method is called from `KernelManager.finish_shutdown()` during the graceful
         phase of its kernel shutdown sequence.
 
         The recommended value will typically be what is configured in the kernel manager.
+        """
+        return recommended
+
+    def get_stable_start_time(self, recommended: float = 10.0) -> float:
+        """
+        Returns the expected upper bound for a kernel (re-)start to complete.
+        This may vary by provisioner.
+
+        The recommended value will typically be what is configured in the kernel restarter.
         """
         return recommended
 

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -155,8 +155,8 @@ class KernelRestarter(LoggingConfigurable):
                 stable_start_time = self.kernel_manager.provisioner.get_stable_start_time(
                     recommended=stable_start_time
                 )
-            if self._initial_startup and self._last_dead - now >= stable_start_time:
+            if self._initial_startup and now - self._last_dead >= stable_start_time:
                 self._initial_startup = False
-            if self._restarting and self._last_dead - now >= stable_start_time:
+            if self._restarting and now - self._last_dead >= stable_start_time:
                 self.log.debug("KernelRestarter: restart apparently succeeded")
                 self._restarting = False

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -143,6 +143,13 @@ class KernelRestarter(LoggingConfigurable):
                 self.kernel_manager.restart_kernel(now=True, newports=newports)
                 self._restarting = True
         else:
+            # Since `is_alive` only tests that the kernel process is alive, it does not
+            # indicate that the kernel has successfully completed startup. To solve this
+            # correctly, we would need to wait for a kernel info reply, but it is not
+            # necessarily appropriate to start a kernel client + channels in the
+            # restarter. Therefore, we use "has been alive continuously for X time" as a
+            # heuristic for a stable start up.
+            # See https://github.com/jupyter/jupyter_client/pull/717 for details.
             if self._initial_startup and self._last_dead - now >= self.stable_start_time:
                 self._initial_startup = False
             if self._restarting and self._last_dead - now >= self.stable_start_time:

--- a/jupyter_client/restarter.py
+++ b/jupyter_client/restarter.py
@@ -150,8 +150,13 @@ class KernelRestarter(LoggingConfigurable):
             # restarter. Therefore, we use "has been alive continuously for X time" as a
             # heuristic for a stable start up.
             # See https://github.com/jupyter/jupyter_client/pull/717 for details.
-            if self._initial_startup and self._last_dead - now >= self.stable_start_time:
+            stable_start_time = self.stable_start_time
+            if self.kernel_manager.provisioner:
+                stable_start_time = self.kernel_manager.provisioner.get_stable_start_time(
+                    recommended=stable_start_time
+                )
+            if self._initial_startup and self._last_dead - now >= stable_start_time:
                 self._initial_startup = False
-            if self._restarting and self._last_dead - now >= self.stable_start_time:
+            if self._restarting and self._last_dead - now >= stable_start_time:
                 self.log.debug("KernelRestarter: restart apparently succeeded")
                 self._restarting = False

--- a/jupyter_client/tests/problemkernel.py
+++ b/jupyter_client/tests/problemkernel.py
@@ -2,10 +2,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import os
-import signal
 import time
-from subprocess import PIPE
-from subprocess import Popen
 
 from ipykernel.displayhook import ZMQDisplayHook
 from ipykernel.kernelapp import IPKernelApp

--- a/jupyter_client/tests/problemkernel.py
+++ b/jupyter_client/tests/problemkernel.py
@@ -1,0 +1,42 @@
+"""Test kernel for signalling subprocesses"""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import os
+import signal
+import time
+from subprocess import PIPE
+from subprocess import Popen
+
+from ipykernel.displayhook import ZMQDisplayHook
+from ipykernel.kernelapp import IPKernelApp
+from ipykernel.kernelbase import Kernel
+
+
+class ProblemTestKernel(Kernel):
+    """Kernel for testing kernel problems"""
+
+    implementation = "problemtest"
+    implementation_version = "0.0"
+    banner = ""
+
+
+class ProblemTestApp(IPKernelApp):
+    kernel_class = ProblemTestKernel
+
+    def init_io(self):
+        # Overridden to disable stdout/stderr capture
+        self.displayhook = ZMQDisplayHook(self.session, self.iopub_socket)
+
+    def init_sockets(self):
+        if os.environ.get("FAIL_ON_START") == "1":
+            # Simulates e.g. a port binding issue (Adress already in use)
+            raise RuntimeError("Failed for testing purposes")
+        return super().init_sockets()
+
+
+if __name__ == "__main__":
+    # make startup artificially slow,
+    # so that we exercise client logic for slow-starting kernels
+    startup_delay = int(os.environ.get("STARTUP_DELAY", "2"))
+    time.sleep(startup_delay)
+    ProblemTestApp.launch_instance()

--- a/jupyter_client/tests/test_restarter.py
+++ b/jupyter_client/tests/test_restarter.py
@@ -80,7 +80,7 @@ def debug_logging():
 
 
 @pytest.mark.asyncio
-async def test_restart_check(config, install_kernel):
+async def test_restart_check(config, install_kernel, debug_logging):
     """Test that the kernel is restarted and recovers"""
     # If this test failes, run it with --log-cli-level=DEBUG to inspect
     N_restarts = 1
@@ -116,6 +116,15 @@ async def test_restart_check(config, install_kernel):
                 # Kill without cleanup to simulate crash:
                 await km.provisioner.kill()
                 await restarts[i]
+                # Wait for kill + restart
+                max_wait = 10.0
+                waited = 0.0
+                while waited < max_wait and km.is_alive():
+                    await asyncio.sleep(0.1)
+                    waited += 0.1
+                while waited < max_wait and not km.is_alive():
+                    await asyncio.sleep(0.1)
+                    waited += 0.1
 
         assert cbs == N_restarts
         assert km.is_alive()
@@ -127,7 +136,7 @@ async def test_restart_check(config, install_kernel):
 
 
 @pytest.mark.asyncio
-async def test_restarter_gives_up(config, install_fail_kernel):
+async def test_restarter_gives_up(config, install_fail_kernel, debug_logging):
     """Test that the restarter gives up after reaching the restart limit"""
     # If this test failes, run it with --log-cli-level=DEBUG to inspect
     N_restarts = 1
@@ -173,7 +182,7 @@ async def test_restarter_gives_up(config, install_fail_kernel):
 
 
 @pytest.mark.asyncio
-async def test_async_restart_check(config, install_kernel):
+async def test_async_restart_check(config, install_kernel, debug_logging):
     """Test that the kernel is restarted and recovers"""
     # If this test failes, run it with --log-cli-level=DEBUG to inspect
     N_restarts = 1
@@ -209,6 +218,15 @@ async def test_async_restart_check(config, install_kernel):
                 # Kill without cleanup to simulate crash:
                 await km.provisioner.kill()
                 await restarts[i]
+                # Wait for kill + restart
+                max_wait = 10.0
+                waited = 0.0
+                while waited < max_wait and await km.is_alive():
+                    await asyncio.sleep(0.1)
+                    waited += 0.1
+                while waited < max_wait and not await km.is_alive():
+                    await asyncio.sleep(0.1)
+                    waited += 0.1
 
         assert cbs == N_restarts
         assert await km.is_alive()
@@ -220,7 +238,7 @@ async def test_async_restart_check(config, install_kernel):
 
 
 @pytest.mark.asyncio
-async def test_async_restarter_gives_up(config, install_slow_fail_kernel):
+async def test_async_restarter_gives_up(config, install_slow_fail_kernel, debug_logging):
     """Test that the restarter gives up after reaching the restart limit"""
     # If this test failes, run it with --log-cli-level=DEBUG to inspect
     N_restarts = 2

--- a/jupyter_client/tests/test_restarter.py
+++ b/jupyter_client/tests/test_restarter.py
@@ -1,0 +1,261 @@
+"""Tests for the KernelManager"""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import asyncio
+import concurrent.futures
+import json
+import os
+import signal
+import sys
+import time
+from subprocess import PIPE
+
+import pytest
+from jupyter_core import paths
+from traitlets.config.loader import Config
+from traitlets.log import get_logger
+
+from jupyter_client import AsyncKernelManager
+from jupyter_client.ioloop import AsyncIOLoopKernelManager, IOLoopKernelManager
+from ..manager import start_new_async_kernel
+from ..manager import start_new_kernel
+
+pjoin = os.path.join
+
+def _install_kernel(name="problemtest", extra_env=None):
+    if extra_env is None:
+        extra_env = dict()
+    kernel_dir = pjoin(paths.jupyter_data_dir(), "kernels", name)
+    os.makedirs(kernel_dir)
+    with open(pjoin(kernel_dir, "kernel.json"), "w") as f:
+        f.write(
+            json.dumps(
+                {
+                    "argv": [
+                        sys.executable,
+                        "-m",
+                        "jupyter_client.tests.problemkernel",
+                        "-f",
+                        "{connection_file}",
+                    ],
+                    "display_name": "Problematic Test Kernel",
+                    "env": {"TEST_VARS": "${TEST_VARS}:test_var_2", **extra_env},
+                }
+            )
+        )
+    return name
+
+@pytest.fixture
+def install_kernel():
+    return _install_kernel("problemtest")
+
+@pytest.fixture
+def install_fail_kernel():
+    return _install_kernel("problemtest-fail", extra_env={
+        "FAIL_ON_START": "1"
+    })
+
+@pytest.fixture
+def install_slow_fail_kernel():
+    return _install_kernel("problemtest-slow", extra_env={
+        "STARTUP_DELAY": "5",
+        "FAIL_ON_START": "1"
+    })
+
+@pytest.fixture(params=["tcp", "ipc"])
+def transport(request):
+    if sys.platform == "win32" and request.param == "ipc":  #
+        pytest.skip("Transport 'ipc' not supported on Windows.")
+    return request.param
+
+@pytest.fixture
+def config(transport):
+    c = Config()
+    c.KernelManager.transport = transport
+    if transport == "ipc":
+        c.KernelManager.ip = "test"
+    return c
+
+@pytest.fixture
+def debug_logging():
+    get_logger().setLevel("DEBUG")
+
+
+@pytest.mark.asyncio
+async def test_restart_check(config, install_kernel):
+    """Test that the kernel is restarted and recovers"""
+    # If this test failes, run it with --log-cli-level=DEBUG to inspect
+    N_restarts = 1
+    config.KernelRestarter.restart_limit = N_restarts
+    config.KernelRestarter.debug = True
+    km = IOLoopKernelManager(kernel_name=install_kernel, config=config)
+
+    cbs = 0
+    restarts = [asyncio.Future() for i in range(N_restarts)]
+    def cb():
+        nonlocal cbs
+        if cbs >= N_restarts:
+            raise RuntimeError("Kernel restarted more than %d times!" % N_restarts)
+        restarts[cbs].set_result(True)
+        cbs += 1
+
+    try:
+        km.start_kernel()
+        km.add_restart_callback(cb, 'restart')
+    except:
+        if km.has_kernel:
+            km.shutdown_kernel()
+        raise
+
+    try:
+        for i in range(N_restarts + 1):
+            kc = km.client()
+            kc.start_channels()
+            kc.wait_for_ready(timeout=60)
+            kc.stop_channels()
+            if i < N_restarts:
+                # Kill without cleanup to simulate crash:
+                await km.provisioner.kill()
+                await restarts[i]
+
+        assert cbs == N_restarts
+        assert km.is_alive()
+
+    finally:
+
+        km.shutdown_kernel(now=True)
+        assert km.context.closed
+
+@pytest.mark.asyncio
+async def test_restarter_gives_up(config, install_fail_kernel):
+    """Test that the restarter gives up after reaching the restart limit"""
+    # If this test failes, run it with --log-cli-level=DEBUG to inspect
+    N_restarts = 1
+    config.KernelRestarter.restart_limit = N_restarts
+    config.KernelRestarter.debug = True
+    km = IOLoopKernelManager(kernel_name=install_fail_kernel, config=config)
+
+    cbs = 0
+    restarts = [asyncio.Future() for i in range(N_restarts)]
+    def cb():
+        nonlocal cbs
+        if cbs >= N_restarts:
+            raise RuntimeError("Kernel restarted more than %d times!" % N_restarts)
+        restarts[cbs].set_result(True)
+        cbs += 1
+
+    died = asyncio.Future()
+    def on_death():
+        died.set_result(True)
+
+    try:
+        km.start_kernel()
+        km.add_restart_callback(cb, 'restart')
+        km.add_restart_callback(on_death, 'dead')
+    except:
+        if km.has_kernel:
+            km.shutdown_kernel()
+        raise
+
+    try:
+        for i in range(N_restarts):
+            await restarts[i]
+
+        assert await died
+        assert cbs == N_restarts
+
+    finally:
+
+        km.shutdown_kernel(now=True)
+        assert km.context.closed
+
+
+@pytest.mark.asyncio
+async def test_async_restart_check(config, install_kernel):
+    """Test that the kernel is restarted and recovers"""
+    # If this test failes, run it with --log-cli-level=DEBUG to inspect
+    N_restarts = 1
+    config.KernelRestarter.restart_limit = N_restarts
+    config.KernelRestarter.debug = True
+    km = AsyncIOLoopKernelManager(kernel_name=install_kernel, config=config)
+
+    cbs = 0
+    restarts = [asyncio.Future() for i in range(N_restarts)]
+    def cb():
+        nonlocal cbs
+        if cbs >= N_restarts:
+            raise RuntimeError("Kernel restarted more than %d times!" % N_restarts)
+        restarts[cbs].set_result(True)
+        cbs += 1
+
+    try:
+        await km.start_kernel()
+        km.add_restart_callback(cb, 'restart')
+    except:
+        if km.has_kernel:
+            await km.shutdown_kernel()
+        raise
+
+    try:
+        for i in range(N_restarts + 1):
+            kc = km.client()
+            kc.start_channels()
+            await kc.wait_for_ready(timeout=60)
+            kc.stop_channels()
+            if i < N_restarts:
+                # Kill without cleanup to simulate crash:
+                await km.provisioner.kill()
+                await restarts[i]
+
+        assert cbs == N_restarts
+        assert await km.is_alive()
+
+    finally:
+
+        await km.shutdown_kernel(now=True)
+        assert km.context.closed
+
+@pytest.mark.asyncio
+async def test_async_restarter_gives_up(config, install_slow_fail_kernel):
+    """Test that the restarter gives up after reaching the restart limit"""
+    # If this test failes, run it with --log-cli-level=DEBUG to inspect
+    N_restarts = 2
+    config.KernelRestarter.restart_limit = N_restarts
+    config.KernelRestarter.debug = True
+    config.KernelRestarter.stable_start_time = 30.
+    km = AsyncIOLoopKernelManager(kernel_name=install_slow_fail_kernel, config=config)
+
+    cbs = 0
+    restarts = [asyncio.Future() for i in range(N_restarts)]
+    def cb():
+        nonlocal cbs
+        if cbs >= N_restarts:
+            raise RuntimeError("Kernel restarted more than %d times!" % N_restarts)
+        restarts[cbs].set_result(True)
+        cbs += 1
+
+    died = asyncio.Future()
+    def on_death():
+        died.set_result(True)
+
+    try:
+        await km.start_kernel()
+        km.add_restart_callback(cb, 'restart')
+        km.add_restart_callback(on_death, 'dead')
+    except:
+        if km.has_kernel:
+            await km.shutdown_kernel()
+        raise
+
+    try:
+        await asyncio.gather(*restarts)
+
+        assert await died
+        assert cbs == N_restarts
+
+    finally:
+
+        await km.shutdown_kernel(now=True)
+        assert km.context.closed
+


### PR DESCRIPTION
Resolves #715.

There is a small change in the behavior of `KernelRestarter.poll()` and the async variant that should be considered whether it is appropriate (or if a better alternative exists). I.e. https://github.com/jupyter/jupyter_client/commit/2fabf92276dc56823cdf18691556e9a2aea37152 . The other parts should be uncontroversial.