### PR TITLE
Remove some deprecated zmq imports

### DIFF
--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -24,7 +24,7 @@ class IOLoopKernelRestarter(KernelRestarter):
             DeprecationWarning,
             stacklevel=4,
         )
-        from zmq.eventloop import ioloop
+        from tornado import ioloop
 
         return ioloop.IOLoop.current()
 

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -30,6 +30,7 @@ from typing import Optional
 from typing import Union
 
 import zmq
+from tornado.ioloop import IOLoop
 from traitlets import Any
 from traitlets import Bool
 from traitlets import CBytes
@@ -46,7 +47,6 @@ from traitlets.config.configurable import Configurable
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets.log import get_logger
 from traitlets.utils.importstring import import_item
-from zmq.eventloop.ioloop import IOLoop
 from zmq.eventloop.zmqstream import ZMQStream
 
 from jupyter_client import protocol_version

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -15,10 +15,10 @@ from typing import Optional
 from typing import Union
 
 import zmq
+from tornado.ioloop import IOLoop
 from traitlets import Instance
 from traitlets import Type
 from zmq import ZMQError
-from zmq.eventloop import ioloop
 from zmq.eventloop import zmqstream
 
 from .session import Session
@@ -47,7 +47,7 @@ class ThreadedZMQSocketChannel(object):
         self,
         socket: Optional[zmq.Socket],
         session: Optional[Session],
-        loop: Optional[zmq.eventloop.ioloop.ZMQIOLoop],
+        loop: Optional[IOLoop],
     ) -> None:
         """Create a channel.
 
@@ -211,7 +211,8 @@ class IOLoopThread(Thread):
         """Run my loop, ignoring EINTR events in the poller"""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        self.ioloop = ioloop.IOLoop()
+        self.ioloop = IOLoop()
+
         self.ioloop._asyncio_event_loop = loop
         # signal that self.ioloop is defined
         self._start_event.set()


### PR DESCRIPTION
The zmq.eventloop.ioloop shim has been deprecated since pyzmq 17

jupyter-client requires pyzmq 23