### PR TITLE
Fix shutdown and cleanup behavior

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,3 +150,5 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
+        with:
+          test_command: pytest --vv || pytest -vv --lf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,8 +71,8 @@ jobs:
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
-          args="-vv --cov jupyter_client --cov-branch --cov-report term-missing:skip-covered --cov-fail-under 70"
-          python -m pytest $args || python -m pytest $args --lf
+          args="-vv --cov jupyter_client --cov-branch --cov-report term-missing:skip-covered"
+          python -m pytest $args --cov-fail-under 70 || python -m pytest $args --lf
       - name: Run the tests on pypy and windows
         if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}
         run: |

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -109,7 +109,7 @@ class HBChannel(Thread):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.run_until_complete(self._async_run())
-        # loop.close()
+        loop.close()
 
     async def _async_run(self) -> None:
         """The thread's main activity.  Call start() instead."""

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -109,7 +109,7 @@ class HBChannel(Thread):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.run_until_complete(self._async_run())
-        loop.close()
+        # loop.close()
 
     async def _async_run(self) -> None:
         """The thread's main activity.  Call start() instead."""

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -109,6 +109,7 @@ class HBChannel(Thread):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.run_until_complete(self._async_run())
+        loop.close()
 
     async def _async_run(self) -> None:
         """The thread's main activity.  Call start() instead."""

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -93,10 +93,7 @@ class KernelClient(ConnectionFileMixin):
     # The PyZMQ Context to use for communication with the kernel.
     context = Instance(zmq.asyncio.Context)
 
-    _created_context: Bool = Bool(False)
-
     def _context_default(self) -> zmq.asyncio.Context:
-        self._created_context = True
         return zmq.asyncio.Context()
 
     # The classes to use for the various channels
@@ -290,9 +287,6 @@ class KernelClient(ConnectionFileMixin):
         :meth:`start_kernel`. If the channels have been stopped and you
         call this, :class:`RuntimeError` will be raised.
         """
-        # Create the context if needed.
-        if not self._created_context:
-            self.context = self._context_default()
         if iopub:
             self.iopub_channel.start()
         if shell:
@@ -322,8 +316,6 @@ class KernelClient(ConnectionFileMixin):
             self.hb_channel.stop()
         if self.control_channel.is_alive():
             self.control_channel.stop()
-        if self._created_context:
-            self._created_context = False
 
     @property
     def channels_running(self) -> bool:

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -2,6 +2,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import asyncio
+import atexit
 import sys
 import time
 import typing as t
@@ -93,7 +94,9 @@ class KernelClient(ConnectionFileMixin):
     context = Instance(zmq.asyncio.Context)
 
     def _context_default(self) -> zmq.asyncio.Context:
-        return zmq.asyncio.Context()
+        context = zmq.asyncio.Context()
+        atexit.register(context.destroy)
+        return context
 
     # The classes to use for the various channels
     shell_channel_class = Type(ChannelABC)
@@ -111,10 +114,6 @@ class KernelClient(ConnectionFileMixin):
 
     # flag for whether execute requests should be allowed to call raw_input:
     allow_stdin: bool = True
-
-    def __del__(self):
-        """Destroy our context when we are garbage collected."""
-        self.context.destroy()
 
     # --------------------------------------------------------------------------
     # Channel proxy methods

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -11,7 +11,6 @@ from queue import Empty
 
 import zmq.asyncio
 from traitlets import Any
-from traitlets import Bool
 from traitlets import Instance
 from traitlets import Type
 

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -116,6 +116,10 @@ class KernelClient(ConnectionFileMixin):
     # flag for whether execute requests should be allowed to call raw_input:
     allow_stdin: bool = True
 
+    def __del__(self):
+        """Destroy our context when we are garbage collected."""
+        self.context.destroy()
+
     # --------------------------------------------------------------------------
     # Channel proxy methods
     # --------------------------------------------------------------------------
@@ -320,7 +324,6 @@ class KernelClient(ConnectionFileMixin):
             self.control_channel.stop()
         if self._created_context:
             self._created_context = False
-            self.context.destroy()
 
     @property
     def channels_running(self) -> bool:

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -117,10 +117,15 @@ class KernelClient(ConnectionFileMixin):
     allow_stdin: bool = True
 
     def __del__(self):
+        """Handle garbage collection.  Destroy context if applicable."""
         if self._created_context and self.context and not self.context.closed:
-            if self.log:
-                self.log.debug("Destroying zmq context for %s", self)
-            self.context.destroy()
+            if self.channels_running:
+                if self.log:
+                    self.log.warning("Could not destroy zmq context for %s", self)
+            else:
+                if self.log:
+                    self.log.debug("Destroying zmq context for %s", self)
+                self.context.destroy()
         try:
             super_del = super().__del__
         except AttributeError:

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -2,10 +2,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import asyncio
-import atexit
 import sys
 import time
 import typing as t
+import weakref
 from functools import partial
 from getpass import getpass
 from queue import Empty
@@ -95,7 +95,8 @@ class KernelClient(ConnectionFileMixin):
 
     def _context_default(self) -> zmq.asyncio.Context:
         context = zmq.asyncio.Context()
-        atexit.register(context.destroy)
+        # Use a finalizer to destroy the context.
+        self._finalizer = weakref.finalize(self, context.destroy)
         return context
 
     # The classes to use for the various channels

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -6,7 +6,6 @@ import os
 import socket
 import typing as t
 import uuid
-import weakref
 
 import zmq
 from traitlets import Any
@@ -107,14 +106,15 @@ class MultiKernelManager(LoggingConfigurable):
 
     @default("context")  # type:ignore[misc]
     def _context_default(self) -> zmq.Context:
-        context = zmq.Context()
-        # Use a finalizer to destroy the context.
-        self._finalizer = weakref.finalize(self, context.destroy)
-        return context
+        return zmq.Context()
 
     connection_dir = Unicode("")
 
     _kernels = Dict()
+
+    def __del__(self):
+        """Clean up the context when garbage collected."""
+        self.context.destroy()
 
     def list_kernel_ids(self) -> t.List[str]:
         """Return a list of the kernel ids of the active kernels."""

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -116,6 +116,7 @@ class MultiKernelManager(LoggingConfigurable):
     _kernels = Dict()
 
     def __del__(self):
+        """Handle garbage collection.  Destroy context if applicable."""
         if self._created_context and self.context and not self.context.closed:
             if self.log:
                 self.log.debug("Destroying zmq context for %s", self)

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -240,7 +240,7 @@ class MultiKernelManager(LoggingConfigurable):
                 await task
                 km = self.get_kernel(kernel_id)
                 await t.cast(asyncio.Future, km.ready)
-            except asyncio.exceptions.CancelledError:
+            except asyncio.CancelledError:
                 pass
             except Exception:
                 self.remove_kernel(kernel_id)
@@ -302,7 +302,7 @@ class MultiKernelManager(LoggingConfigurable):
             for km in kms:
                 try:
                     await km.ready
-                except asyncio.exceptions.CancelledError:
+                except asyncio.CancelledError:
                     self._pending_kernels[km.kernel_id].cancel()
                 except Exception:
                     # Will have been logged in _add_kernel_when_ready

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -311,7 +311,7 @@ class MultiKernelManager(LoggingConfigurable):
             for km in kms:
                 try:
                     await km.ready
-                except Exception as e:
+                except Exception:
                     # Will have been logged in _add_kernel_when_ready
                     pass
 

--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -194,6 +194,7 @@ class TestKernelManagerShutDownGracefully:
 class TestKernelManager:
     def test_lifecycle(self, km):
         km.start_kernel(stdout=PIPE, stderr=PIPE)
+        kc = km.client()
         assert km.is_alive()
         is_done = km.ready.done()
         assert is_done
@@ -201,6 +202,7 @@ class TestKernelManager:
         assert km.is_alive()
         km.interrupt_kernel()
         assert isinstance(km, KernelManager)
+        kc.stop_channels()
         km.shutdown_kernel(now=True)
         assert km.context.closed
 

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -88,9 +88,11 @@ class TestKernelManager(TestCase):
         assert kid in km.list_kernel_ids()
         km.interrupt_kernel(kid)
         k = km.get_kernel(kid)
+        kc = k.client()
         assert isinstance(k, KernelManager)
         km.shutdown_kernel(kid, now=True)
         assert kid not in km, f"{kid} not in {km}"
+        kc.stop_channels()
 
     def _run_cinfo(self, km, transport, ip):
         kid = km.start_kernel(stdout=PIPE, stderr=PIPE)
@@ -415,10 +417,6 @@ class TestAsyncKernelManager(AsyncTestCase):
         kernel = km.get_kernel(kid)
         assert not kernel.ready.done()
         # Try shutting down while the kernel is pending
-        with pytest.raises(RuntimeError):
-            await ensure_future(km.shutdown_kernel(kid, now=True))
-        await kernel.ready
-        # Shutdown once the kernel is ready
         await ensure_future(km.shutdown_kernel(kid, now=True))
         # Wait for the kernel to shutdown
         await kernel.ready
@@ -476,6 +474,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.run_until_complete(self.raw_tcp_lifecycle())
+        loop.close()
 
     # static so picklable for multiprocessing on Windows
     @classmethod
@@ -491,6 +490,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.run_until_complete(cls.raw_tcp_lifecycle(test_kid=test_kid))
+        loop.close()
 
     @gen_test
     async def test_start_parallel_thread_kernels(self):

--- a/jupyter_client/tests/test_multikernelmanager.py
+++ b/jupyter_client/tests/test_multikernelmanager.py
@@ -160,8 +160,10 @@ class TestKernelManager(TestCase):
 
     def tcp_lifecycle_with_loop(self):
         # Ensure each thread has an event loop
-        asyncio.set_event_loop(asyncio.new_event_loop())
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         self.test_tcp_lifecycle()
+        loop.close()
 
     def test_start_parallel_thread_kernels(self):
         self.test_tcp_lifecycle()

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -243,6 +243,9 @@ class IOLoopThread(Thread):
         self.close()
         self.ioloop = None
 
+    def __del__(self):
+        self.close()
+
     def close(self) -> None:
         if self.ioloop is not None:
             try:

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -243,9 +243,6 @@ class IOLoopThread(Thread):
         self.close()
         self.ioloop = None
 
-    def __del__(self):
-        self.close()
-
     def close(self) -> None:
         if self.ioloop is not None:
             try:

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -7,8 +7,6 @@ import asyncio
 import inspect
 import os
 
-# import atexit
-
 
 def run_sync(coro):
     def wrapped(*args, **kwargs):

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -13,8 +13,8 @@ def run_sync(coro):
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+            # Workaround for bugs.python.org/issue39529.
+            loop = asyncio.get_event_loop_policy().get_event_loop()
         import nest_asyncio  # type: ignore
 
         nest_asyncio.apply(loop)

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -4,6 +4,7 @@ utils:
 - vendor functions from ipython_genutils that should be retired at some point.
 """
 import asyncio
+import atexit
 import inspect
 import os
 
@@ -14,6 +15,7 @@ def run_sync(coro):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
+            atexit.register(loop.close)
             asyncio.set_event_loop(loop)
         import nest_asyncio  # type: ignore
 

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -4,9 +4,10 @@ utils:
 - vendor functions from ipython_genutils that should be retired at some point.
 """
 import asyncio
-import atexit
 import inspect
 import os
+
+# import atexit
 
 
 def run_sync(coro):
@@ -15,7 +16,7 @@ def run_sync(coro):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
-            atexit.register(loop.close)
+            # atexit.register(loop.close)
             asyncio.set_event_loop(loop)
         import nest_asyncio  # type: ignore
 

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -14,7 +14,11 @@ def run_sync(coro):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             # Workaround for bugs.python.org/issue39529.
-            loop = asyncio.get_event_loop_policy().get_event_loop()
+            try:
+                loop = asyncio.get_event_loop_policy().get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
         import nest_asyncio  # type: ignore
 
         nest_asyncio.apply(loop)

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -16,7 +16,6 @@ def run_sync(coro):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
-            # atexit.register(loop.close)
             asyncio.set_event_loop(loop)
         import nest_asyncio  # type: ignore
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,6 @@ filterwarnings= [
   # Fail on warnings
   "error",
 
-  # Workarounds for https://github.com/pytest-dev/pytest-asyncio/issues/77
-  "ignore:unclosed <socket.socket:ResourceWarning",
-  "ignore:unclosed event loop:ResourceWarning",
-
   # Workaround for https://github.com/tornadoweb/tornado/issues/3106
   # (To be fixed in Tornado 6.2)
   "ignore:There is no current event loop:DeprecationWarning:tornado",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ filterwarnings= [
   # Fail on warnings
   "error",
 
-  # We're missing an event loop close somewhere.
+  # We need to handle properly closing loops as part of https://github.com/jupyter/jupyter_client/issues/755.
   "ignore:unclosed <socket.socket:ResourceWarning",
   "ignore:unclosed event loop:ResourceWarning",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,13 @@ filterwarnings= [
   # Fail on warnings
   "error",
 
+  # We're missing an event loop close somewhere.
+  "ignore:unclosed <socket.socket:ResourceWarning",
+  "ignore:unclosed event loop:ResourceWarning",
+
   # Workaround for https://github.com/tornadoweb/tornado/issues/3106
   # (To be fixed in Tornado 6.2)
   "ignore:There is no current event loop:DeprecationWarning:tornado",
-
-  # Randomly occuring.
-  "ignore:unclosed <socket.socket:ResourceWarning",
 
   # ZMQ uses Future internally, which raises a DeprecationWarning
   # When there is no loop running.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ filterwarnings= [
   # (To be fixed in Tornado 6.2)
   "ignore:There is no current event loop:DeprecationWarning:tornado",
 
+  # Randomly occuring.
+  "ignore:unclosed <socket.socket:ResourceWarning",
+
   # ZMQ uses Future internally, which raises a DeprecationWarning
   # When there is no loop running.
   # We could eventually find a way to make sure these are only created


### PR DESCRIPTION
Fixes #771 

```
$ jupyter qtconsole
qt.qpa.drawing: Layer-backing can not be explicitly controlled on 10.14 when built against the 10.14 SDK
$
```

Includes improvements made while working on https://github.com/jupyter-server/jupyter_server/pull/792

Also avoids leaving event loops open at exit in a few more places.


