### PR TITLE
Remove deprecated zmq imports (#915)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,6 @@
 repos:
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.9.0
-    hooks:
-      - id: reorder-python-imports
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 24.2.0
     hooks:
       - id: black
         args: ["--line-length", "100"]
@@ -12,8 +8,8 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: "3.8.4"
+  - repo: https://github.com/PyCQA/flake8
+    rev: "7.0.0"
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/jupyter_client/ioloop/restarter.py
+++ b/jupyter_client/ioloop/restarter.py
@@ -3,6 +3,7 @@
 This watches a kernel's state using KernelManager.is_alive and auto
 restarts the kernel if it dies.
 """
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import warnings
@@ -24,6 +25,8 @@ class IOLoopKernelRestarter(KernelRestarter):
             DeprecationWarning,
             stacklevel=4,
         )
+        from tornado import ioloop
+
         return ioloop.IOLoop.current()
 
     _pcallback = None

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -8,6 +8,7 @@ Also defined here are utilities for working with Sessions:
 Sessions.
 * A Message object for convenience that allows attribute-access to the msg dict.
 """
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import hashlib
@@ -27,6 +28,7 @@ from hmac import (
 )  # We are using compare_digest to limit the surface of timing attacks
 
 import zmq
+from tornado.ioloop import IOLoop
 from traitlets import Any  # type: ignore
 from traitlets import Bool
 from traitlets import CBytes
@@ -43,7 +45,6 @@ from traitlets.config.configurable import Configurable  # type: ignore
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets.log import get_logger  # type: ignore
 from traitlets.utils.importstring import import_item  # type: ignore
-from zmq.eventloop.ioloop import IOLoop
 from zmq.eventloop.zmqstream import ZMQStream
 from zmq.utils import jsonapi
 
@@ -444,7 +445,7 @@ class Session(Configurable):
 
     digest_history = Set()
     digest_history_size = Integer(
-        2 ** 16,
+        2**16,
         config=True,
         help="""The maximum number of digests to remember.
 
@@ -483,7 +484,7 @@ class Session(Configurable):
 
     # thresholds:
     copy_threshold = Integer(
-        2 ** 16,
+        2**16,
         config=True,
         help="Threshold (in bytes) beyond which a buffer should be sent without copying.",
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 100
+max-line-length = 105
 
 [bdist_wheel]
 universal=0


### PR DESCRIPTION

(cherry picked from commit 31610879ef878882d98bbd34d18aac574e6d190d)