### PR TITLE
Add more coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
             python-version: "3.8"
     steps:
       - uses: actions/checkout@v3
+      - shell: bash
+        run: cat ~/.ssh/config
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - run: hatch run test:test -k test_console_app_ssh
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,6 @@ jobs:
             python-version: "3.8"
     steps:
       - uses: actions/checkout@v3
-      - shell: bash
-        run: |
-          ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,10 +56,9 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - shell: bash
         run: |
-          mkdir ~/.ssh
+          mkdir -p ~/.ssh
           eval `ssh-agent -s`
-          ssh-keygen -t rsa -f test_key -N ""
-          ssh-add ./test_key
+          hatch run test:test -k test_console_app_ssh
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
       - shell: bash
         run: |
           ssh-keygen -f test_consoleapp -N ""
+          ssh-add ./test_consoleapp
           ssh -v -f 127.0.0.1 -i test_consoleapp -o StrictHostKeyChecking=no exit
           exit 1
       - name: Run the tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,14 +57,16 @@ jobs:
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
-          hatch run cov:test || hatch run test:test --lf
-      - name: Run the tests on pypy and windows
-        if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}
+          hatch run cov:test --cov-fail-under 70 || hatch run test:test --lf
+      - name: Run the tests on pypy
+        if: ${{ startsWith(matrix.python-version, 'pypy') }}
         run: |
-          # Ignore warnings on Windows and PyPI
-          pip install -e ".[test]"
-          python -m pytest -vv -W ignore || python -m pytest -vv -W ignore --lf
-
+          # Ignore warnings on pypy
+          hatch run test:test -W default
+      - name: Run the tests on Windows
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |
+           hatch run cov:test || hatch run test:test --lf
       - name: Code coverage
         run: |
           pip install codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - shell: bash
+        run: |
+          ssh-keygen -f test_consoleapp -N ""
+          ssh -f 127.0.0.1 -i test_consoleapp -o StrictHostKeyChecking=no exit
+          exit 1
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: webfactory/ssh-agent@v0.6.0
         with:
-          ssh-private-key: not-a-real-key
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,9 +54,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - uses: webfactory/ssh-agent@v0.6.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - shell: bash
+        run: |
+          mkdir ~/.ssh
+          ssh-agent
+          ssh-keygen -f test_key -N ""
+          ssh-add test_key
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,13 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - shell: bash
-        run: |
-          ssh-keygen -f test_consoleapp -N ""
-          ssh-agent /bin/sh
-          ssh-add ./test_consoleapp
-          ssh -v -f 127.0.0.1 -i test_consoleapp -o StrictHostKeyChecking=no exit
-          exit 1
+      - uses: webfactory/ssh-agent@v0.6.0
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,13 +57,15 @@ jobs:
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
-          hatch run cov:test || hatch run test:test --lf
-      - name: Run the tests on pypy and windows
-        if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}
+          hatch run cov:test --cov-fail-under 75 || hatch run test:test --lf
+      - name: Run the tests on pypy
+        if: ${{ startsWith(matrix.python-version, 'pypy') }}
         run: |
-          # Ignore warnings on Windows and PyPI
-          pip install -e ".[test]"
-          python -m pytest -vv -W ignore || python -m pytest -vv -W ignore --lf
+          hatch run test:test -W default || hatch run test:test -W default --lf
+      - name: Run the tests on windows
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |
+          hatch run cov:test -W default || hatch run test:test -W default --lf
       - name: Code coverage
         run: |
           pip install codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       - shell: bash
         run: |
           mkdir ~/.ssh
-          ssh-agent
+          eval `ssh-agent -s`
           ssh-keygen -t rsa -f test_key -N ""
           ssh-add ./test_key
       - name: Run the tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: webfactory/ssh-agent@v0.6.0
+        with:
+          ssh-private-key: not-a-real-key
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,8 @@ jobs:
       - shell: bash
         run: |
           ssh-keygen -f test_consoleapp -N ""
-          ssh-add ./test_consoleapp
+          ssh-agent /bin/sh
+          #ssh-add ./test_consoleapp
           ssh -v -f 127.0.0.1 -i test_consoleapp -o StrictHostKeyChecking=no exit
           exit 1
       - name: Run the tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,6 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - shell: bash
         run: |
-          mkdir -p ~/.ssh
-          eval `ssh-agent -s`
           hatch run test:test -k test_console_app_ssh
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,8 @@ jobs:
         run: |
           mkdir ~/.ssh
           ssh-agent
-          ssh-keygen -f test_key -N ""
-          ssh-add test_key
+          ssh-keygen -t rsa -f test_key -N ""
+          ssh-add ./test_key
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       - shell: bash
         run: |
           ssh-keygen -f test_consoleapp -N ""
-          ssh -f 127.0.0.1 -i test_consoleapp -o StrictHostKeyChecking=no exit
+          ssh -v -f 127.0.0.1 -i test_consoleapp -o StrictHostKeyChecking=no exit
           exit 1
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - shell: bash
-        run: cat ~/.ssh/config
+        run: ls -ltr ~/.ssh
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           ssh-keygen -f test_consoleapp -N ""
           ssh-agent /bin/sh
-          #ssh-add ./test_consoleapp
+          ssh-add ./test_consoleapp
           ssh -v -f 127.0.0.1 -i test_consoleapp -o StrictHostKeyChecking=no exit
           exit 1
       - name: Run the tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - shell: bash
-        run: ls -ltr ~/.ssh
+        run: |
+          ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - run: hatch run test:test -k test_console_app_ssh
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,27 +54,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - shell: bash
-        run: |
-          hatch run test:test -k test_console_app_ssh
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
-          hatch run cov:test --cov-fail-under 70 || hatch run test:test --lf
-      - name: Run the tests on pypy
-        if: ${{ startsWith(matrix.python-version, 'pypy') }}
+          hatch run cov:test || hatch run test:test --lf
+      - name: Run the tests on pypy and windows
+        if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}
         run: |
-          # Ignore warnings on pypy
-          hatch run test:test -W default
-      - name: Run the tests on Windows
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        run: |
-           hatch run cov:test || hatch run test:test --lf
+          # Ignore warnings on Windows and PyPI
+          pip install -e ".[test]"
+          python -m pytest -vv -W ignore || python -m pytest -vv -W ignore --lf
       - name: Code coverage
         run: |
           pip install codecov
           codecov
-
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -116,7 +109,6 @@ jobs:
       - name: Run the tests
         run: |
           pytest -vv -W default || pytest -vv -W default --lf
-
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -310,7 +310,6 @@ def tunnel_to_kernel(
         password = getpass("SSH Password for %s: " % sshserver)
 
     for lp, rp in zip(lports, rports):
-        print('what?')
         tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)
 
     return tuple(lports)

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -12,7 +12,6 @@ import os
 import socket
 import stat
 import tempfile
-import time
 import warnings
 from getpass import getpass
 from typing import Any

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -311,7 +311,7 @@ def tunnel_to_kernel(
         password = getpass("SSH Password for %s: " % sshserver)
 
     for lp, rp in zip(lports, rports):
-        for i in range(3):
+        for _ in range(3):
             try:
                 tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)
                 continue

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -12,6 +12,7 @@ import os
 import socket
 import stat
 import tempfile
+import time
 import warnings
 from getpass import getpass
 from typing import Any
@@ -310,7 +311,13 @@ def tunnel_to_kernel(
         password = getpass("SSH Password for %s: " % sshserver)
 
     for lp, rp in zip(lports, rports):
-        tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)
+        for i in range(3):
+            try:
+                tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)
+                continue
+            except RuntimeError:
+                time.sleep(0.1)
+                pass
 
     return tuple(lports)
 

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -311,13 +311,7 @@ def tunnel_to_kernel(
         password = getpass("SSH Password for %s: " % sshserver)
 
     for lp, rp in zip(lports, rports):
-        for _ in range(3):
-            try:
-                tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)
-                continue
-            except RuntimeError:
-                time.sleep(0.1)
-                pass
+        tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)
 
     return tuple(lports)
 

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -310,6 +310,7 @@ def tunnel_to_kernel(
         password = getpass("SSH Password for %s: " % sshserver)
 
     for lp, rp in zip(lports, rports):
+        print('what?')
         tunnel.ssh_tunnel(lp, rp, sshserver, remote_ip, sshkey, password)
 
     return tuple(lports)

--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -361,7 +361,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
         Classes which mix this class in should call:
                JupyterConsoleApp.initialize(self,argv)
         """
-        if self._dispatching:  # type:ignore[attr-defined]
+        if getattr(self, "_dispatching", False):
             return
         self.init_connection_file()
         self.init_ssh()

--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -66,6 +66,7 @@ class ListKernelSpecs(JupyterApp):
                 print(f"  {kernelname.ljust(name_len)}    {path}")
         else:
             print(json.dumps({"kernelspecs": specs}, indent=2))
+        return specs
 
 
 class InstallKernelSpec(JupyterApp):
@@ -228,7 +229,7 @@ class InstallNativeKernelSpec(JupyterApp):
     description = """[DEPRECATED] Install the IPython kernel spec directory for this Python."""
     kernel_spec_manager = Instance(KernelSpecManager)
 
-    def _kernel_spec_manager_default(self):
+    def _kernel_spec_manager_default(self):  # pragma: no cover
         return KernelSpecManager(data_dir=self.data_dir)
 
     user = Bool(
@@ -248,7 +249,7 @@ class InstallNativeKernelSpec(JupyterApp):
         "debug": base_flags["debug"],
     }
 
-    def start(self):
+    def start(self):  # pragma: no cover
         self.log.warning(
             "`jupyter kernelspec install-self` is DEPRECATED as of 4.0."
             " You probably want `ipython kernel install` to install the IPython kernelspec."

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -255,7 +255,7 @@ class Message:
 
     # Having this iterator lets dict(msg_obj) work out of the box.
     def __iter__(self) -> t.ItemsView[str, t.Any]:
-        return iter(self.__dict__.items())
+        return iter(self.__dict__.items())  # type:ignore[return-value]
 
     def __repr__(self) -> str:
         return repr(self.__dict__)

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -69,7 +69,7 @@ utc = timezone.utc
 def squash_unicode(obj):
     """coerce unicode back to bytestrings."""
     if isinstance(obj, dict):
-        for key in obj.keys():
+        for key in list(obj.keys()):
             obj[key] = squash_unicode(obj[key])
             if isinstance(key, str):
                 obj[squash_unicode(key)] = obj.pop(key)
@@ -184,7 +184,7 @@ session_flags = {
 }
 
 
-def default_secure(cfg: t.Any) -> None:
+def default_secure(cfg: t.Any) -> None:  # pragma: no cover
     """Set the default behavior for a config environment to be secure.
 
     If Session.key/keyfile have not been set, set Session.key to
@@ -255,7 +255,7 @@ class Message:
 
     # Having this iterator lets dict(msg_obj) work out of the box.
     def __iter__(self) -> t.ItemsView[str, t.Any]:
-        return self.__dict__.items()
+        return iter(self.__dict__.items())
 
     def __repr__(self) -> str:
         return repr(self.__dict__)
@@ -1086,7 +1086,7 @@ class Session(Configurable):
         # adapt to the current version
         return adapt(message)
 
-    def unserialize(self, *args: t.Any, **kwargs: t.Any) -> t.Dict[str, t.Any]:
+    def unserialize(self, *args: t.Any, **kwargs: t.Any) -> t.Dict[str, t.Any]:  # pragma: no cover
         warnings.warn(
             "Session.unserialize is deprecated. Use Session.deserialize.",
             DeprecationWarning,

--- a/jupyter_client/ssh/tunnel.py
+++ b/jupyter_client/ssh/tunnel.py
@@ -260,7 +260,7 @@ def openssh_tunnel(
     failed = False
     while True:
         try:
-            i = tunnel.expect([ssh_newkey, _password_pat], timeout=1)
+            i = tunnel.expect([ssh_newkey, _password_pat], timeout=0.1)
             if i == 0:
                 raise SSHException("The authenticity of the host can't be established.")
         except pexpect.TIMEOUT:

--- a/jupyter_client/ssh/tunnel.py
+++ b/jupyter_client/ssh/tunnel.py
@@ -260,12 +260,13 @@ def openssh_tunnel(
     failed = False
     while True:
         try:
-            i = tunnel.expect([ssh_newkey, _password_pat], timeout=0.1)
+            i = tunnel.expect([ssh_newkey, _password_pat], timeout=1)
             if i == 0:
                 raise SSHException("The authenticity of the host can't be established.")
         except pexpect.TIMEOUT:
             continue
         except pexpect.EOF as e:
+            tunnel.wait()
             if tunnel.exitstatus:
                 print(tunnel.exitstatus)
                 print(tunnel.before)

--- a/jupyter_client/ssh/tunnel.py
+++ b/jupyter_client/ssh/tunnel.py
@@ -80,8 +80,6 @@ def _try_passwordless_openssh(server, keyfile):
     cmd = "ssh -f " + server
     if keyfile:
         cmd += " -i " + keyfile
-    # if "PYTEST_CURRENT_TEST" in os.environ:
-    #     cmd += " -o StrictHostKeyChecking=no"
     cmd += " exit"
 
     # pop SSH_ASKPASS from env

--- a/jupyter_client/ssh/tunnel.py
+++ b/jupyter_client/ssh/tunnel.py
@@ -95,6 +95,8 @@ def _try_passwordless_openssh(server, keyfile):
             i = p.expect([ssh_newkey, _password_pat], timeout=0.1)
             if i == 0:
                 raise SSHException("The authenticity of the host can't be established.")
+            elif i == 1:
+                raise RuntimeError("Asked for a password")
         except pexpect.TIMEOUT:
             continue
         except pexpect.EOF:

--- a/jupyter_client/ssh/tunnel.py
+++ b/jupyter_client/ssh/tunnel.py
@@ -95,8 +95,6 @@ def _try_passwordless_openssh(server, keyfile):
             i = p.expect([ssh_newkey, _password_pat], timeout=0.1)
             if i == 0:
                 raise SSHException("The authenticity of the host can't be established.")
-            elif i == 1:
-                raise RuntimeError("Asked for a password")
         except pexpect.TIMEOUT:
             continue
         except pexpect.EOF:

--- a/jupyter_client/ssh/tunnel.py
+++ b/jupyter_client/ssh/tunnel.py
@@ -80,8 +80,8 @@ def _try_passwordless_openssh(server, keyfile):
     cmd = "ssh -f " + server
     if keyfile:
         cmd += " -i " + keyfile
-    if "PYTEST_CURRENT_TEST" in os.environ:
-        cmd += " -o StrictHostKeyChecking=no"
+    # if "PYTEST_CURRENT_TEST" in os.environ:
+    #     cmd += " -o StrictHostKeyChecking=no"
     cmd += " exit"
 
     # pop SSH_ASKPASS from env

--- a/jupyter_client/ssh/tunnel.py
+++ b/jupyter_client/ssh/tunnel.py
@@ -80,6 +80,8 @@ def _try_passwordless_openssh(server, keyfile):
     cmd = "ssh -f " + server
     if keyfile:
         cmd += " -i " + keyfile
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        cmd += " -o StrictHostKeyChecking=no"
     cmd += " exit"
 
     # pop SSH_ASKPASS from env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,9 @@ exclude_lines = [
   "class .*\bProtocol\\):",
 "@(abc\\.)?abstractmethod",
 ]
+omit = [
+    "jupyter_client/ssh/forward.py"
+]
 
 [tool.mypy]
 check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
 docs = [
     "ipykernel",
     "myst-parser",
-    "sphinx>=1.3.6",
+    "sphinx>=4",
     "pydata_sphinx_theme",
     "sphinxcontrib_github_alt",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ test = [
     "coverage",
     "ipykernel>=6.11",
     "mypy",
+    "paramiko; sys_platform == 'win32'",
     "pre-commit",
     "pytest",
     "pytest-asyncio>=0.19",
@@ -95,7 +96,7 @@ dependencies = ["coverage", "pytest-cov"]
 [tool.hatch.envs.cov.env-vars]
 ARGS = "-vv --cov jupyter_client --cov-branch --cov-report term-missing:skip-covered"
 [tool.hatch.envs.cov.scripts]
-test = "python -m pytest $ARGS --cov-fail-under 70 {args}"
+test = "python -m pytest $ARGS {args}"
 
 [tool.black]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import asyncio
+import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -64,3 +66,13 @@ def env():
 @pytest.fixture()
 def kernel_dir():
     return pjoin(paths.jupyter_data_dir(), 'kernels')
+
+
+@pytest.fixture
+def kernel_spec(tmpdir):
+    test_dir = Path(tmpdir / "test")
+    test_dir.mkdir()
+    kernel_data = {"argv": [], "display_name": "test", "language": "test"}
+    spec_file_path = Path(test_dir / "kernel.json")
+    spec_file_path.write_text(json.dumps(kernel_data), 'utf8')
+    return str(test_dir)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import os
+import platform
+import sys
 from threading import Event
 from unittest import mock
 from unittest import TestCase
@@ -130,6 +132,10 @@ class TestAsyncKernelClient:
         assert reply["header"]["msg_type"] == reply_type + "_reply"
         assert reply["parent_header"]["msg_type"] == reply_type + "_request"
 
+    @pytest.mark.skipif(
+        sys.platform != 'linux' or platform.python_implementation().lower() == 'pypy',
+        reason='only works with cpython on ubuntu in ci',
+    )
     async def test_input_request(self, kc):
         with mock.patch('builtins.input', return_value='test\n'):
             reply = await kc.execute_interactive("a = input()", timeout=TIMEOUT)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 from threading import Event
+from unittest import mock
 from unittest import TestCase
 
 import pytest
@@ -11,6 +12,7 @@ from traitlets import DottedObjectName
 from traitlets import Type
 
 from .utils import test_env
+from jupyter_client.client import validate_string_dict
 from jupyter_client.kernelspec import KernelSpecManager
 from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
 from jupyter_client.kernelspec import NoSuchKernel
@@ -128,6 +130,25 @@ class TestAsyncKernelClient:
         assert reply["header"]["msg_type"] == reply_type + "_reply"
         assert reply["parent_header"]["msg_type"] == reply_type + "_request"
 
+    async def test_input_request(self, kc):
+        with mock.patch('builtins.input', return_value='test\n'):
+            reply = await kc.execute_interactive("a = input()", timeout=TIMEOUT)
+        assert reply["content"]["status"] == "ok"
+
+    async def test_output_hook(self, kc):
+        called = False
+
+        def output_hook(msg):
+            nonlocal called
+            if msg['header']['msg_type'] == 'stream':
+                called = True
+
+        reply = await kc.execute_interactive(
+            "print('hello')", timeout=TIMEOUT, output_hook=output_hook
+        )
+        assert reply["content"]["status"] == "ok"
+        assert called
+
     async def test_history(self, kc):
         msg_id = await kc.history(session=0)
         assert isinstance(msg_id, str)
@@ -145,6 +166,12 @@ class TestAsyncKernelClient:
         assert isinstance(msg_id, str)
         reply = await kc.complete("code", reply=True, timeout=TIMEOUT)
         self._check_reply("complete", reply)
+
+    async def test_is_complete(self, kc):
+        msg_id = await kc.is_complete("who cares")
+        assert isinstance(msg_id, str)
+        reply = await kc.is_complete("code", reply=True, timeout=TIMEOUT)
+        self._check_reply("is_complete", reply)
 
     async def test_kernel_info(self, kc):
         msg_id = await kc.kernel_info()
@@ -272,3 +299,10 @@ class TestThreadedKernelClient(TestKernelClient):
         kc = self.kc
         msg_id = kc.shutdown()
         self.assertIsInstance(msg_id, str)
+
+
+def test_validate_string_dict():
+    with pytest.raises(ValueError):
+        validate_string_dict(dict(a=1))
+    with pytest.raises(ValueError):
+        validate_string_dict({1: 'a'})

--- a/tests/test_consoleapp.py
+++ b/tests/test_consoleapp.py
@@ -15,8 +15,8 @@ from jupyter_client.manager import start_new_kernel
 def sshkey(tmp_path):
     os.chdir(tmp_path)
     name = "test_consoleapp"
-    subprocess.run(["ssh-keygen", "-f", name, "-N", ""])
-    subprocess.run(["ssh-add", name])
+    subprocess.check_call(["ssh-keygen", "-f", name, "-N", ""])
+    subprocess.check_call(["ssh-add", name])
     yield name
 
 

--- a/tests/test_consoleapp.py
+++ b/tests/test_consoleapp.py
@@ -1,0 +1,47 @@
+"""Tests for the JupyterConsoleApp"""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import os
+import subprocess
+
+import pytest
+from jupyter_core.application import JupyterApp
+
+from jupyter_client.consoleapp import JupyterConsoleApp
+from jupyter_client.manager import start_new_kernel
+
+
+@pytest.fixture
+def sshkey(tmp_path):
+    os.chdir(tmp_path)
+    name = "test_consoleapp"
+    subprocess.run(["ssh-keygen", "-f", name, "-N", ""])
+    yield name
+
+
+class MockConsoleApp(JupyterConsoleApp, JupyterApp):
+    pass
+
+
+def test_console_app_no_existing():
+    app = MockConsoleApp()
+    app.initialize([])
+
+
+def test_console_app_existing(tmp_path):
+    km, kc = start_new_kernel()
+    cf = kc.connection_file
+    app = MockConsoleApp(connection_file=cf, existing=cf)
+    app.initialize([])
+    kc.stop_channels()
+    km.shutdown_kernel()
+
+
+def test_console_app_ssh(sshkey, tmp_path):
+    km, kc = start_new_kernel()
+    cf = kc.connection_file
+    os.chdir(tmp_path)
+    app = MockConsoleApp(connection_file=cf, existing=cf, sshkey=sshkey)
+    app.initialize([])
+    kc.stop_channels()
+    km.shutdown_kernel()

--- a/tests/test_consoleapp.py
+++ b/tests/test_consoleapp.py
@@ -16,6 +16,7 @@ def sshkey(tmp_path):
     os.chdir(tmp_path)
     name = "test_consoleapp"
     subprocess.run(["ssh-keygen", "-f", name, "-N", ""])
+    subprocess.run(["ssh-add", name])
     yield name
 
 

--- a/tests/test_consoleapp.py
+++ b/tests/test_consoleapp.py
@@ -2,9 +2,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import os
-import subprocess
 
-import pytest
 from jupyter_core.application import JupyterApp
 
 from jupyter_client.consoleapp import JupyterConsoleApp

--- a/tests/test_consoleapp.py
+++ b/tests/test_consoleapp.py
@@ -35,7 +35,6 @@ def test_console_app_ssh(tmp_path):
     app = MockConsoleApp(
         connection_file=cf, existing=cf, sshserver="does_not_exist", sshkey="test_console_app"
     )
-
     with pytest.raises(SystemExit):
         app.initialize([])
     kc.stop_channels()

--- a/tests/test_consoleapp.py
+++ b/tests/test_consoleapp.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 import os
 
+import pytest
 from jupyter_core.application import JupyterApp
 
 from jupyter_client.consoleapp import JupyterConsoleApp
@@ -31,7 +32,11 @@ def test_console_app_ssh(tmp_path):
     km, kc = start_new_kernel()
     cf = kc.connection_file
     os.chdir(tmp_path)
-    app = MockConsoleApp(connection_file=cf, existing=cf, sshkey="test_console_app")
-    app.initialize([])
+    app = MockConsoleApp(
+        connection_file=cf, existing=cf, sshserver="does_not_exist", sshkey="test_console_app"
+    )
+
+    with pytest.raises(SystemExit):
+        app.initialize([])
     kc.stop_channels()
     km.shutdown_kernel()

--- a/tests/test_consoleapp.py
+++ b/tests/test_consoleapp.py
@@ -11,15 +11,6 @@ from jupyter_client.consoleapp import JupyterConsoleApp
 from jupyter_client.manager import start_new_kernel
 
 
-@pytest.fixture
-def sshkey(tmp_path):
-    os.chdir(tmp_path)
-    name = "test_consoleapp"
-    subprocess.check_call(["ssh-keygen", "-f", name, "-N", ""])
-    subprocess.check_call(["ssh-add", name])
-    yield name
-
-
 class MockConsoleApp(JupyterConsoleApp, JupyterApp):
     pass
 
@@ -38,11 +29,11 @@ def test_console_app_existing(tmp_path):
     km.shutdown_kernel()
 
 
-def test_console_app_ssh(sshkey, tmp_path):
+def test_console_app_ssh(tmp_path):
     km, kc = start_new_kernel()
     cf = kc.connection_file
     os.chdir(tmp_path)
-    app = MockConsoleApp(connection_file=cf, existing=cf, sshkey=sshkey)
+    app = MockConsoleApp(connection_file=cf, existing=cf, sshkey="test_console_app")
     app.initialize([])
     kc.stop_channels()
     km.shutdown_kernel()

--- a/tests/test_kernelspecapp.py
+++ b/tests/test_kernelspecapp.py
@@ -39,9 +39,11 @@ def test_kernelspec_sub_apps(kernel_spec):
 
 def test_kernelspec_app():
     app = KernelSpecApp()
-    app.launch_instance(["list"])
+    app.initialize(["list"])
+    app.start()
 
 
 def test_list_provisioners_app():
     app = ListProvisioners()
-    app.launch_instance([])
+    app.initialize([])
+    app.start()

--- a/tests/test_kernelspecapp.py
+++ b/tests/test_kernelspecapp.py
@@ -1,0 +1,47 @@
+"""Tests for the kernelspecapp"""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import os
+import warnings
+
+from jupyter_client.kernelspecapp import InstallKernelSpec
+from jupyter_client.kernelspecapp import KernelSpecApp
+from jupyter_client.kernelspecapp import ListKernelSpecs
+from jupyter_client.kernelspecapp import ListProvisioners
+from jupyter_client.kernelspecapp import RemoveKernelSpec
+
+
+def test_kernelspec_sub_apps(kernel_spec):
+    app = InstallKernelSpec()
+    prefix = os.path.dirname(os.environ['JUPYTER_DATA_DIR'])
+    kernel_dir = os.path.join(prefix, 'share/jupyter/kernels')
+    app.kernel_spec_manager.kernel_dirs.append(kernel_dir)
+    app.prefix = prefix = prefix
+    app.initialize([kernel_spec])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        app.start()
+
+    app = ListKernelSpecs()
+    app.kernel_spec_manager.kernel_dirs.append(kernel_dir)
+    specs = app.start()
+    assert 'test' in specs
+
+    app = RemoveKernelSpec(spec_names=['test'], force=True)
+    app.kernel_spec_manager.kernel_dirs.append(kernel_dir)
+    app.start()
+
+    app = ListKernelSpecs()
+    app.kernel_spec_manager.kernel_dirs.append(kernel_dir)
+    specs = app.start()
+    assert 'test' not in specs
+
+
+def test_kernelspec_app():
+    app = KernelSpecApp()
+    app.launch_instance(["list"])
+
+
+def test_list_provisioners_app():
+    app = ListProvisioners()
+    app.launch_instance()

--- a/tests/test_kernelspecapp.py
+++ b/tests/test_kernelspecapp.py
@@ -44,4 +44,4 @@ def test_kernelspec_app():
 
 def test_list_provisioners_app():
     app = ListProvisioners()
-    app.launch_instance()
+    app.launch_instance([])

--- a/tests/test_localinterfaces.py
+++ b/tests/test_localinterfaces.py
@@ -4,6 +4,8 @@
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
 # -----------------------------------------------------------------------------
+import sys
+
 from jupyter_client import localinterfaces
 
 
@@ -13,3 +15,15 @@ def test_load_ips():
 
     # Just check this doesn't error
     localinterfaces._load_ips(suppress_exceptions=False)
+
+    localinterfaces.is_local_ip('8.8.8.8')
+    localinterfaces.is_public_ip('127.0.0.1')
+    ips = localinterfaces.local_ips()
+    assert '127.0.0.1' in ips
+
+    localinterfaces._load_ips_gethostbyname()
+    localinterfaces._load_ips_dumb()
+
+    if sys.platform == 'linux':
+        localinterfaces._load_ips_ip()
+        localinterfaces._load_ips_ifconfig()

--- a/tests/test_restarter.py
+++ b/tests/test_restarter.py
@@ -80,6 +80,13 @@ def debug_logging():
     get_logger().setLevel("DEBUG")
 
 
+win_skip = pytest.mark.skipif(
+    os.name == 'nt',
+    reason='"RuntimeError: Cannot run the event loop while another loop is running" error on Windows',
+)
+
+
+@win_skip
 @pytest.mark.asyncio
 async def test_restart_check(config, install_kernel, debug_logging):
     """Test that the kernel is restarted and recovers"""
@@ -136,6 +143,7 @@ async def test_restart_check(config, install_kernel, debug_logging):
         assert km.context.closed
 
 
+@win_skip
 @pytest.mark.asyncio
 async def test_restarter_gives_up(config, install_fail_kernel, debug_logging):
     """Test that the restarter gives up after reaching the restart limit"""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -491,8 +491,8 @@ class TestSession:
 
     def test_set_packer(self, session):
         s = session
-        s.packer = ss.json_packer
-        s.unpacker = ss.json_unpacker
+        s.packer = "json"
+        s.unpacker = "json"
 
     def test_clone(self, session):
         s = session

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,6 @@
 """test building messages with Session"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import datetime
 import hmac
 import os
 import platform
@@ -518,7 +517,7 @@ def test_json_packer():
     ss.json_packer(dict(a=1))
     with pytest.raises(ValueError):
         ss.json_packer(dict(a=ss.Session()))
-    ss.json_packer(dict(a=datetime.datetime(2021, 4, 1, 12, tzinfo=tzlocal())))
+    ss.json_packer(dict(a=datetime(2021, 4, 1, 12, tzinfo=tzlocal())))
 
 
 def test_message_cls():


### PR DESCRIPTION
- Add coverage for `JupyterConsoleApp`, with attempted ssh tunneling.   Skip checking `ssh/forward.py` since it isn't used and is listed as a demo.
- Add coverage for the kernel spec apps
- Increase `Session` coverage
- Increase `localinterfaces` coverage
- Increase `KernelClient` coverage
- Add Windows coverage