### PR TITLE
Update consoleapp.py

### DIFF
--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -86,6 +86,7 @@ app_aliases = dict(
     f="JupyterConsoleApp.connection_file",
     kernel="JupyterConsoleApp.kernel_name",
     ssh="JupyterConsoleApp.sshserver",
+    sshkey="JupyterConsoleApp.sshkey",
 )
 aliases.update(app_aliases)
 


### PR DESCRIPTION
Supporting setting sshkey via command line 

Example
```
jupyter qtconsole --existing C:\Users\<user>\qtconfig.json --ssh <user>@<host>:10022 --sshkey <key_path>
```