### PR TITLE
Avoid running nested runloops in ThreadedZMQSocketChannel

### DIFF
--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -1,17 +1,15 @@
 """ Defines a KernelClient that provides thread-safe sockets with async callbacks on message
 replies.
 """
+import asyncio
 import atexit
 import errno
 import time
 from threading import Event
 from threading import Thread
 from typing import Any
-from typing import Awaitable
 from typing import Dict
-from typing import List
 from typing import Optional
-from typing import Union
 
 import zmq
 from traitlets import Instance
@@ -109,7 +107,7 @@ class ThreadedZMQSocketChannel(object):
         assert self.ioloop is not None
         self.ioloop.add_callback(thread_send)
 
-    def _handle_recv(self, future_msg: Awaitable) -> None:
+    def _handle_recv(self, future_msg: asyncio.Future) -> None:
         """Callback for stream.on_recv.
 
         Unpacks message, and calls handlers with it.


### PR DESCRIPTION
Hi!

I'm the maintainer of a project called [IPyIDA](https://github.com/eset/ipyida), which integrates the QtConsole inside [IDA Pro](https://hex-rays.com).

I'm using lots of plumbing to make this all work, and use [QtKernelManager and QtKernelClient](https://github.com/eset/ipyida/blob/508f542686da0b5379f269fa779c6d3fc45451eb/ipyida/ida_qtconsole.py#L140-L144) (which inherits from ThreadKernelClient) to connect to the kernel.

Since jupyter_client version 7, IPyIDA doesn't work and raises a RuntimeError and starting the client (see eset/ipyida#44). My temporary solution was to [require working version of jupyter_client](https://github.com/eset/ipyida/blob/508f542686da0b5379f269fa779c6d3fc45451eb/setup.py#L36) until I can find the source of the problem.

After much hours (probably too much :D) trying to understand the problem I think I found a proper solution. My understanding is that the `SocketStream.on_recv` was designed to be used with (pre-v6) Tornado runloop. Since Tornado 6, the Tornado runloop is just a wrapper around asyncio's. `on_recv` still works with the asyncio runloop but receives the (completed) Future object with the result. Trying to await the Future in another runloop crashes because the callback is called from an already running runloop.

The suggested commit fixes the problem with minimal changes because I didn't want to break other things I may not have full understanding about.