### PR TITLE
Use tornado 6.2's PeriodicCallback in restarter

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -76,7 +76,6 @@ jobs:
           git clone https://github.com/jupyter/jupyter_kernel_test.git
           cd jupyter_kernel_test
           conda env update --name jupyter_kernel_test --file environment.yml
-          conda install -c conda-forge xeus-cling
           pip install -e ".[test]"
           python -m unittest -v
 

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -5,14 +5,12 @@ restarts the kernel if it dies.
 """
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import asyncio
 import time
 import warnings
 
 from traitlets import Instance
 
 from jupyter_client.restarter import KernelRestarter
-from jupyter_client.utils import run_sync
 
 
 class IOLoopKernelRestarter(KernelRestarter):

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -34,12 +34,10 @@ class IOLoopKernelRestarter(KernelRestarter):
     def start(self):
         """Start the polling of the kernel."""
         if self._pcallback is None:
-            if asyncio.iscoroutinefunction(self.poll):
-                cb = run_sync(self.poll)
-            else:
-                cb = self.poll
-            self._pcallback = ioloop.PeriodicCallback(
-                cb,
+            from tornado.ioloop import PeriodicCallback
+
+            self._pcallback = PeriodicCallback(
+                self.poll,
                 1000 * self.time_to_dead,
             )
             self._pcallback.start()

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -27,6 +27,7 @@ class IOLoopKernelRestarter(KernelRestarter):
             stacklevel=4,
         )
         from zmq.eventloop import ioloop
+
         return ioloop.IOLoop.current()
 
     _pcallback = None

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -10,7 +10,6 @@ import time
 import warnings
 
 from traitlets import Instance
-from zmq.eventloop import ioloop
 
 from jupyter_client.restarter import KernelRestarter
 from jupyter_client.utils import run_sync
@@ -27,6 +26,7 @@ class IOLoopKernelRestarter(KernelRestarter):
             DeprecationWarning,
             stacklevel=4,
         )
+        from zmq.eventloop import ioloop
         return ioloop.IOLoop.current()
 
     _pcallback = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "nest-asyncio>=1.5.4",
     "python-dateutil>=2.8.2",
     "pyzmq>=23.0",
-    "tornado>=6.0",
+    "tornado>=6.2",
     "traitlets",
 ]
 


### PR DESCRIPTION
Since tornado 6.2, the `PeriodicCallback` will now await any callbacks that are awaitable (https://github.com/tornadoweb/tornado/pull/2924). So we no longer need to wrap the async restarter's `poll` method in a `run_sync` call. This allows us to not depend on `nest_asyncio` with the default configuration of jupyter client, so we can avoid some of its pitfalls (e.g. https://github.com/jupyterlab/jupyterlab/issues/11934).