### PR TITLE
Fix possibly not defined tracker

### DIFF
--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -861,6 +861,8 @@ class Session(Configurable):
             # use dummy tracker, which will be done immediately
             tracker = DONE
             stream.send_multipart(to_send, copy=copy)
+        else:
+            tracker = DONE
 
         if self.debug:
             pprint.pprint(msg)  # noqa


### PR DESCRIPTION
See [this error](https://github.com/ipython/ipykernel/actions/runs/6651844622/job/18074668768?pr=1079#step:4:664):
```
Traceback (most recent call last):
  File "/Users/runner/work/ipykernel/ipykernel/ipykernel/iostream.py", line 175, in _handle_event
    raise e
  File "/Users/runner/work/ipykernel/ipykernel/ipykernel/iostream.py", line 171, in _handle_event
    event_f()
  File "/Users/runner/work/ipykernel/ipykernel/ipykernel/iostream.py", line 638, in _flush
    self.session.send(
  File "/Users/runner/Library/Application Support/hatch/env/virtual/ipykernel/8WkbHHn4/cov.qt6/lib/python3.11/site-packages/jupyter_client/session.py", line 870, in send
    msg["tracker"] = tracker
                     ^^^^^^^
UnboundLocalError: cannot access local variable 'tracker' where it is not associated with a value
```