### PR TITLE
Prefer sending signals to kernel process group

### DIFF
--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -85,34 +85,54 @@ class LocalProvisioner(KernelProvisionerBase):
                     os.killpg(self.pgid, signum)
                     return
                 except OSError:
-                    pass
-            try:
-                self.process.send_signal(signum)
-            except OSError:
-                pass
+                    pass  # We'll retry sending the signal to only the process below
+
+            # If we're here, send the signal to the process and let caller handle exceptions
+            self.process.send_signal(signum)
             return
 
     async def kill(self, restart: bool = False) -> None:
         if self.process:
+            if hasattr(signal, "SIGKILL"):
+                # If available, give preference to signalling the process-group over `kill()`.
+                try:
+                    await self.send_signal(signal.SIGKILL)
+                    return
+                except OSError:
+                    pass
             try:
                 self.process.kill()
             except OSError as e:
-                # In Windows, we will get an Access Denied error if the process
-                # has already terminated. Ignore it.
-                if sys.platform == 'win32':
-                    if e.winerror != 5:
-                        raise
-                # On Unix, we may get an ESRCH error if the process has already
-                # terminated. Ignore it.
-                else:
-                    from errno import ESRCH
-
-                    if e.errno != ESRCH:
-                        raise
+                LocalProvisioner._tolerate_no_process(e)
 
     async def terminate(self, restart: bool = False) -> None:
         if self.process:
-            return self.process.terminate()
+            if hasattr(signal, "SIGTERM"):
+                # If available, give preference to signalling the process group over `terminate()`.
+                try:
+                    await self.send_signal(signal.SIGTERM)
+                    return
+                except OSError:
+                    pass
+            try:
+                self.process.terminate()
+            except OSError as e:
+                LocalProvisioner._tolerate_no_process(e)
+
+    @staticmethod
+    def _tolerate_no_process(os_error: OSError):
+        # In Windows, we will get an Access Denied error if the process
+        # has already terminated. Ignore it.
+        if sys.platform == 'win32':
+            if os_error.winerror != 5:
+                raise
+        # On Unix, we may get an ESRCH error (or ProcessLookupError instance) if
+        # the process has already terminated. Ignore it.
+        else:
+            from errno import ESRCH
+
+            if not isinstance(os_error, ProcessLookupError) or os_error.errno != ESRCH:
+                raise
 
     async def cleanup(self, restart: bool = False) -> None:
         if self.ports_cached and not restart:


### PR DESCRIPTION
Per [this comment in #104](https://github.com/jupyter/jupyter_client/issues/104#issuecomment-1027506791), we should restore the behavior that signaling the process group is preferred over the Popen `kill()` and `terminate()` methods (which essentially signal the process).  This pull request updates the LocalProvisioner to send `SIGKILL`/`SIGTERM` to the process group, prior to falling back to Popen `kill()`/`terminate()`, respectively.

As also noted in the comment, this functionality is masked by the fact that we still prefer a message-based shutdown unless the message-based shutdown fails or an auto-restart event occurs (when the kernel process can no longer be tracked), in which case the "immediate" form of restart occurs (using the signal-based approach).