### PR TITLE
Reflect current protocol version in documentation

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -21,7 +21,7 @@ Versioning
 
 The Jupyter message specification is versioned independently of the packages
 that use it.
-The current version of the specification is 5.3.
+The current version of the specification is 5.4.
 
 .. note::
    *New in* and *Changed in* messages in this document refer to versions of the


### PR DESCRIPTION
For consistency with the documentation, since the deprecation of `shutdown_request` on shell was done in 5.4.