### PR TITLE
Await `kernel.ready` in `_async_shutdown_kernel`

### DIFF
--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -264,7 +264,8 @@ class MultiKernelManager(LoggingConfigurable):
             kernel = self._pending_kernels[kernel_id]
             try:
                 await kernel
-                await kernel.ready
+                km = self.get_kernel(kernel_id)
+                await km.ready
             except Exception:
                 self.remove_kernel(kernel_id)
                 return

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -260,10 +260,11 @@ class MultiKernelManager(LoggingConfigurable):
         if self._using_pending_kernels() and kernel_id in self._pending_kernels:
             raise RuntimeError("Kernel is in a pending state. Cannot shutdown.")
         # If the kernel is still starting, wait for it to be ready.
-        elif kernel_id in self._starting_kernels:
-            kernel = self._starting_kernels[kernel_id]
+        elif kernel_id in self._pending_kernels:
+            kernel = self._pending_kernels[kernel_id]
             try:
                 await kernel
+                await kernel.ready
             except Exception:
                 self.remove_kernel(kernel_id)
                 return


### PR DESCRIPTION
Attempt at fixing https://github.com/jupyterlab/jupyterlab/issues/11886.

According to the comment above:

https://github.com/jupyter/jupyter_client/blob/263173095ceab87a572937f21f843886ffe356f1/jupyter_client/multikernelmanager.py#L262

This branch of the code should be waiting for the kernel to be ready.

This change seems to be fixing the issue noticed in JupyterLab in https://github.com/jupyterlab/jupyterlab/issues/11886.

Example run: https://github.com/jupyterlab/jupyterlab/runs/4894046802?check_suite_focus=true from https://github.com/jupyterlab/jupyterlab/pull/11887