### PR TITLE
Fix ready promise and session send

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
           pip check
       - name: Run the tests
         run: |
-          pytest -vv jupyter_client || pytest -vv jupyter_client --lf
+          pytest -vv -W default jupyter_client || pytest -vv -W default jupyter_client --lf
 
   make_sdist:
     name: Make SDist

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -29,7 +29,7 @@ from hmac import (
 from typing import Optional
 from typing import Union
 
-import zmq
+import zmq.asyncio
 from traitlets import Any
 from traitlets import Bool
 from traitlets import CBytes
@@ -806,6 +806,10 @@ class Session(Configurable):
         if not isinstance(stream, zmq.Socket):
             # ZMQStreams and dummy sockets do not support tracking.
             track = False
+
+        if isinstance(stream, zmq.asyncio.Socket):
+            assert stream is not None
+            stream = zmq.Socket.shadow(stream.underlying)
 
         if isinstance(msg_or_type, (Message, dict)):
             # We got a Message or message dict, not a msg_type so don't


### PR DESCRIPTION
- Preserves previous use of `ready` promises, but preserves the promise created in the constructor for initial use.
- Backports a fix from #835 to handle asyncio sockets in `Session.send`