### PR TITLE
Manage Kernel status/state with a state machine

### DIFF
--- a/jupyter_client/state_machine.py
+++ b/jupyter_client/state_machine.py
@@ -1,0 +1,63 @@
+from transitions.extensions.asyncio import AsyncMachine
+
+from jupyter_client.manager import AsyncKernelManager
+
+
+KERNEL_STATES = [
+    "unknown",
+    "starting",
+    "started",
+    "terminating",
+    "dead",
+    "connecting",
+    "connected",
+    "disconnected",
+]
+
+
+KERNEL_TRANSITIONS = [
+    {
+        "trigger": "_launch_kernel",
+        "source": ["unknown", "dead"],
+        "dest": "started",
+        "before": "to_starting",
+    },
+    # {
+    #     "trigger": "start_heartbeat",
+    #     "source": "started",
+    #     "dest": "connected",
+    #     "before": "to_connecting",
+    # },
+    {
+        "trigger": "shutdown_kernel",
+        "source": ["connected", "started"],
+        "dest": "dead",
+        "before": "to_terminating",
+    },
+]
+
+
+class KernelStateMachine(AsyncMachine):
+    """A State machine that maintains the kernel
+    state from a kernel manager
+    """
+
+    def __init__(self, kernel_manager: AsyncKernelManager):
+        super().__init__(
+            model=kernel_manager,
+            states=KERNEL_STATES,
+            transitions=KERNEL_TRANSITIONS,
+            initial="unknown",
+        )
+
+    # `transitions` tries to create *new* methods for each
+    # trigger name. since we already have methods for these
+    # methods, we'll wrap the methods instead.
+    def _checked_assignment(self, kernel_manager, name, trigger):
+        # Check that
+        if hasattr(kernel_manager, name):
+            predefined_func = getattr(kernel_manager, name)
+            self.events[name].add_callback("before", predefined_func)
+            setattr(kernel_manager, name, trigger)
+        else:
+            setattr(kernel_manager, name, trigger)

--- a/jupyter_client/state_machine.py
+++ b/jupyter_client/state_machine.py
@@ -54,10 +54,10 @@ class KernelStateMachine(AsyncMachine):
     # trigger name. since we already have methods for these
     # methods, we'll wrap the methods instead.
     def _checked_assignment(self, kernel_manager, name, trigger):
-        # Check that
+        # If the trigger shares the same name as a method in the
+        # kernel manager, move the kernel_manager method to the
+        # callback list.
         if hasattr(kernel_manager, name):
             predefined_func = getattr(kernel_manager, name)
             self.events[name].add_callback("before", predefined_func)
-            setattr(kernel_manager, name, trigger)
-        else:
-            setattr(kernel_manager, name, trigger)
+        setattr(kernel_manager, name, trigger)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dateutil>=2.8.2
 pyzmq>=22.3
 tornado>=6.0
 traitlets
+transitions


### PR DESCRIPTION
Implements #763

This is an early draft of the work. I wanted to open-source this early to encourage feedback/discussion.

Adds a state machine to the default `KernelManager` implementation . This exposes an API to see what state the kernel is in at any given time. This replaces the previous "pending kernel" API we added recently in favor of something more robust.

You'll notice it takes very little code. The `transitions` library does most of the heavy lifting here. 

Todo
------

- [ ] Deprecate the `.ready` API for pending kernels; add a backwards compatible API for the deprecation cycle.
- [ ] Add unit tests
- [ ] Add documentation
