### PR TITLE
MAINT: consistently use relative imports.

### DIFF
--- a/jupyter_client/adapter.py
+++ b/jupyter_client/adapter.py
@@ -5,7 +5,7 @@ import json
 import re
 from typing import Any, Dict, List, Tuple
 
-from jupyter_client import protocol_version_info
+from ._version import protocol_version_info
 
 
 def code_to_line(code: str, cursor_pos: int) -> Tuple[str, int]:

--- a/jupyter_client/asynchronous/client.py
+++ b/jupyter_client/asynchronous/client.py
@@ -6,8 +6,8 @@ import asyncio
 import zmq.asyncio
 from traitlets import Instance, Type
 
-from jupyter_client.channels import AsyncZMQSocketChannel, HBChannel
-from jupyter_client.client import KernelClient, reqrep
+from ..channels import AsyncZMQSocketChannel, HBChannel
+from ..client import KernelClient, reqrep
 
 
 def wrapped(meth, channel):

--- a/jupyter_client/blocking/client.py
+++ b/jupyter_client/blocking/client.py
@@ -6,9 +6,8 @@ Useful for test suites and blocking terminal interfaces.
 # Distributed under the terms of the Modified BSD License.
 from traitlets import Type
 
-from jupyter_client.channels import HBChannel, ZMQSocketChannel
-from jupyter_client.client import KernelClient, reqrep
-
+from ..channels import HBChannel, ZMQSocketChannel
+from ..client import KernelClient, reqrep
 from ..utils import run_sync
 
 

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -9,10 +9,9 @@ from queue import Empty
 from threading import Event, Thread
 
 import zmq.asyncio
+from jupyter_core.utils import ensure_async
 
-from jupyter_client import protocol_version_info
-from jupyter_client.utils import ensure_async
-
+from ._version import protocol_version_info
 from .channelsabc import HBChannelABC
 from .session import Session
 

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -11,11 +11,10 @@ from getpass import getpass
 from queue import Empty
 
 import zmq.asyncio
+from jupyter_core.utils import ensure_async
 from traitlets import Any, Bool, Instance, Type
 
-from jupyter_client.channels import major_protocol_version
-from jupyter_client.utils import ensure_async
-
+from .channels import major_protocol_version
 from .channelsabc import ChannelABC, HBChannelABC
 from .clientabc import KernelClientABC
 from .connect import ConnectionFileMixin

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -495,7 +495,7 @@ class KernelClient(ConnectionFileMixin):
         if output_hook is None:
             # detect IPython kernel
             if "IPython" in sys.modules:
-                from IPython import get_ipython  # type: ignore
+                from IPython import get_ipython
 
                 ip = get_ipython()
                 in_kernel = getattr(ip, "kernel", False)

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -369,7 +369,7 @@ class ConnectionFileMixin(LoggingConfigurable):
     session = Instance("jupyter_client.session.Session")
 
     def _session_default(self):
-        from jupyter_client.session import Session
+        from .session import Session
 
         return Session(parent=self)
 

--- a/jupyter_client/ioloop/manager.py
+++ b/jupyter_client/ioloop/manager.py
@@ -8,8 +8,7 @@ from tornado import ioloop
 from traitlets import Instance, Type
 from zmq.eventloop.zmqstream import ZMQStream
 
-from jupyter_client.manager import AsyncKernelManager, KernelManager
-
+from ..manager import AsyncKernelManager, KernelManager
 from .restarter import AsyncIOLoopKernelRestarter, IOLoopKernelRestarter
 
 

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -10,7 +10,7 @@ import warnings
 
 from traitlets import Instance
 
-from jupyter_client.restarter import KernelRestarter
+from ..restarter import KernelRestarter
 
 
 class IOLoopKernelRestarter(KernelRestarter):

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -195,15 +195,12 @@ class KernelSpecManager(LoggingConfigurable):
         # At some point, we should stop adding .ipython/kernels to the path,
         # but the cost to keeping it is very small.
         try:
-            from IPython.paths import get_ipython_dir  # type: ignore
-        except ImportError:
-            try:
-                from IPython.utils.path import get_ipython_dir  # type: ignore
-            except ImportError:
-                # no IPython, no ipython dir
-                get_ipython_dir = None
-        if get_ipython_dir is not None:
+            # this should always be valid on IPython 3+
+            from IPython.paths import get_ipython_dir
+
             dirs.append(os.path.join(get_ipython_dir(), "kernels"))
+        except ModuleNotFoundError:
+            pass
         return dirs
 
     def find_kernel_specs(self):

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from enum import Enum
 
 import zmq
+from jupyter_core.utils import run_sync
 from traitlets import (
     Any,
     Bool,
@@ -29,15 +30,14 @@ from traitlets import (
 )
 from traitlets.utils.importstring import import_item
 
-from jupyter_client import KernelClient, kernelspec
-from jupyter_client.asynchronous import AsyncKernelClient
-from jupyter_client.blocking import BlockingKernelClient
-
+from . import kernelspec
+from .asynchronous import AsyncKernelClient
+from .blocking import BlockingKernelClient
+from .client import KernelClient
 from .connect import ConnectionFileMixin
 from .managerabc import KernelManagerABC
 from .provisioning import KernelProvisionerBase
 from .provisioning import KernelProvisionerFactory as KPF  # noqa
-from .utils import run_sync
 
 
 class _ShutdownStatus(Enum):

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -48,9 +48,9 @@ from traitlets.utils.importstring import import_item
 from zmq.eventloop.ioloop import IOLoop
 from zmq.eventloop.zmqstream import ZMQStream
 
-from jupyter_client import protocol_version
-from jupyter_client.adapter import adapt
-from jupyter_client.jsonutil import extract_dates, json_clean, json_default, squash_dates
+from ._version import protocol_version
+from .adapter import adapt
+from .jsonutil import extract_dates, json_clean, json_default, squash_dates
 
 PICKLE_PROTOCOL = pickle.DEFAULT_PROTOCOL
 

--- a/jupyter_client/ssh/__init__.py
+++ b/jupyter_client/ssh/__init__.py
@@ -1,1 +1,1 @@
-from jupyter_client.ssh.tunnel import *  # noqa
+from .tunnel import *  # noqa

--- a/jupyter_client/threaded.py
+++ b/jupyter_client/threaded.py
@@ -12,9 +12,8 @@ from tornado.ioloop import IOLoop
 from traitlets import Instance, Type
 from zmq.eventloop import zmqstream
 
-from jupyter_client import KernelClient
-from jupyter_client.channels import HBChannel
-
+from .channels import HBChannel
+from .client import KernelClient
 from .session import Session
 
 # Local imports

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from threading import Event
 from unittest import TestCase, mock
 
 import pytest
-from IPython.utils.capture import capture_output  # type:ignore
+from IPython.utils.capture import capture_output
 from traitlets import DottedObjectName, Type
 
 from jupyter_client.client import validate_string_dict


### PR DESCRIPTION
It seem like jupyter_client uses a mix of absolute and relative imports, even in same files, which seem a bit weird.

Normalise everything to relative imports, which should make it a bit easier to detect potential cycles, or higher-level imports.

I've found 6 places that now use `..` to imports somethings, where would potentially want to make some refactor at some point in the future to not import something closer to the root.