### PR TITLE
Unicode error correction using Error Handler

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -101,7 +101,7 @@ def json_packer(obj):
             default=json_default,
             ensure_ascii=False,
             allow_nan=False,
-        ).encode("utf8")
+        ).encode("utf8", errors="surrogateescape")
     except (TypeError, ValueError) as e:
         # Fallback to trying to clean the json before serializing
         packed = json.dumps(
@@ -109,7 +109,7 @@ def json_packer(obj):
             default=json_default,
             ensure_ascii=False,
             allow_nan=False,
-        ).encode("utf8")
+        ).encode("utf8", errors="surrogateescape")
 
         warnings.warn(
             f"Message serialization failed with:\n{e}\n"


### PR DESCRIPTION
 Added Unicode error correction using following Error Handler errors="surrogateescape" as discussed here https://github.com/jupyter/jupyter_client/issues/778.

Fixes #778