### PR TITLE
Minor Fixes.

### DIFF
--- a/jupyter_client/consoleapp.py
+++ b/jupyter_client/consoleapp.py
@@ -13,6 +13,7 @@ import sys
 import typing as t
 import uuid
 import warnings
+from inspect import iscoroutinefunction
 
 from jupyter_core.application import base_aliases, base_flags
 from traitlets import CBool, CUnicode, Dict, List, Type, Unicode
@@ -149,7 +150,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
         to force a direct exit without any confirmation.""",
     )
 
-    def build_kernel_argv(self, argv: object = None) -> None:
+    def build_kernel_argv(self, argv: t.Any = None) -> None:
         """build argv to be passed to kernel subprocess
 
         Override in subclasses if any args should be passed to the kernel
@@ -311,6 +312,8 @@ class JupyterConsoleApp(ConnectionFileMixin):
             self.exit(1)  # type:ignore[attr-defined]
 
         self.kernel_manager = t.cast(KernelManager, self.kernel_manager)
+
+        assert not iscoroutinefunction(self.kernel_manager.start_kernel)
         self.kernel_manager.client_factory = self.kernel_client_class
         kwargs = {}
         kwargs["extra_arguments"] = self.kernel_argv
@@ -352,7 +355,7 @@ class JupyterConsoleApp(ConnectionFileMixin):
 
         self.kernel_client.start_channels()
 
-    def initialize(self, argv: object = None) -> None:
+    def initialize(self, argv: t.Any = None) -> None:
         """
         Classes which mix this class in should call:
                JupyterConsoleApp.initialize(self,argv)


### PR DESCRIPTION
I'm investigating an issue where Jupyter-Console does not and it seem there are mixup between sync and async KernelManager and other in a few places.

Basically both Async and Blocking KM are expected by the type system to work as KM independently, but obviously some have Async methods and other have Sync methods, which need to be awaited.

When touching traitlets config files it's easy to change the default class from Sync to async, and then you get weird error messages.

So dropping a few asserts here and fixign a few types while investigating.

I think the Sync and Async should be more distinct now that we are mostly async everywhere to avoid those confusions.