### PR TITLE
MAINT: Don't format log in log call.

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -639,7 +639,7 @@ class ConnectionFileMixin(LoggingConfigurable):
         """Create a zmq Socket and connect it to the kernel."""
         url = self._make_url(channel)
         socket_type = channel_socket_types[channel]
-        self.log.debug("Connecting to: %s" % url)
+        self.log.debug("Connecting to: %s", url)
         sock = self.context.socket(socket_type)
         # set linger to 1s to prevent hangs at exit
         sock.linger = 1000

--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -181,7 +181,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
                     "Could not find existing kernel connection file %s", self.existing
                 )
                 self.exit(1)  # type:ignore[attr-defined]
-            self.log.debug("Connecting to existing kernel: %s" % cf)
+            self.log.debug("Connecting to existing kernel: %s", cf)
             self.connection_file = cf
         else:
             # not existing, check if we are going to write the file
@@ -243,7 +243,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
             "control_port": self.control_port,
         }
 
-        self.log.info(f"Forwarding connections to {ip} via {self.sshserver}")
+        self.log.info("Forwarding connections to %s via %s", ip, self.sshserver)
 
         # tunnels return a new set of ports, which will be on localhost:
         self.ip = localhost()
@@ -267,7 +267,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
         self.connection_file = root + "-ssh" + ext
         self.write_connection_file()  # write the new connection file
         self.log.info("To connect another client via this tunnel, use:")
-        self.log.info("--existing %s" % os.path.basename(self.connection_file))
+        self.log.info("--existing %s", os.path.basename(self.connection_file))
 
     def _new_connection_file(self) -> str:
         cf = ""

--- a/jupyter_client/kernelapp.py
+++ b/jupyter_client/kernelapp.py
@@ -56,7 +56,7 @@ class KernelApp(JupyterApp):
 
     def shutdown(self, signo: int) -> None:
         """Shut down the application."""
-        self.log.info("Shutting down on signal %d" % signo)
+        self.log.info("Shutting down on signal %d", signo)
         self.km.shutdown_kernel()
         self.loop.stop()
 

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -283,7 +283,7 @@ class KernelSpecManager(LoggingConfigurable):
 
         resource_dir = self._find_spec_directory(kernel_name.lower())
         if resource_dir is None:
-            self.log.warning(f"Kernelspec name {kernel_name} cannot be found!")
+            self.log.warning("Kernelspec name %s cannot be found!", kernel_name)
             raise NoSuchKernel(kernel_name)
 
         return self._get_kernel_spec_by_name(kernel_name, resource_dir)

--- a/jupyter_client/kernelspecapp.py
+++ b/jupyter_client/kernelspecapp.py
@@ -62,7 +62,7 @@ class ListKernelSpecs(JupyterApp):
 
             self.log.info("Available kernels:")
             for kernelname, path in sorted(paths.items(), key=path_key):
-                self.log.info(f"  {kernelname.ljust(name_len)}    {path}")
+                self.log.info("  %s    %s", kernelname.ljust(name_len), path)
         else:
             self.log.info(json.dumps({"kernelspecs": specs}, indent=2))
         return specs
@@ -164,7 +164,7 @@ class InstallKernelSpec(JupyterApp):
                     )
                 self.exit(1)
             elif e.errno == errno.EEXIST:
-                self.log.warn("A kernel spec is already present at %s" % e.filename)
+                self.log.warn("A kernel spec is already present at %s", e.filename)
                 self.exit(1)
             raise
 
@@ -209,7 +209,7 @@ class RemoveKernelSpec(JupyterApp):
         if not (self.force or self.answer_yes):
             self.log.info("Kernel specs to remove:")
             for name in self.spec_names:
-                self.log.info(f"  {name.ljust(20)}\t{spec_paths[name]}")
+                self.log.info("  %s\t%s", name.ljust(20), name.ljust(20))
             answer = input("Remove %i kernel specs [y/N]: " % len(self.spec_names))
             if not answer.lower().startswith("y"):
                 return
@@ -262,7 +262,7 @@ class InstallNativeKernelSpec(JupyterApp):
         )
         try:
             from ipykernel import kernelspec
-        except ImportError:
+        except ModuleNotFoundError:
             self.log.info("ipykernel not available, can't install its spec.", file=sys.stderr)
             self.exit(1)
         try:
@@ -295,7 +295,7 @@ class ListProvisioners(JupyterApp):
         name_len = len(sorted(provisioners, key=lambda name: len(name))[-1])
 
         for name in sorted(provisioners):
-            self.log.info(f"  {name.ljust(name_len)}    {provisioners[name]}")
+            self.log.info("  %s    %s", name.ljust(name_len), provisioners[name])
 
 
 class KernelSpecApp(Application):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -239,7 +239,7 @@ class MultiKernelManager(LoggingConfigurable):
         restart : bool
             Will the kernel be restarted?
         """
-        self.log.info("Kernel shutdown: %s" % kernel_id)
+        self.log.info("Kernel shutdown: %s", kernel_id)
         # If the kernel is still starting, wait for it to be ready.
         if kernel_id in self._pending_kernels:
             task = self._pending_kernels[kernel_id]
@@ -281,7 +281,7 @@ class MultiKernelManager(LoggingConfigurable):
         pollinterval: t.Optional[float] = 0.1,
     ) -> None:
         """Wait for a kernel to finish shutting down, and kill it if it doesn't"""
-        self.log.info("Kernel shutdown: %s" % kernel_id)
+        self.log.info("Kernel shutdown: %s", kernel_id)
 
     @kernel_method
     def cleanup_resources(self, kernel_id: str, restart: bool = False) -> None:
@@ -329,7 +329,7 @@ class MultiKernelManager(LoggingConfigurable):
         if not kernel.ready.done():
             raise RuntimeError("Kernel is in a pending state. Cannot interrupt.")
         out = kernel.interrupt_kernel()
-        self.log.info("Kernel interrupted: %s" % kernel_id)
+        self.log.info("Kernel interrupted: %s", kernel_id)
         return out
 
     @kernel_method
@@ -346,7 +346,7 @@ class MultiKernelManager(LoggingConfigurable):
         signum : int
             Signal number to send kernel.
         """
-        self.log.info(f"Signaled Kernel {kernel_id} with {signum}")
+        self.log.info("Signaled Kernel %s with %s", kernel_id, signum)
 
     async def _async_restart_kernel(self, kernel_id: str, now: bool = False) -> None:
         """Restart a kernel by its uuid, keeping the same ports.
@@ -368,7 +368,7 @@ class MultiKernelManager(LoggingConfigurable):
             if not kernel.ready.done():
                 raise RuntimeError("Kernel is in a pending state. Cannot restart.")
         await ensure_async(kernel.restart_kernel(now=now))
-        self.log.info("Kernel restarted: %s" % kernel_id)
+        self.log.info("Kernel restarted: %s", kernel_id)
 
     restart_kernel = run_sync(_async_restart_kernel)
 

--- a/jupyter_client/runapp.py
+++ b/jupyter_client/runapp.py
@@ -102,7 +102,7 @@ class RunApp(JupyterApp, JupyterConsoleApp):
         super().start()
         if self.filenames_to_run:
             for filename in self.filenames_to_run:
-                self.log.debug("jupyter run: executing `%s`" % filename)
+                self.log.debug("jupyter run: executing `%s`", filename)
                 with open(filename) as fp:
                     code = fp.read()
                     reply = self.kernel_client.execute_interactive(code, timeout=OUTPUT_TIMEOUT)


### PR DESCRIPTION
In particular f-string:

There are many reason not to use f-string in logs,
 - F-strings are eager, so might be slow.
 - prevent structured logging or handler to highlight.
 - Security (untrusted input can lead to DOS on formatting, https://discuss.python.org/t/safer-logging-methods-for-f-strings-and-new-style-formatting/13802)
 - Performance (we can filter before formatting).

But also % formatting in a couple of places.