### PR TITLE
Switch to pydata sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -306,17 +306,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'ipython': ('http://ipython.readthedocs.io/en/stable/', None)}
-
-# Read The Docs
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme  # type:ignore[import]
-
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
 
 
 def setup(app):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ doc = [
     "ipykernel",
     "myst-parser",
     "sphinx>=1.3.6",
-    "sphinx_rtd_theme",
+    "pydata_sphinx_theme",
     "sphinxcontrib_github_alt",
 ]
 


### PR DESCRIPTION
The docs build was failing due to a version parsing error in `sphinx_rtd_theme`, so it seemed like a good time to upgrade.