### PR TITLE
Revert latest changes to `ThreadedZMQSocketChannel` because they break Qtconsole

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -79,3 +79,40 @@ jobs:
           conda install -c conda-forge xeus-cling
           pip install -e ".[test]"
           python -m unittest -v
+
+  qtconsole:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+          architecture: "x64"
+
+      - name: Install System Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+
+      - name: Install qtconsole dependencies
+        shell: bash -l {0}
+        run: |
+          cd ${GITHUB_WORKSPACE}/..
+          git clone https://github.com/jupyter/qtconsole.git
+          cd qtconsole
+          ${pythonLocation}/bin/python -m pip install -e ".[test]"
+          ${pythonLocation}/bin/python -m pip install pyqt5
+
+      - name: Install Jupyter-Client changes
+        shell: bash -l {0}
+        run: ${pythonLocation}/bin/python -m pip install -e .
+
+      - name: Test qtconsole
+        shell: bash -l {0}
+        run: |
+          cd ${GITHUB_WORKSPACE}/../qtconsole
+          xvfb-run --auto-servernum ${pythonLocation}/bin/python -m pytest -x -vv -s --full-trace --color=yes qtconsole

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -70,7 +70,7 @@ class ThreadedZMQSocketChannel(object):
         def setup_stream():
             assert self.socket is not None
             self.stream = zmqstream.ZMQStream(self.socket, self.ioloop)
-            self.stream.on_recv(self._handle_recv)
+            self.stream.on_recv(self._handle_recv)  # type:ignore[arg-type]
             evt.set()
 
         assert self.ioloop is not None

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -8,9 +8,11 @@ import time
 from threading import Event
 from threading import Thread
 from typing import Any
+from typing import Awaitable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
 
 import zmq
 from traitlets import Instance
@@ -26,6 +28,10 @@ from jupyter_client.channels import HBChannel
 # Local imports
 # import ZMQError in top-level namespace, to avoid ugly attribute-error messages
 # during garbage collection of threads at exit
+
+
+async def get_msg(msg: Awaitable) -> Union[List[bytes], List[zmq.Message]]:
+    return await msg
 
 
 class ThreadedZMQSocketChannel(object):
@@ -108,11 +114,13 @@ class ThreadedZMQSocketChannel(object):
         assert self.ioloop is not None
         self.ioloop.add_callback(thread_send)
 
-    def _handle_recv(self, msg_list: List[bytes]) -> None:
+    def _handle_recv(self, future_msg: Awaitable) -> None:
         """Callback for stream.on_recv.
 
         Unpacks message, and calls handlers with it.
         """
+        assert self.ioloop is not None
+        msg_list = self.ioloop._asyncio_event_loop.run_until_complete(get_msg(future_msg))
         assert self.session is not None
         ident, smsg = self.session.feed_identities(msg_list)
         msg = self.session.deserialize(smsg)


### PR DESCRIPTION
- Those changes were done in commit https://github.com/jupyter/jupyter_client/commit/0057186519ed356b822b1b1a0052e4068fccff12, released in version 7.3.2.
- They break Qtconsole and hence Spyder, but I checked locally that a simple revert fixes the problem.
- I added the qtconsole test suite here to avoid future breakages.