### PR TITLE
Allow to update kernels env in between restart.

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -268,6 +268,21 @@ class KernelManager(ConnectionFileMixin):
     # Kernel management
     # --------------------------------------------------------------------------
 
+    def update_env(self, *, env: t.Dict[str, str]) -> None:
+        """
+        Allow to update the environment of a kernel manager.
+
+        This will take effect only after kernel restart when the new env is
+        passed to the new kernel.
+
+        This is useful as some of the information of the current kernel reflect
+        the state of the session that started it, and those session information
+        (like the attach file path, or name), are mutable.
+
+        .. version-added: 8.5
+        """
+        self._launch_args['env'].update(env)
+
     def format_kernel_cmd(self, extra_arguments: t.Optional[t.List[str]] = None) -> t.List[str]:
         """Replace templated args (e.g. {connection_file})"""
         extra_arguments = extra_arguments or []

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -212,6 +212,17 @@ class MultiKernelManager(LoggingConfigurable):
         )
         return km, kernel_name, kernel_id
 
+    def update_env(self, *, kernel_id: str, env: t.Dict[str, str]) -> None:
+        """
+        Allow to update the environment of the given kernel.
+
+        Forward the update env request to the corresponding kernel.
+
+        .. version-added: 8.5
+        """
+        if kernel_id in self:
+            self._kernels[kernel_id].update_env(env)
+
     async def _add_kernel_when_ready(
         self, kernel_id: str, km: KernelManager, kernel_awaitable: t.Awaitable
     ) -> None:


### PR DESCRIPTION
This allow to update the running env of kernels.

This will allow resolves some inconsistencies between kernel restart, and actually stopping and starting a kernel session.

In parsley via a few lines in Jupyter Server in update_session, this will let us update the `__session__` which is supposed to reflect some information about the current session, and help correct ipython/ipykernel#1102 where renaming a notebook is not reflected in the kernel unless you manually stop/start the session, or restart the server.