### PR TITLE
Clean up types and remove use of entrypoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: mypy
         exclude: tests
         args: ["--config-file", "pyproject.toml"]
-        additional_dependencies: [pyzmq, tornado, types-paramiko]
+        additional_dependencies: [pyzmq, tornado, types-paramiko, traitlets, "jupyter_core>=5.0", ipykernel]
         stages: [manual]
 
   - repo: https://github.com/PyCQA/doc8

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -128,7 +128,7 @@ class KernelClient(ConnectionFileMixin):
                     self.log.debug("Destroying zmq context for %s", self)
                 self.context.destroy()
         try:
-            super_del = super().__del__
+            super_del = super().__del__  # type:ignore[misc]
         except AttributeError:
             pass
         else:

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -30,7 +30,6 @@ from jupyter_core.paths import secure_write
 from traitlets import Bool
 from traitlets import CaselessStrEnum
 from traitlets import Instance
-from traitlets import Int
 from traitlets import Integer
 from traitlets import observe
 from traitlets import Type

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -47,11 +47,11 @@ KernelConnectionInfo = Dict[str, Union[int, str, bytes]]
 
 def write_connection_file(
     fname: Optional[str] = None,
-    shell_port: Union[Integer, Int, int] = 0,
-    iopub_port: Union[Integer, Int, int] = 0,
-    stdin_port: Union[Integer, Int, int] = 0,
-    hb_port: Union[Integer, Int, int] = 0,
-    control_port: Union[Integer, Int, int] = 0,
+    shell_port: int = 0,
+    iopub_port: int = 0,
+    stdin_port: int = 0,
+    hb_port: int = 0,
+    control_port: int = 0,
     ip: str = "",
     key: bytes = b"",
     transport: str = "tcp",
@@ -334,7 +334,7 @@ port_names = ["%s_port" % channel for channel in ("shell", "stdin", "iopub", "hb
 class ConnectionFileMixin(LoggingConfigurable):
     """Mixin for configurable classes that work with connection files"""
 
-    data_dir = Unicode()
+    data_dir: Union[str, Unicode] = Unicode()
 
     def _data_dir_default(self):
         return jupyter_data_dir()
@@ -353,7 +353,9 @@ class ConnectionFileMixin(LoggingConfigurable):
     _connection_file_written = Bool(False)
 
     transport = CaselessStrEnum(["tcp", "ipc"], default_value="tcp", config=True)
-    kernel_name = Unicode()
+    kernel_name: Union[str, Unicode] = Unicode()
+
+    context = Instance(zmq.Context)
 
     ip = Unicode(
         config=True,

--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -1,6 +1,8 @@
 """A kernel manager with a tornado IOLoop"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import typing as t
+
 import zmq
 from tornado import ioloop
 from traitlets import Instance
@@ -48,7 +50,7 @@ class IOLoopKernelManager(KernelManager):
         ),
         config=True,
     )
-    _restarter = Instance("jupyter_client.ioloop.IOLoopKernelRestarter", allow_none=True)
+    _restarter: t.Any = Instance("jupyter_client.ioloop.IOLoopKernelRestarter", allow_none=True)
 
     def start_restarter(self):
         if self.autorestart and self.has_kernel:
@@ -87,7 +89,9 @@ class AsyncIOLoopKernelManager(AsyncKernelManager):
         ),
         config=True,
     )
-    _restarter = Instance("jupyter_client.ioloop.AsyncIOLoopKernelRestarter", allow_none=True)
+    _restarter: t.Any = Instance(
+        "jupyter_client.ioloop.AsyncIOLoopKernelRestarter", allow_none=True
+    )
 
     def start_restarter(self):
         if self.autorestart and self.has_kernel:

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -221,7 +221,7 @@ class KernelSpecManager(LoggingConfigurable):
 
         if self.ensure_native_kernel and NATIVE_KERNEL_NAME not in d:
             try:
-                from ipykernel.kernelspec import RESOURCES  # type: ignore
+                from ipykernel.kernelspec import RESOURCES
 
                 self.log.debug(
                     "Native kernel (%s) available from %s",

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -129,7 +129,7 @@ class KernelManager(ConnectionFileMixin):
     def _client_class_changed(self, change: t.Dict[str, DottedObjectName]) -> None:
         self.client_factory = import_item(str(change["new"]))
 
-    kernel_id: str = Unicode(None, allow_none=True)
+    kernel_id: t.Union[str, Unicode] = Unicode(None, allow_none=True)
 
     # The kernel provisioner with which this KernelManager is communicating.
     # This will generally be a LocalProvisioner instance unless the kernelspec
@@ -161,10 +161,10 @@ class KernelManager(ConnectionFileMixin):
         "vary by provisioned environment.",
     )
 
-    kernel_name: Unicode = Unicode(kernelspec.NATIVE_KERNEL_NAME)
+    kernel_name: t.Union[str, Unicode] = Unicode(kernelspec.NATIVE_KERNEL_NAME)
 
     @observe("kernel_name")  # type:ignore[misc]
-    def _kernel_name_changed(self, change: t.Dict[str, Unicode]) -> None:
+    def _kernel_name_changed(self, change: t.Dict[str, str]) -> None:
         self._kernel_spec = None
         if change["new"] == "python":
             self.kernel_name = kernelspec.NATIVE_KERNEL_NAME
@@ -240,7 +240,7 @@ class KernelManager(ConnectionFileMixin):
 
     def client(self, **kwargs: t.Any) -> KernelClient:
         """Create a client configured to connect to our kernel"""
-        kw = {}
+        kw: dict = {}
         kw.update(self.get_connection_info(session=True))
         kw.update(
             dict(
@@ -684,7 +684,7 @@ def start_new_kernel(
     kc = km.client()
     kc.start_channels()
     try:
-        kc.wait_for_ready(timeout=startup_timeout)
+        kc.wait_for_ready(timeout=startup_timeout)  # type:ignore[attr-defined]
     except RuntimeError:
         kc.stop_channels()
         km.shutdown_kernel()
@@ -702,7 +702,7 @@ async def start_new_async_kernel(
     kc = km.client()
     kc.start_channels()
     try:
-        await kc.wait_for_ready(timeout=startup_timeout)
+        await kc.wait_for_ready(timeout=startup_timeout)  # type:ignore[attr-defined]
     except RuntimeError:
         kc.stop_channels()
         await km.shutdown_kernel()

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -122,7 +122,7 @@ class MultiKernelManager(LoggingConfigurable):
                 self.log.debug("Destroying zmq context for %s", self)
             self.context.destroy()
         try:
-            super_del = super().__del__
+            super_del = super().__del__  # type:ignore[misc]
         except AttributeError:
             pass
         else:

--- a/jupyter_client/provisioning/factory.py
+++ b/jupyter_client/provisioning/factory.py
@@ -174,7 +174,7 @@ class KernelProvisionerFactory(SingletonConfigurable):
         return entry_points(group=KernelProvisionerFactory.GROUP_NAME)
 
     def _get_provisioner(self, name: str) -> EntryPoint:
-        """Wrapper around entrypoints.get_single() - primarily to facilitate testing."""
+        """Wrapper around entry_points (to fetch a single provisioner) - primarily to facilitate testing."""
         eps = entry_points(group=KernelProvisionerFactory.GROUP_NAME, name=name)
         if eps:
             return eps[0]

--- a/jupyter_client/provisioning/factory.py
+++ b/jupyter_client/provisioning/factory.py
@@ -170,7 +170,7 @@ class KernelProvisionerFactory(SingletonConfigurable):
 
     @staticmethod
     def _get_all_provisioners() -> List[EntryPoint]:
-        """Wrapper around entrypoints.get_group_all() - primarily to facilitate testing."""
+        """Wrapper around entry_points (to fetch the set of provisioners) - primarily to facilitate testing."""
         return entry_points(group=KernelProvisionerFactory.GROUP_NAME)
 
     def _get_provisioner(self, name: str) -> EntryPoint:

--- a/jupyter_client/provisioning/factory.py
+++ b/jupyter_client/provisioning/factory.py
@@ -2,16 +2,20 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import glob
+import sys
 from os import getenv
 from os import path
 from typing import Any
 from typing import Dict
 from typing import List
 
-from entrypoints import EntryPoint
-from entrypoints import get_group_all
-from entrypoints import get_single
-from entrypoints import NoSuchEntryPoint
+
+# See compatibility note on `group` keyword in https://docs.python.org/3/library/importlib.metadata.html#entry-points
+if sys.version_info < (3, 10):  # pragma: no cover
+    from importlib_metadata import entry_points, EntryPoint
+else:  # pragma: no cover
+    from importlib.metadata import entry_points, EntryPoint
+
 from traitlets.config import default
 from traitlets.config import SingletonConfigurable
 from traitlets.config import Unicode
@@ -119,7 +123,7 @@ class KernelProvisionerFactory(SingletonConfigurable):
             try:
                 ep = self._get_provisioner(provisioner_name)
                 self.provisioners[provisioner_name] = ep  # Update cache
-            except NoSuchEntryPoint:
+            except Exception:
                 is_available = False
         return is_available
 
@@ -161,41 +165,41 @@ class KernelProvisionerFactory(SingletonConfigurable):
         """
         entries = {}
         for name, ep in self.provisioners.items():
-            entries[name] = f"{ep.module_name}:{ep.object_name}"
+            entries[name] = ep.value
         return entries
 
     @staticmethod
     def _get_all_provisioners() -> List[EntryPoint]:
         """Wrapper around entrypoints.get_group_all() - primarily to facilitate testing."""
-        return get_group_all(KernelProvisionerFactory.GROUP_NAME)
+        return entry_points(group=KernelProvisionerFactory.GROUP_NAME)
 
     def _get_provisioner(self, name: str) -> EntryPoint:
         """Wrapper around entrypoints.get_single() - primarily to facilitate testing."""
-        try:
-            ep = get_single(KernelProvisionerFactory.GROUP_NAME, name)
-        except NoSuchEntryPoint:
-            # Check if the entrypoint name is 'local-provisioner'.  Although this should never
-            # happen, we have seen cases where the previous distribution of jupyter_client has
-            # remained which doesn't include kernel-provisioner entrypoints (so 'local-provisioner'
-            # is deemed not found even though its definition is in THIS package).  In such cass,
-            # the entrypoints package uses what it first finds - which is the older distribution
-            # resulting in a violation of a supposed invariant condition.  To address this scenario,
-            # we will log a warning message indicating this situation, then build the entrypoint
-            # instance ourselves - since we have that information.
-            if name == 'local-provisioner':
-                distros = glob.glob(f"{path.dirname(path.dirname(__file__))}-*")
-                self.log.warning(
-                    f"Kernel Provisioning: The 'local-provisioner' is not found.  This is likely "
-                    f"due to the presence of multiple jupyter_client distributions and a previous "
-                    f"distribution is being used as the source for entrypoints - which does not "
-                    f"include 'local-provisioner'.  That distribution should be removed such that "
-                    f"only the version-appropriate distribution remains (version >= 7).  Until "
-                    f"then, a 'local-provisioner' entrypoint will be automatically constructed "
-                    f"and used.\nThe candidate distribution locations are: {distros}"
-                )
-                ep = EntryPoint(
-                    'local-provisioner', 'jupyter_client.provisioning', 'LocalProvisioner'
-                )
-            else:
-                raise
-        return ep
+        eps = entry_points(group=KernelProvisionerFactory.GROUP_NAME, name=name)
+        if eps:
+            return eps[0]
+
+        # Check if the entrypoint name is 'local-provisioner'.  Although this should never
+        # happen, we have seen cases where the previous distribution of jupyter_client has
+        # remained which doesn't include kernel-provisioner entrypoints (so 'local-provisioner'
+        # is deemed not found even though its definition is in THIS package).  In such cass,
+        # the entrypoints package uses what it first finds - which is the older distribution
+        # resulting in a violation of a supposed invariant condition.  To address this scenario,
+        # we will log a warning message indicating this situation, then build the entrypoint
+        # instance ourselves - since we have that information.
+        if name == 'local-provisioner':
+            distros = glob.glob(f"{path.dirname(path.dirname(__file__))}-*")
+            self.log.warning(
+                f"Kernel Provisioning: The 'local-provisioner' is not found.  This is likely "
+                f"due to the presence of multiple jupyter_client distributions and a previous "
+                f"distribution is being used as the source for entrypoints - which does not "
+                f"include 'local-provisioner'.  That distribution should be removed such that "
+                f"only the version-appropriate distribution remains (version >= 7).  Until "
+                f"then, a 'local-provisioner' entrypoint will be automatically constructed "
+                f"and used.\nThe candidate distribution locations are: {distros}"
+            )
+            return EntryPoint(
+                'local-provisioner', 'jupyter_client.provisioning', 'LocalProvisioner'
+            )
+
+        raise

--- a/jupyter_client/provisioning/factory.py
+++ b/jupyter_client/provisioning/factory.py
@@ -182,7 +182,7 @@ class KernelProvisionerFactory(SingletonConfigurable):
         # Check if the entrypoint name is 'local-provisioner'.  Although this should never
         # happen, we have seen cases where the previous distribution of jupyter_client has
         # remained which doesn't include kernel-provisioner entrypoints (so 'local-provisioner'
-        # is deemed not found even though its definition is in THIS package).  In such cass,
+        # is deemed not found even though its definition is in THIS package).  In such cases,
         # the entrypoints package uses what it first finds - which is the older distribution
         # resulting in a violation of a supposed invariant condition.  To address this scenario,
         # we will log a warning message indicating this situation, then build the entrypoint

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -9,6 +9,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
 
 from traitlets.config import Instance
 from traitlets.config import LoggingConfigurable
@@ -21,7 +22,9 @@ class KernelProvisionerMeta(ABCMeta, type(LoggingConfigurable)):  # type: ignore
     pass
 
 
-class KernelProvisionerBase(ABC, LoggingConfigurable, metaclass=KernelProvisionerMeta):
+class KernelProvisionerBase(
+    ABC, LoggingConfigurable, metaclass=KernelProvisionerMeta
+):  # type:ignore[misc]
     """
     Abstract base class defining methods for KernelProvisioner classes.
 
@@ -35,7 +38,7 @@ class KernelProvisionerBase(ABC, LoggingConfigurable, metaclass=KernelProvisione
 
     # The kernel specification associated with this provisioner
     kernel_spec: Any = Instance('jupyter_client.kernelspec.KernelSpec', allow_none=True)
-    kernel_id: str = Unicode(None, allow_none=True)
+    kernel_id: Union[str, Unicode] = Unicode(None, allow_none=True)
     connection_info: KernelConnectionInfo = {}
 
     @property

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -22,9 +22,9 @@ class KernelProvisionerMeta(ABCMeta, type(LoggingConfigurable)):  # type: ignore
     pass
 
 
-class KernelProvisionerBase(
+class KernelProvisionerBase(  # type:ignore[misc]
     ABC, LoggingConfigurable, metaclass=KernelProvisionerMeta
-):  # type:ignore[misc]
+):
     """
     Abstract base class defining methods for KernelProvisioner classes.
 

--- a/jupyter_client/runapp.py
+++ b/jupyter_client/runapp.py
@@ -44,8 +44,8 @@ class RunApp(JupyterApp, JupyterConsoleApp):
     version = __version__
     name = "jupyter run"
     description = """Run Jupyter kernel code."""
-    flags = Dict(flags)
-    aliases = Dict(aliases)
+    flags = Dict(flags)  # type:ignore[assignment]
+    aliases = Dict(aliases)  # type:ignore[assignment]
     frontend_aliases = Any(frontend_aliases)
     frontend_flags = Any(frontend_flags)
     kernel_timeout = Float(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "entrypoints",
+    "importlib_metadata>=4.8.3;python_version<\"3.10\"",
     "jupyter_core>=4.9.2",
     "python-dateutil>=2.8.2",
     "pyzmq>=23.0",
@@ -138,15 +138,6 @@ warn_unused_configs = true
 warn_redundant_casts = true
 warn_return_any = false
 warn_unused_ignores = true
-
-[[tool.mypy.overrides]]
-module = [
-    "traitlets.*",
-    "jupyter_core.*",
-    "ipykernel",
-    "entrypoints"
-]
-ignore_missing_imports = true
 
 [tool.flake8]
 ignore = "E501, W503, E402"


### PR DESCRIPTION
`entrypoints` has been deprecated in favor of `importlib.metadata`.