### PR TITLE
Do not use datetime.utcnow() that is deprecated in Python 3.12

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -197,7 +197,7 @@ def default_secure(cfg: t.Any) -> None:  # pragma: no cover
 
 def utcnow() -> datetime:
     """Return timezone-aware UTC timestamp"""
-    return datetime.now(utc)  # noqa
+    return datetime.now(utc)
 
 
 # -----------------------------------------------------------------------------

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -197,7 +197,7 @@ def default_secure(cfg: t.Any) -> None:  # pragma: no cover
 
 def utcnow() -> datetime:
     """Return timezone-aware UTC timestamp"""
-    return datetime.utcnow().replace(tzinfo=utc)  # noqa
+    return datetime.now(utc)  # noqa
 
 
 # -----------------------------------------------------------------------------

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -4,10 +4,10 @@ utils:
 - vendor functions from ipython_genutils that should be retired at some point.
 """
 import os
-from datetime import datetime, timedelta, tzinfo
 
 from jupyter_core.utils import ensure_async, run_sync  # noqa: F401  # noqa: F401
 
+from .session import utcnow
 
 def _filefind(filename, path_dirs=None):
     """Find a file by looking through a sequence of paths.
@@ -84,35 +84,3 @@ def _expand_path(s):
     if os.name == "nt":
         s = s.replace("IPYTHON_TEMP", "$\\")
     return s
-
-
-# constant for zero offset
-ZERO = timedelta(0)
-
-
-class tzUTC(tzinfo):  # noqa
-    """tzinfo object for UTC (zero offset)"""
-
-    def utcoffset(self, d):
-        """Compute utcoffset."""
-        return ZERO
-
-    def dst(self, d):
-        """Compute dst."""
-        return ZERO
-
-
-UTC = tzUTC()  # type:ignore
-
-
-def utc_aware(unaware):
-    """decorator for adding UTC tzinfo to datetime's utcfoo methods"""
-
-    def utc_method(*args, **kwargs):
-        dt = unaware(*args, **kwargs)
-        return dt.replace(tzinfo=UTC)
-
-    return utc_method
-
-
-utcnow = utc_aware(datetime.utcnow)

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -9,6 +9,7 @@ from jupyter_core.utils import ensure_async, run_sync  # noqa: F401  # noqa: F40
 
 from .session import utcnow
 
+
 def _filefind(filename, path_dirs=None):
     """Find a file by looking through a sequence of paths.
 

--- a/jupyter_client/utils.py
+++ b/jupyter_client/utils.py
@@ -7,7 +7,7 @@ import os
 
 from jupyter_core.utils import ensure_async, run_sync  # noqa: F401  # noqa: F401
 
-from .session import utcnow
+from .session import utcnow  # noqa
 
 
 def _filefind(filename, path_dirs=None):


### PR DESCRIPTION
* Do not use datetime.utcnow() that is deprecated in Python 3.12
* Import session.utcnow() into utils instead of reimplementing it