### PR TITLE
Workaround for launch bug

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -158,6 +158,18 @@ def write_connection_file(
     cfg["signature_scheme"] = signature_scheme
     cfg["kernel_name"] = kernel_name
 
+    # Prevent over-writing a file that has already been written with the same
+    # info.  This is to prevent a race condition where the process has
+    # already been launched but has not yet read the connection file.
+    if os.path.exists(fname):
+        with open(fname) as f:
+            try:
+                data = json.load(f)
+                if data == cfg:
+                    return fname, cfg
+            except Exception:
+                pass
+
     # Only ever write this file as user read/writeable
     # This would otherwise introduce a vulnerability as a file has secrets
     # which would let others execute arbitrarily code as you


### PR DESCRIPTION
cc @kevin-bates 

This prevents a race condition where the kernel launch process is attempting to read the connection file, and we overwrite the file while it is being read.   The symptom is that the kernel fails to start because it cannot decode the JSON in the connection file.

We should backport this fix to 7.x, but I think for 8.x we should change it so that the provisioner is entirely responsible for the handling of the connection file, even if the information lives on the kernel manager.   Nothing would change for the local provisioner.