### PR TITLE
Json packer: handle TypeError and fallback to old json_clean

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -100,7 +100,7 @@ def json_packer(obj):
             ensure_ascii=False,
             allow_nan=False,
         ).encode("utf8")
-    except ValueError as e:
+    except (TypeError, ValueError) as e:
         # Fallback to trying to clean the json before serializing
         packed = json.dumps(
             json_clean(obj),


### PR DESCRIPTION
`TypeError` are raised when the dictionaries contain invalid keys, which `json_clean` used to handle so we can fallback to it.

cc. @minrk 