### PR TITLE
Fix pending kernels again

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -57,34 +57,37 @@ class _ShutdownStatus(Enum):
 F = t.TypeVar('F', bound=t.Callable[..., t.Any])
 
 
-def in_pending_state(method: F) -> F:
-    """Sets the kernel to a pending state by
-    creating a fresh Future for the KernelManager's `ready`
-    attribute. Once the method is finished, set the Future's results.
-    """
+def in_pending_state(prefix=''):
+    def decorator(method: F) -> F:
+        """Sets the kernel to a pending state by
+        creating a fresh Future for the KernelManager's `ready`
+        attribute. Once the method is finished, set the Future's results.
+        """
 
-    @t.no_type_check
-    @functools.wraps(method)
-    async def wrapper(self, *args, **kwargs):
-        # Create a future for the decorated method
-        try:
-            self._ready = Future()
-        except RuntimeError:
-            # No event loop running, use concurrent future
-            self._ready = CFuture()
-        try:
-            # call wrapped method, await, and set the result or exception.
-            out = await method(self, *args, **kwargs)
-            # Add a small sleep to ensure tests can capture the state before done
-            await asyncio.sleep(0.01)
-            self._ready.set_result(None)
-            return out
-        except Exception as e:
-            self._ready.set_exception(e)
-            self.log.exception(self._ready.exception())
-            raise e
+        @t.no_type_check
+        @functools.wraps(method)
+        async def wrapper(self, *args, **kwargs):
+            # Create a future for the decorated method
+            name = f"{prefix}_ready"
+            future = getattr(self, name)
+            if not future or future.done():
+                future = self._future_factory()
+                setattr(self, name, future)
+            try:
+                # call wrapped method, await, and set the result or exception.
+                out = await method(self, *args, **kwargs)
+                # Add a small sleep to ensure tests can capture the state before done
+                await asyncio.sleep(0.01)
+                future.set_result(None)
+                return out
+            except Exception as e:
+                future.set_exception(e)
+                self.log.exception(future.exception())
+                raise e
 
-    return t.cast(F, wrapper)
+        return t.cast(F, wrapper)
+
+    return decorator
 
 
 class KernelManager(ConnectionFileMixin):
@@ -114,18 +117,14 @@ class KernelManager(ConnectionFileMixin):
             data={"action": action, "kernel_id": self.kernel_id, "caller": "kernel_manager"},
         )
 
-    _ready: t.Union[Future, CFuture]
+    _ready: CFuture
+    _shutdown_ready: CFuture
 
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
         self._shutdown_status = _ShutdownStatus.Unset
-        # Create a place holder future.
-        try:
-            asyncio.get_running_loop()
-            self._ready = Future()
-        except RuntimeError:
-            # No event loop running, use concurrent future
-            self._ready = CFuture()
+        self._ready = None
+        self._shutdown_ready = None
 
     _created_context: Bool = Bool(False)
 
@@ -142,6 +141,8 @@ class KernelManager(ConnectionFileMixin):
         "jupyter_client.blocking.BlockingKernelClient"
     )
     client_factory: Type = Type(klass="jupyter_client.KernelClient")
+
+    _future_factory = Future
 
     @default("client_factory")  # type:ignore[misc]
     def _client_factory_default(self) -> Type:
@@ -208,9 +209,18 @@ class KernelManager(ConnectionFileMixin):
         return self.transport == "tcp"
 
     @property
-    def ready(self) -> t.Union[CFuture, Future]:
-        """A future that resolves when the kernel process has started for the first time"""
+    def ready(self) -> CFuture:
+        """A future that resolves when the kernel process has started."""
+        if not self._ready:
+            self._ready = self._future_factory()
         return self._ready
+
+    @property
+    def shutdown_ready(self) -> CFuture:
+        """A future that resolves when the kernel process has shut down."""
+        if not self._shutdown_ready:
+            self._shutdown_ready = self._future_factory()
+        return self._shutdown_ready
 
     @property
     def ipykernel(self) -> bool:
@@ -395,7 +405,7 @@ class KernelManager(ConnectionFileMixin):
 
     post_start_kernel = run_sync(_async_post_start_kernel)
 
-    @in_pending_state
+    @in_pending_state()
     async def _async_start_kernel(self, **kw: t.Any) -> None:
         """Starts a kernel on this host in a separate process.
 
@@ -491,7 +501,7 @@ class KernelManager(ConnectionFileMixin):
 
     cleanup_resources = run_sync(_async_cleanup_resources)
 
-    @in_pending_state
+    @in_pending_state('_shutdown')
     async def _async_shutdown_kernel(self, now: bool = False, restart: bool = False) -> None:
         """Attempts to stop the kernel process cleanly.
 
@@ -510,6 +520,8 @@ class KernelManager(ConnectionFileMixin):
             Will this kernel be restarted after it is shutdown. When this
             is True, connection files will not be cleaned up.
         """
+        # Reset the start ready future.
+        self._ready = self._future_factory()
         self._emit(action="shutdown_started")
         self.shutting_down = True  # Used by restarter to prevent race condition
         # Stop monitoring for restarting while we shutdown.
@@ -681,6 +693,8 @@ class AsyncKernelManager(KernelManager):
 
     # The PyZMQ Context to use for communication with the kernel.
     context: Instance = Instance(zmq.asyncio.Context)
+
+    _future_factory = Future
 
     @default("context")  # type:ignore[misc]
     def _context_default(self) -> zmq.asyncio.Context:

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -57,7 +57,7 @@ class _ShutdownStatus(Enum):
 F = t.TypeVar('F', bound=t.Callable[..., t.Any])
 
 
-def in_pending_state(prefix=''):
+def in_pending_state(prefix: str = '') -> t.Callable[[F], F]:
     def decorator(method: F) -> F:
         """Sets the kernel to a pending state by
         creating a fresh Future for the KernelManager's `ready`
@@ -117,8 +117,8 @@ class KernelManager(ConnectionFileMixin):
             data={"action": action, "kernel_id": self.kernel_id, "caller": "kernel_manager"},
         )
 
-    _ready: CFuture
-    _shutdown_ready: CFuture
+    _ready: t.Optional[CFuture]
+    _shutdown_ready: t.Optional[CFuture]
 
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
@@ -142,7 +142,7 @@ class KernelManager(ConnectionFileMixin):
     )
     client_factory: Type = Type(klass="jupyter_client.KernelClient")
 
-    _future_factory = Future
+    _future_factory: t.Type[CFuture] = CFuture
 
     @default("client_factory")  # type:ignore[misc]
     def _client_factory_default(self) -> Type:
@@ -213,6 +213,7 @@ class KernelManager(ConnectionFileMixin):
         """A future that resolves when the kernel process has started."""
         if not self._ready:
             self._ready = self._future_factory()
+        assert self._ready is not None
         return self._ready
 
     @property
@@ -220,6 +221,7 @@ class KernelManager(ConnectionFileMixin):
         """A future that resolves when the kernel process has shut down."""
         if not self._shutdown_ready:
             self._shutdown_ready = self._future_factory()
+        assert self._shutdown_ready is not None
         return self._shutdown_ready
 
     @property
@@ -694,7 +696,7 @@ class AsyncKernelManager(KernelManager):
     # The PyZMQ Context to use for communication with the kernel.
     context: Instance = Instance(zmq.asyncio.Context)
 
-    _future_factory = Future
+    _future_factory: t.Type[Future] = Future  # type:ignore[assignment]
 
     @default("context")  # type:ignore[misc]
     def _context_default(self) -> zmq.asyncio.Context:

--- a/tests/test_kernelmanager.py
+++ b/tests/test_kernelmanager.py
@@ -135,13 +135,13 @@ def check_emitted_events(jp_read_emitted_events):
 
 
 @pytest.fixture(params=[AsyncKernelManager, AsyncKMSubclass])
-def async_km(request, config, jp_event_logger):
+async def async_km(request, config, jp_event_logger):
     km = request.param(config=config, event_logger=jp_event_logger)
     return km
 
 
 @pytest.fixture
-def async_km_subclass(config, jp_event_logger):
+async def async_km_subclass(config, jp_event_logger):
     km = AsyncKMSubclass(config=config, event_logger=jp_event_logger)
     return km
 
@@ -489,11 +489,11 @@ class TestAsyncKernelManager:
         await async_km.start_kernel(stdout=PIPE, stderr=PIPE)
         is_alive = await async_km.is_alive()
         assert is_alive
-        is_ready = async_km.ready.done()
-        assert is_ready
+        await async_km.ready
         await async_km.restart_kernel(now=True)
         is_alive = await async_km.is_alive()
         assert is_alive
+        await async_km.ready
         await async_km.interrupt_kernel()
         assert isinstance(async_km, AsyncKernelManager)
         await async_km.shutdown_kernel(now=True)

--- a/tests/test_multikernelmanager.py
+++ b/tests/test_multikernelmanager.py
@@ -429,7 +429,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         assert isinstance(k, AsyncKernelManager)
         await ensure_future(km.shutdown_kernel(kid, now=True))
         # Wait for the kernel to shutdown
-        await kernel.ready
+        await kernel.shutdown_ready
         assert kid not in km, f"{kid} not in {km}"
 
     @gen_test
@@ -443,7 +443,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         await kernel.ready
         await ensure_future(km.shutdown_kernel(kid, now=True))
         # Wait for the kernel to shutdown
-        await kernel.ready
+        await kernel.shutdown_ready
         assert kid not in km, f"{kid} not in {km}"
 
     @gen_test
@@ -455,7 +455,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         # Try shutting down while the kernel is pending
         await ensure_future(km.shutdown_kernel(kid, now=True))
         # Wait for the kernel to shutdown
-        await kernel.ready
+        await kernel.shutdown_ready
         assert kid not in km, f"{kid} not in {km}"
 
     @gen_test
@@ -470,7 +470,7 @@ class TestAsyncKernelManager(AsyncTestCase):
         await kernel.ready
         await ensure_future(km.shutdown_kernel(kid, now=True))
         # Wait for the kernel to shutdown
-        await kernel.ready
+        await kernel.shutdown_ready
         assert kid not in km, f"{kid} not in {km}"
 
     @gen_test


### PR DESCRIPTION
- Make the ready promise less timing-sensitive. 
- Separate out a `shutdown_ready` promise.
- Always return concurrent future in synchronous manager and asyncio future in async manager.