### PR TITLE
Unused `*args` in `KernelManager`'s `__init__`

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -9,6 +9,7 @@ import signal
 import sys
 import typing as t
 import uuid
+import warnings
 from asyncio.futures import Future
 from concurrent.futures import Future as CFuture
 from contextlib import contextmanager
@@ -106,6 +107,15 @@ class KernelManager(ConnectionFileMixin):
 
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         """Initialize a kernel manager."""
+        if args:
+            warnings.warn(
+                'Passing positional only arguments to '
+                '`KernelManager.__init__` is deprecated since jupyter_client'
+                ' 8.6, and will become an error on future versions. Positional '
+                ' arguments have been ignored since jupyter_client 7.0',
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._owns_kernel = kwargs.pop("owns_kernel", True)
         super().__init__(**kwargs)
         self._shutdown_status = _ShutdownStatus.Unset

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -109,10 +109,10 @@ class KernelManager(ConnectionFileMixin):
         """Initialize a kernel manager."""
         if args:
             warnings.warn(
-                'Passing positional only arguments to '
-                '`KernelManager.__init__` is deprecated since jupyter_client'
-                ' 8.6, and will become an error on future versions. Positional '
-                ' arguments have been ignored since jupyter_client 7.0',
+                "Passing positional only arguments to "
+                "`KernelManager.__init__` is deprecated since jupyter_client"
+                " 8.6, and will become an error on future versions. Positional "
+                " arguments have been ignored since jupyter_client 7.0",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
I think that if it is unused, then it is likely a mistake from the caller that meant to pass a kwarg.

Should it maybe get a deprectation period ?