### PR TITLE
Path resolution by kernel manager and providers

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -279,6 +279,12 @@ class KernelManager(ConnectionFileMixin):
     # Kernel management
     # --------------------------------------------------------------------------
 
+    def resolve_path(self, path: str) -> t.Optional[str]:
+        """Resolve path to given file."""
+        assert self.provisioner is not None
+        print('kernel manager resolving path!', path, 'to', self.provisioner.resolve_path(path))
+        return self.provisioner.resolve_path(path)
+
     def update_env(self, *, env: t.Dict[str, str]) -> None:
         """
         Allow to update the environment of a kernel manager.

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -219,6 +219,21 @@ class KernelProvisionerBase(  # type:ignore[misc]
         """
         return recommended
 
+    def resolve_path(self, path: str) -> Optional[str]:
+        """
+        Returns the path resolved relative to kernel working directory.
+
+        For example, path `my_code.py` for a kernel started in `/tmp/`
+        should result in `/tmp/my_code.py`, while path `~/test.py` for
+        a kernel started in `/home/my_user/` should resolve to the
+        (fully specified) `/home/my_user/test.py` path.
+
+        The provisioner may choose not to resolve any paths, or restrict
+        the resolution to paths local to the kernel working directory
+        to prevent path traversal and exposure of file system layout.
+        """
+        return None
+
     def _finalize_env(self, env: Dict[str, str]) -> None:
         """
         Ensures env is appropriate prior to launch.


### PR DESCRIPTION
Addresses https://github.com/jupyter-server/jupyter_server/issues/1280

Sibling PR to https://github.com/jupyter-server/jupyter_server/pull/1331

Allow providers to acknowledge ownership of the files and provide a fully resolved path. Implements resolution for the local provisioner.