### PR TITLE
Make cache_ports configurable with default value of False.

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -185,7 +185,7 @@ class KernelManager(ConnectionFileMixin):
     cache_ports: Bool = Bool(
         False,
         config=True,
-        help="True if the MultiKernelManager should cache ports for this KernelManager instance"
+        help="True if the MultiKernelManager should cache ports for this KernelManager instance",
     )
 
     @default("cache_ports")  # type:ignore[misc]

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -183,6 +183,8 @@ class KernelManager(ConnectionFileMixin):
         return self._kernel_spec
 
     cache_ports: Bool = Bool(
+        False,
+        config=True,
         help="True if the MultiKernelManager should cache ports for this KernelManager instance"
     )
 


### PR DESCRIPTION
This addresses issue #878 and #955. Suggested by @kevin-bates. 