### PR TITLE
Make run_sync compatible with python 3.10.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,8 @@ jobs:
           - os: ubuntu-latest
             python-version: "pypy-3.8"
           - os: ubuntu-latest
+            python-version: "3.10.9"
+          - os: ubuntu-latest
             python-version: "3.11"
           - os: macos-latest
             python-version: "3.8"


### PR DESCRIPTION
Make run_sync compatible with python 3.10.9
    
Fix https://github.com/jupyter/jupyter_client/issues/901