### PR TITLE
Use pytest_asyncio fixture

### DIFF
--- a/jupyter_client/tests/test_kernelmanager.py
+++ b/jupyter_client/tests/test_kernelmanager.py
@@ -11,6 +11,7 @@ import time
 from subprocess import PIPE
 
 import pytest
+import pytest_asyncio
 from jupyter_core import paths
 from traitlets.config.loader import Config
 
@@ -123,7 +124,7 @@ def async_km_subclass(config):
     return km
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def start_async_kernel():
     km, kc = await start_new_async_kernel(kernel_name="signaltest")
     yield km, kc


### PR DESCRIPTION
Test `test_start_new_async_kernel` failed in https://github.com/conda-forge/jupyter_client-feedstock/pull/81 because pytest's asyncio mode is `strict`. I don't know why it doesn't fail here.
We can either mark the `start_async_kernel` fixture as a `pytest_asyncio` one, or globally set the mode to `auto`. This PR does the former.