### PR TITLE
Test against all kernels in jupyter kernel test and clean up CI

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -17,38 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-          architecture: "x64"
-      - name: Install node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: Cache pip
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-pip-
-      - name: Cache checked links
-        if: ${{ matrix.group == 'link_check' }}
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pytest-link-check
-          key: ${{ runner.os }}-linkcheck-${{ hashFiles('**/*.md', '**/*.rst') }}-md-links
-          restore-keys: |
-            ${{ runner.os }}-linkcheck-
-      - name: Upgrade packaging dependencies
-        run: |
-          pip install --upgrade pip setuptools wheel --user
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install Dependencies
         run: |
           pip install -e .

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: "3.9"
+        python-version: ["3.9"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: "3.9"
 
     steps:
       - name: Checkout

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           auto-update-conda: true
           activate-environment: jupyter_kernel_test
+          miniforge-variant: Mambaforge
           python-version: ${{ matrix.python-version }}
 
       - name: Test jupyter_kernel_test

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           package_name: jupyter_server
 
+      # Test using jupyter_kernel_test
+
       - name: Setup conda ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -58,5 +60,6 @@ jobs:
           git clone https://github.com/jupyter/jupyter_kernel_test.git
           cd jupyter_kernel_test
           conda env update --name jupyter_kernel_test --file environment.yml
+          conda install -c conda-forge xeus-cling
           pip install -e ".[test]"
           python -m unittest -v

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -45,9 +45,18 @@ jobs:
         with:
           package_name: jupyter_server
 
+      - name: Setup conda ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          activate-environment: jupyter_kernel_test
+          python-version: ${{ matrix.python-version }}
+
       - name: Test jupyter_kernel_test
+        shell: bash -l {0}
         run: |
           git clone https://github.com/jupyter/jupyter_kernel_test.git
           cd jupyter_kernel_test
+          conda env update --name jupyter_kernel_test --file environment.yml
           pip install -e ".[test]"
-          python test_ipykernel.py
+          python -m unittest -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "pypy-3.7"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     env:
       OS: ${{ matrix.os }}
@@ -90,12 +90,7 @@ jobs:
         run: mypy jupyter_client --exclude '\/tests|kernelspecapp|ioloop|runapp' --install-types --non-interactive
 
       - name: Run the tests with coverage
-        if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: pytest --cov jupyter_client -v jupyter_client
-
-      - name: Run the tests on pypy
-        if: startsWith(matrix.python-version, 'pypy')
-        run: pytest -v jupyter_client
 
       - name: Build the docs
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/base-setup@v1
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
         run: |
@@ -89,8 +89,13 @@ jobs:
       - name: Check types
         run: mypy jupyter_client --exclude '\/tests|kernelspecapp|ioloop|runapp' --install-types --non-interactive
 
-      - name: Run the tests
+      - name: Run the tests with coverage
+        if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: pytest --cov jupyter_client -v jupyter_client
+
+      - name: Run the tests on pypy
+        if: startsWith(matrix.python-version, 'pypy')
+        run: pytest -v jupyter_client
 
       - name: Build the docs
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "pypy-3.7"]
 
     env:
       OS: ${{ matrix.os }}
@@ -78,33 +78,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Update pip
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade wheel setuptools
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.pip-cache.outputs.dir }}
-            .mypy_cache
-          key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements*.txt') }}-git-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements*.txt') }}
-            ${{ runner.os }}-python-${{ matrix.python-version }}-pip-
-            ${{ runner.os }}-python
-            ${{ runner.os }}-
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/base-setup@v1
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
- Fixes #728 
- Adds testing against Python 3.10
- Uses `base-setup` from `jupyterlab/maintainer-tools` for cleanup