### PR TITLE
Make sure loop is marked with nest_asyncio

### DIFF
--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -3,7 +3,6 @@ replies.
 """
 import asyncio
 import atexit
-import nest_asyncio
 import errno
 import time
 from threading import Event
@@ -15,6 +14,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+import nest_asyncio
 import zmq
 from traitlets import Instance
 from traitlets import Type

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -3,6 +3,7 @@ replies.
 """
 import asyncio
 import atexit
+import nest_asyncio
 import errno
 import time
 from threading import Event
@@ -211,6 +212,7 @@ class IOLoopThread(Thread):
         """Run my loop, ignoring EINTR events in the poller"""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
+        nest_asyncio.apply(loop)
         self.ioloop = ioloop.IOLoop()
         self.ioloop._asyncio_event_loop = loop
         # signal that self.ioloop is defined

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -14,7 +14,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-import nest_asyncio
+import nest_asyncio  # type:ignore
 import zmq
 from traitlets import Instance
 from traitlets import Type


### PR DESCRIPTION
I know that this is already obsolete with https://github.com/jupyter/jupyter_client/pull/835.  Sometimes, this loop is not marked by nest_asyncio (when calling `run_sync`) so this makes sure that the two eventloops (`asyncio.new_event_loop()` and the other created in `ioloop.IOLoop()`) do not make the system crash. Unfortunately, I can not really give you a reproducible example as I was messing with spyder code when it happened. Feel free to close this PR if you think this is not needed.