### PR TITLE
MAINT: Proper typing and cast

### DIFF
--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -10,6 +10,7 @@ import typing as t
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from traitlets import Bool, Dict, Instance, List, Unicode
 from traitlets.config.application import Application
+from traitlets.config.loader import Config
 
 from . import __version__
 from .kernelspec import KernelSpecManager
@@ -321,8 +322,10 @@ class KernelSpecApp(Application):
         }
     )
 
-    aliases: t.Dict[str, object] = {}  # type:ignore[assignment]
-    flags: t.Dict[str, object] = {}  # type:ignore[assignment]
+    aliases: t.Dict[t.Union[str, t.Tuple[str, ...]], t.Union[str, t.Tuple[str, str]]] = {}
+    flags: t.Dict[
+        t.Union[str, t.Tuple[str, ...]], t.Tuple[t.Union[t.Dict[str, t.Any], Config], str]
+    ] = {}
 
     def start(self):
         """Start the application."""

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -600,7 +600,7 @@ class KernelManager(ConnectionFileMixin):
         if not self.has_kernel:
             if self._ready is not None:
                 if isinstance(self._ready, CFuture):
-                    ready = asyncio.ensure_future(self._ready)  # type:ignore
+                    ready = asyncio.ensure_future(t.cast(Future[t.Any], self._ready))
                 else:
                     ready = self._ready
                 # Wait for a shutdown if one is in progress.


### PR DESCRIPTION
Cast has minimal if no runtime cost, and is slightly more precise that just ignoring types