### PR TITLE
Clean up handling of connection file and info

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -307,10 +307,8 @@ class KernelManager(ConnectionFileMixin):
         and
         """
         assert self.provisioner is not None
-        connection_info = await self.provisioner.launch_kernel(kernel_cmd, **kw)
+        await self.provisioner.launch_kernel(kernel_cmd, **kw)
         assert self.provisioner.has_process
-        # Provisioner provides the connection information.  Load into kernel manager and write file.
-        self._force_connection_info(connection_info)
 
     _launch_kernel = run_sync(_async_launch_kernel)
 

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -10,7 +10,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from ..connect import KernelConnectionInfo
 from ..connect import LocalPortCache
 from ..launcher import launch_kernel
 from ..localinterfaces import is_local_ip

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -210,7 +210,6 @@ class LocalProvisioner(KernelProvisionerBase):
 
         self.pid = self.process.pid
         self.pgid = pgid
-        return self.connection_info
 
     @staticmethod
     def _scrub_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -198,7 +198,7 @@ class LocalProvisioner(KernelProvisionerBase):
 
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)
 
-    async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
+    async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> None:
         scrubbed_kwargs = LocalProvisioner._scrub_kwargs(kwargs)
         self.process = launch_kernel(cmd, **scrubbed_kwargs)
         pgid = None

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -108,12 +108,18 @@ class KernelProvisionerBase(ABC, LoggingConfigurable, metaclass=KernelProvisione
         pass
 
     @abstractmethod
-    async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
+    async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> None:
         """
-        Launch the kernel process and return its connection information.
+        Launch the kernel process.
 
         This method is called from `KernelManager.launch_kernel()` during the
         kernel manager's start kernel sequence.
+
+        The provisioner is responsible for writing the connection file
+        and updating the ``parent`` object's ``connection_info`` either in
+        this method or in :meth:`pre_launch`.
+
+        See ``LocalProvisioner.pre_launch()`` for an example.
         """
         pass
 


### PR DESCRIPTION
`KernelProvisioners` are now explicitly responsible for the handling of the connection info and file, but the properties and methods of the `ConnectionFileMixin` continue to live on the `KernelManager` since they are needed when a provisioner is not available.