### PR TITLE
Mock is not needed

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,6 @@ coverage
 ipykernel>=5.5.6
 ipython
 jedi<0.18; python_version<="3.6"
-mock
 mypy
 pre-commit
 pytest


### PR DESCRIPTION
Since 3f8599f56d1d898e54a8116550b024226c985ac4 we always use unittest.mock