### PR TITLE
Fix asyncio error when opening notebooks

### DIFF
--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -7,6 +7,10 @@ import asyncio
 import inspect
 import os
 
+import nest_asyncio  # type: ignore
+
+nest_asyncio.apply()
+
 
 def run_sync(coro):
     def wrapped(*args, **kwargs):
@@ -15,7 +19,6 @@ def run_sync(coro):
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        import nest_asyncio  # type: ignore
 
         nest_asyncio.apply(loop)
         future = asyncio.ensure_future(coro(*args, **kwargs))


### PR DESCRIPTION
This is a fix for https://github.com/jupyter/notebook/issues/6164

We are only applying `nest_asyncio` when `run_sync` has been called
which means there could be tasks queued that are unpatched e.g. from
the original issue:

```
<Task pending coro=<HTTP1ServerConnection._server_request_loop() running at /apps/python3/lib/python3.7/site-packages/tornado/http1connection.py:823>
```
which originates from Tornado.

A similar issue was reported in `nest-asyncio`: https://github.com/erdewit/nest_asyncio/issues/22
where the solution is to call `apply` on import so that unpatched tasks
do not get created.