### PR TITLE
Further improvements to pending kernels managment

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -22,14 +21,12 @@ jobs:
 
       - name: Test IPykernel
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
-        continue-on-error: true
         with:
           package_name: ipykernel
           package_spec: "pyqt5 ipykernel[test]"
 
       - name: Test NBClient
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
-        continue-on-error: true
         with:
           package_name: nbclient
           env_values: IPYKERNEL_CELL_NAME=\<IPY-INPUT\>
@@ -42,7 +39,6 @@ jobs:
 
       - name: Test nbconvert
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
-        continue-on-error: true
         with:
           package_name: nbconvert
 
@@ -55,7 +51,6 @@ jobs:
 
       - name: Setup conda ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
-        continue-on-error: true
         with:
           auto-update-conda: true
           activate-environment: jupyter_kernel_test

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -22,12 +22,14 @@ jobs:
 
       - name: Test IPykernel
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        continue-on-error: true
         with:
           package_name: ipykernel
           package_spec: "pyqt5 ipykernel[test]"
 
       - name: Test NBClient
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        continue-on-error: true
         with:
           package_name: nbclient
           env_values: IPYKERNEL_CELL_NAME=\<IPY-INPUT\>
@@ -40,6 +42,7 @@ jobs:
 
       - name: Test nbconvert
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        continue-on-error: true
         with:
           package_name: nbconvert
 
@@ -52,6 +55,7 @@ jobs:
 
       - name: Setup conda ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
+        continue-on-error: true
         with:
           auto-update-conda: true
           activate-environment: jupyter_kernel_test

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ with Jupyter kernels.
    kernels
    wrapperkernels
    provisioning
+   pending-kernels
 
 .. toctree::
    :maxdepth: 2

--- a/docs/pending-kernels.rst
+++ b/docs/pending-kernels.rst
@@ -1,0 +1,36 @@
+Pending Kernels
+===============
+
+*Added in 7.1.0*
+
+In scenarios where an kernel takes a long time to start (e.g. kernels running remotely), it can be advantageous to immediately return the kernel's model and ID from key methods like ``.start_kernel()`` and ``.shutdown_kernel()``. The kernel will continue its task without blocking other managerial actions.
+
+This intermediate state is called a **"pending kernel"**.
+
+How they work
+-------------
+
+When ``.start_kernel()`` or ``.shutdown_kernel()`` is called, a ``Future`` is created under the ``KernelManager.ready`` property. This property can be awaited anytime to ensure that the kernel moves out of its pending state, e.g.:
+
+.. code-block:: python
+
+    # await a Kernel Manager's `.ready` property to
+    # block further action until the kernel is out
+    # of its pending state.
+    await kernel_manager.ready
+
+Once the kernel is finished pending, ``.ready.done()`` will be ``True`` and either 1) ``.ready.result()`` will return ``None`` or 2) ``.ready.exception()`` will return a raised exception
+
+Using pending kernels
+---------------------
+
+The most common way to interact with pending kernels is through the ``MultiKernelManager``—the object that manages a collection of kernels—by setting its ``use_pending_kernels`` trait to ``True``. Pending kernels are "opt-in"; they are not used by default in the ``MultiKernelManager``.
+
+When ``use_pending_kernels`` is ``True``, the following changes are made to the ``MultiKernelManager``:
+
+1. ``start_kernel`` and ``stop_kernel`` return immediately while running the pending task in a background thread.
+2. The following methods raise a ``RuntimeError`` if a kernel is pending:
+    * ``restart_kernel``
+    * ``interrupt_kernel``
+    * ``shutdown_kernel``
+3. ``shutdown_all`` will wait for all pending kernels to become ready before attempting to shut them down.

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -76,6 +76,7 @@ def in_pending_state(method):
         except Exception as e:
             self._ready.set_exception(e)
             self.log.exception(self._ready.exception())
+            raise e
 
     return wrapper
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -485,7 +485,6 @@ class KernelManager(ConnectionFileMixin):
 
         await ensure_async(self.cleanup_resources(restart=restart))
 
-
     shutdown_kernel = run_sync(_async_shutdown_kernel)
 
     async def _async_restart_kernel(self, now: bool = False, newports: bool = False, **kw) -> None:

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -2,8 +2,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import asyncio
-import os
 import functools
+import os
 import re
 import signal
 import sys
@@ -57,6 +57,7 @@ def in_pending_state(method):
     creating a fresh Future for the KernelManager's `ready`
     attribute. Once the method is finished, set the Future's results.
     """
+
     @functools.wraps(method)
     async def wrapper(self, *args, **kwargs):
         # Create a future for the decorated method
@@ -75,6 +76,7 @@ def in_pending_state(method):
         except Exception as e:
             self._ready.set_exception(e)
             self.log.exception(self._ready.exception())
+
     return wrapper
 
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -89,6 +89,7 @@ class KernelManager(ConnectionFileMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
         self._shutdown_status = _ShutdownStatus.Unset
+        # Create a place holder future.
         try:
             self._ready = Future()
         except RuntimeError:

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -326,7 +326,6 @@ class MultiKernelManager(LoggingConfigurable):
 
     shutdown_all = run_sync(_async_shutdown_all)
 
-    # @kernel_method
     def interrupt_kernel(self, kernel_id: str) -> None:
         """Interrupt (SIGINT) the kernel by its uuid.
 

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -217,7 +217,7 @@ class MultiKernelManager(LoggingConfigurable):
             await fut
             # raise an exception if one occurred during kernel startup.
             if km.ready.exception():
-                raise km.ready.exception()
+                raise km.ready.exception()  # type: ignore
 
         return kernel_id
 

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -207,7 +207,6 @@ class MultiKernelManager(LoggingConfigurable):
         starter = ensure_async(km.start_kernel(**kwargs))
         fut = asyncio.ensure_future(self._add_kernel_when_ready(kernel_id, km, starter))
         self._pending_kernels[kernel_id] = fut
-
         # Handling a Pending Kernel
         if self._using_pending_kernels():
             # If using pending kernels, do not block


### PR DESCRIPTION
Two changes in this PR, summarized below. This work is a follow-up to #712 

### Make `shutdown_kernel` a pending state

Makes `shutdown_kernel` also show the kernel in a pending state. Since the KernelManager is still managing a process while it's shutting down, which might take a long time, I think this should show as a pending state too.

### Make `KernelManager` only responsible for reporting kernel pending state 

Also, after working with pending kernels a bit, I believe it makes the most sense to make the `KernelManager` responsible for _reporting_ the kernel's pending state, while the layer that sits above the KernelManager, e.g. `MultiKernelManager`, responsible for _reacting_ to that state.

This essentially means removing *all* `self.ready` checks in the individual KernelManager. For example, 
https://github.com/jupyter/jupyter_client/blob/30823666344c9d03daa7330a81caedd04a6a53a6/jupyter_client/manager.py#L455-L457
should be removed; rather, a MultiKernelManager whose `use_pending_kernels` attribute is `True` would determine if shutdown is a passthrough, etc. 

Another example is https://github.com/jupyter/jupyter_client/blob/30823666344c9d03daa7330a81caedd04a6a53a6/jupyter_client/manager.py#L506-L507
The MultiKernelManager would be responsible for handling what to do when a kernel restart happens while a kernel is in a pending state.