### PR TITLE
Parameterized kernel specs

### DIFF
--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -240,18 +240,18 @@ class KernelSpecManager(LoggingConfigurable):
         print(kspec.argv)
         is_secure = self.check_kernel_is_secure(kspec=kspec)
         if is_secure == True:
-            print('---is_secure---')
-            return kspec # a kernel spec is allowed
+            print("---is_secure---")
+            return kspec  # a kernel spec is allowed
         else:
             if self._allow_insecure_kernelspec_params == True:
-                print('---_allow_insecure_kernelspec_params---')
-                return kspec # a kernel spec is allowed
+                print("---_allow_insecure_kernelspec_params---")
+                return kspec  # a kernel spec is allowed
             else:
-                print('---should default---')
+                print("---should default---")
                 kspec_data = self.check_kernel_custom_all_default_values(kspec=kspec)
                 if kspec_data.all_has_default == True:
-                    return kspec_data.kspec # a kernel spec is modyfied and is allowed
-    
+                    return kspec_data.kspec  # a kernel spec is modyfied and is allowed
+
     def check_kernel_is_secure(self, kspec):
         is_secure = False
         if (
@@ -262,11 +262,13 @@ class KernelSpecManager(LoggingConfigurable):
             and "properties" in kspec.metadata["parameters"]
             and isinstance(kspec.metadata["parameters"]["properties"], dict)
         ):
-            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0)
-            print('counter_secure_kernel_variables')
-            
+            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(
+                obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0
+            )
+            print("counter_secure_kernel_variables")
+
             total_sum_kernel_variables = self.get_argv_env_kernel_variables(kspec=kspec)
-           
+
             if counter_secure_kernel_variables == total_sum_kernel_variables:
                 is_secure = True
             else:
@@ -274,28 +276,27 @@ class KernelSpecManager(LoggingConfigurable):
         else:
             is_secure = True
         return is_secure
-    
+
     def get_argv_env_kernel_variables(self, kspec):
         total_sum_kernel_variables = 0
         env = None
         argv = None
         sum_argv_kernel_variables = 0
         sum_env_kernel_variables = 0
-        if hasattr(kspec, 'env'):
+        if hasattr(kspec, "env"):
             env = kspec.env
             sum_env_kernel_variables = self.get_count_all_kernel_variables(parameters=env)
             print("sum_env_kernel_variables")
             print(sum_env_kernel_variables)
-        if hasattr(kspec, 'argv'):
+        if hasattr(kspec, "argv"):
             argv = kspec.argv
             sum_argv_kernel_variables = self.get_count_all_kernel_variables(parameters=argv)
             print("sum_argv_kernel_variables")
             print(sum_argv_kernel_variables)
         total_sum_kernel_variables = sum_env_kernel_variables + sum_argv_kernel_variables
-        print('total_sum_kernel_variables')
+        print("total_sum_kernel_variables")
         print(total_sum_kernel_variables)
         return total_sum_kernel_variables
-
 
     def get_count_secure_kernel_variables(self, obj, counter_secure_kernel_variables):
         print("get_count_secure_kernel_variables")
@@ -311,14 +312,16 @@ class KernelSpecManager(LoggingConfigurable):
                 for property_key, property_value in propetries:
                     if property_value.get("enum"):
                         counter_secure_kernel_variables = counter_secure_kernel_variables + 1
-                        print('if enum counter_secure_kernel_variables')
+                        print("if enum counter_secure_kernel_variables")
                         print(counter_secure_kernel_variables)
-                    elif property_value.get("type") == 'object':
-                        counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=obj, counter_secure_kernel_variables=counter_secure_kernel_variables)
-                        print('if object counter_secure_kernel_variables')
+                    elif property_value.get("type") == "object":
+                        counter_secure_kernel_variables = self.get_count_secure_kernel_variables(
+                            obj=obj, counter_secure_kernel_variables=counter_secure_kernel_variables
+                        )
+                        print("if object counter_secure_kernel_variables")
                         print(counter_secure_kernel_variables)
         return counter_secure_kernel_variables
-    
+
     def get_count_all_kernel_variables(self, parameters):
         sum = 0
         if isinstance(parameters, list):
@@ -342,7 +345,7 @@ class KernelSpecManager(LoggingConfigurable):
             if match:
                 if match.group(1):
                     return True
-                else: 
+                else:
                     return False
             else:
                 return False
@@ -361,9 +364,9 @@ class KernelSpecManager(LoggingConfigurable):
         ):
             print("yesstart")
             propetries = kspec.metadata["parameters"]["properties"].items()
-            
+
             new_kspec = {}
-            print('propetries')
+            print("propetries")
             print(propetries)
             for property_key, property_value in propetries:
                 if "default" in property_value:
@@ -372,22 +375,13 @@ class KernelSpecManager(LoggingConfigurable):
                     )
             total_sum_kernel_variables = self.get_argv_env_kernel_variables(kspec=new_kspec)
             if total_sum_kernel_variables > 0:
-                result = {
-                    "kspec": kspec,
-                    "all_have_default" : False
-                }
+                result = {"kspec": kspec, "all_have_default": False}
 
                 return result
-            else: 
-                 result = {
-                    "kspec": new_kspec,
-                    "all_have_default" : True
-                }
+            else:
+                result = {"kspec": new_kspec, "all_have_default": True}
         else:
-            result = {
-                    "kspec": kspec,
-                    "all_have_default" : False
-            }
+            result = {"kspec": kspec, "all_have_default": False}
 
     def replace_spec_parameter(self, variable, value, spec) -> str:
         regexp = r"\{" + variable + "\\}"
@@ -397,15 +391,13 @@ class KernelSpecManager(LoggingConfigurable):
     def replaceByDefault(self, kspec, kernel_variable, default_value):
         new_env = {}
         new_argv = []
-        if hasattr(kspec, 'env'):
+        if hasattr(kspec, "env"):
             tmp_env = kspec.env.copy()
-            print('----tmp_env---')
+            print("----tmp_env---")
             print(tmp_env)
             env = tmp_env.env
-            
-            
 
-            print('replaceByDefault env')
+            print("replaceByDefault env")
             print(env)
             # check and replace env variables
 
@@ -418,10 +410,12 @@ class KernelSpecManager(LoggingConfigurable):
                 kspec.env = tmp_env
 
         # check and replace argv parameters
-        if hasattr(kspec, 'argv'):
+        if hasattr(kspec, "argv"):
             argv = kspec.argv.copy()
             for argv_item in argv:
-                new_argv_item = self.replace_spec_parameter(kernel_variable, default_value, argv_item)
+                new_argv_item = self.replace_spec_parameter(
+                    kernel_variable, default_value, argv_item
+                )
                 new_argv.append(new_argv_item)
 
             if len(new_argv) > 0:

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -228,6 +228,15 @@ class KernelSpecManager(LoggingConfigurable):
         return d
         # TODO: Caching?
 
+    def allow_parameterized_kernels(self, isParameterizedKernel):
+        self.isParameterizedKernel = isParameterizedKernel
+
+    def _checkParameterizedKernel(self, kspec:KernelSpec)->KernelSpec:
+        print('kspec')
+        print(kspec)
+        if not self.isParameterizedKernel:
+            return kspec
+
     def _get_kernel_spec_by_name(self, kernel_name: str, resource_dir: str) -> KernelSpec:
         """Returns a :class:`KernelSpec` instance for a given kernel_name
         and resource_dir.
@@ -248,6 +257,8 @@ class KernelSpecManager(LoggingConfigurable):
 
         if not KPF.instance(parent=self.parent).is_provisioner_available(kspec):
             raise NoSuchKernel(kernel_name)
+        
+        kspec = self._checkParameterizedKernel(kspec)
 
         return kspec
 

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -241,18 +241,18 @@ class KernelSpecManager(LoggingConfigurable):
         is_secure = self.check_kernel_is_secure(kspec=kspec)
         if is_secure == True:
             if kspec.metadata and isinstance(kspec.metadata, dict):
-                kspec.metadata.update({'is_secure':True})
+                kspec.metadata.update({"is_secure": True})
             else:
                 kspec.metadata = {}
-                kspec.metadata.update({'is_secure':True})
-            print('---is_secure---')
-            return kspec # a kernel spec is allowed
+                kspec.metadata.update({"is_secure": True})
+            print("---is_secure---")
+            return kspec  # a kernel spec is allowed
         else:
             if kspec.metadata and isinstance(kspec.metadata, dict):
-                kspec.metadata.update({'is_secure':False})
+                kspec.metadata.update({"is_secure": False})
             else:
                 kspec.metadata = {}
-                kspec.metadata.update({'is_secure':False})
+                kspec.metadata.update({"is_secure": False})
             if self._allow_insecure_kernelspec_params == True:
                 print("---_allow_insecure_kernelspec_params---")
                 return kspec  # a kernel spec is allowed
@@ -261,17 +261,17 @@ class KernelSpecManager(LoggingConfigurable):
                 kspec_data = self.check_kernel_custom_all_default_values(kspec=kspec)
                 print("kspec_data")
                 print(kspec_data)
-                print('??????')
+                print("??????")
                 print(kspec_data["all_have_default"])
 
-                if kspec_data['all_have_default'] == True:
-                    print('default_true')
-                    return kspec_data["kspec"] # a kernel spec is modyfied and is allowed
+                if kspec_data["all_have_default"] == True:
+                    print("default_true")
+                    return kspec_data["kspec"]  # a kernel spec is modyfied and is allowed
                 else:
                     return None
-    
+
     def check_kernel_is_secure(self, kspec):
-        print('check_kernel_is_secure')
+        print("check_kernel_is_secure")
         is_secure = False
         if (
             kspec.metadata
@@ -281,8 +281,10 @@ class KernelSpecManager(LoggingConfigurable):
             and "properties" in kspec.metadata["parameters"]
             and isinstance(kspec.metadata["parameters"]["properties"], dict)
         ):
-            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0)
-            
+            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(
+                obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0
+            )
+
             total_sum_kernel_variables = self.get_argv_env_kernel_variables(kspec=kspec)
 
             if counter_secure_kernel_variables == total_sum_kernel_variables:
@@ -318,27 +320,32 @@ class KernelSpecManager(LoggingConfigurable):
         print("get_count_secure_kernel_variables")
         print("---obj---")
         print(obj)
-       
+
         print(counter_secure_kernel_variables)
         is_secure = True
         if "properties" in obj:
             propetries = obj["properties"].items()
             if len(propetries) > 0:
                 for property_key, property_value in propetries:
-                    if property_value.get("type") == 'string' or property_value.get("type") == 'null':
+                    if (
+                        property_value.get("type") == "string"
+                        or property_value.get("type") == "null"
+                    ):
                         if property_value.get("enum"):
                             counter_secure_kernel_variables = counter_secure_kernel_variables + 1
                         else:
-                            print('string, null')
+                            print("string, null")
                             is_secure = False
                     elif property_value.get("enum"):
                         counter_secure_kernel_variables = counter_secure_kernel_variables + 1
-                        print('if enum counter_secure_kernel_variables')
-                 
-                    elif property_value.get("type") == 'object':
-                        counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=obj, counter_secure_kernel_variables=counter_secure_kernel_variables)
-                        print('if object counter_secure_kernel_variables')
-       
+                        print("if enum counter_secure_kernel_variables")
+
+                    elif property_value.get("type") == "object":
+                        counter_secure_kernel_variables = self.get_count_secure_kernel_variables(
+                            obj=obj, counter_secure_kernel_variables=counter_secure_kernel_variables
+                        )
+                        print("if object counter_secure_kernel_variables")
+
         if is_secure == False:
             counter_secure_kernel_variables = 0
         print("counter_secure_kernel_variables")
@@ -368,12 +375,12 @@ class KernelSpecManager(LoggingConfigurable):
         if match is None:
             pattern = re.compile(r"\{([A-Za-z0-9_]+)\}")
             matches = pattern.findall(string)
-            print('matches')
+            print("matches")
             print(matches)
             if len(matches) > 0:
-                print('-match yes')
+                print("-match yes")
                 return True
-            else: 
+            else:
                 return False
         else:
             return False
@@ -401,31 +408,19 @@ class KernelSpecManager(LoggingConfigurable):
                     has_default = False
 
             if has_default == False:
-                 result = {
-                    "kspec": kspec,
-                    "all_have_default" : False
-                }
+                result = {"kspec": kspec, "all_have_default": False}
             else:
-                #check if there is anything after replacing
+                # check if there is anything after replacing
                 total_sum_kernel_variables = self.get_argv_env_kernel_variables(kspec=new_kspec)
-                print('---default total_sum_kernel_variables---')
+                print("---default total_sum_kernel_variables---")
                 print(total_sum_kernel_variables)
 
                 if total_sum_kernel_variables > 0:
-                    result = {
-                        "kspec": kspec,
-                        "all_have_default" : False
-                    }
-                else: 
-                    result = {
-                        "kspec": new_kspec,
-                        "all_have_default" : True
-                    }
+                    result = {"kspec": kspec, "all_have_default": False}
+                else:
+                    result = {"kspec": new_kspec, "all_have_default": True}
         else:
-            result = {
-                    "kspec": kspec,
-                    "all_have_default" : False
-            }
+            result = {"kspec": kspec, "all_have_default": False}
         print("result")
         print(result["all_have_default"])
         return result
@@ -440,18 +435,19 @@ class KernelSpecManager(LoggingConfigurable):
         new_argv = []
         if hasattr(kspec, "env"):
             tmp_env = kspec.env.copy()
-            if 'env' in tmp_env:
-                print('----tmp_env---')
+            if "env" in tmp_env:
+                print("----tmp_env---")
                 print(tmp_env)
                 env = tmp_env.env
-                
-            
-                print('replaceByDefault env')
+
+                print("replaceByDefault env")
                 print(env)
                 # check and replace env variables
 
                 for env_key, env_item in env.items():
-                    new_env_item = self.replace_spec_parameter(kernel_variable, default_value, env_item)
+                    new_env_item = self.replace_spec_parameter(
+                        kernel_variable, default_value, env_item
+                    )
                     new_env[env_key] = new_env_item
 
                 if len(new_env) > 0:
@@ -459,7 +455,7 @@ class KernelSpecManager(LoggingConfigurable):
                     kspec.env = tmp_env
 
         # check and replace argv parameters
-        if hasattr(kspec, 'argv') and kspec.argv is not None:
+        if hasattr(kspec, "argv") and kspec.argv is not None:
             argv = kspec.argv.copy()
             for argv_item in argv:
                 new_argv_item = self.replace_spec_parameter(
@@ -494,14 +490,12 @@ class KernelSpecManager(LoggingConfigurable):
             raise NoSuchKernel(kernel_name)
 
         kspec = self._check_parameterized_kernel(kspec)
-        print('new kspec')
+        print("new kspec")
         print(kspec)
         if kspec is not None:
-             return kspec
+            return kspec
         else:
             return None
-
-        
 
     def _find_spec_directory(self, kernel_name: str) -> str | None:
         """Find the resource directory of a named kernel spec"""

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -231,7 +231,7 @@ class KernelSpecManager(LoggingConfigurable):
         # TODO: Caching?
 
     def allow_insecure_kernelspec_params(self, allow_insecure_kernelspec_params):
-        print('allow_insecure_kernelspec_params')
+        print("allow_insecure_kernelspec_params")
         print(allow_insecure_kernelspec_params)
         self._allow_insecure_kernelspec_params = allow_insecure_kernelspec_params
 
@@ -240,15 +240,15 @@ class KernelSpecManager(LoggingConfigurable):
         print(kspec.argv)
         is_secure = self.check_kernel_is_secure(kspec=kspec)
         if is_secure == True:
-            return kspec # a kernel spec is allowed
+            return kspec  # a kernel spec is allowed
         else:
             if self._allow_insecure_kernelspec_params == True:
-                return kspec # a kernel spec is allowed
+                return kspec  # a kernel spec is allowed
             else:
                 kspec_data = self.check_kernel_custom_all_default_values(kspec=kspec)
                 if kspec_data.is_default == True:
-                    return kspec_data.kspec # a kernel spec is modyfied and is allowed
-    
+                    return kspec_data.kspec  # a kernel spec is modyfied and is allowed
+
     def check_kernel_is_secure(self, kspec):
         is_secure = False
         if (
@@ -259,9 +259,11 @@ class KernelSpecManager(LoggingConfigurable):
             and "properties" in kspec.metadata["parameters"]
             and isinstance(kspec.metadata["parameters"]["properties"], dict)
         ):
-            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0)
-            print('counter_secure_kernel_variables')
-            
+            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(
+                obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0
+            )
+            print("counter_secure_kernel_variables")
+
             env = None
             argv = None
             sum_argv_kernel_variables = 0
@@ -284,60 +286,60 @@ class KernelSpecManager(LoggingConfigurable):
         else:
             is_secure = True
         return is_secure
-    
 
     def get_count_secure_kernel_variables(self, obj, counter_secure_kernel_variables):
-         print('get_count_secure_kernel_variables')
-         print('---obj---')
-         print(obj)
-         print('counter_secure_kernel_variables')
-         print(counter_secure_kernel_variables)
-         if "properties" in obj:
+        print("get_count_secure_kernel_variables")
+        print("---obj---")
+        print(obj)
+        print("counter_secure_kernel_variables")
+        print(counter_secure_kernel_variables)
+        if "properties" in obj:
             propetries = obj["properties"].items()
-            print('propetries')
+            print("propetries")
             print(propetries)
             if len(propetries) > 0:
                 for property_key, property_value in propetries:
                     if property_value["enum"]:
                         counter_secure_kernel_variables = counter_secure_kernel_variables + 1
-                        print('if enum counter_secure_kernel_variables')
+                        print("if enum counter_secure_kernel_variables")
                         print(propetries)
-                    elif property_value['type'] == 'object':
-                        counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=obj, counter_secure_kernel_variables=counter_secure_kernel_variables)
-                        print('if object counter_secure_kernel_variables')
+                    elif property_value["type"] == "object":
+                        counter_secure_kernel_variables = self.get_count_secure_kernel_variables(
+                            obj=obj, counter_secure_kernel_variables=counter_secure_kernel_variables
+                        )
+                        print("if object counter_secure_kernel_variables")
                         print(propetries)
-         return counter_secure_kernel_variables
-    
+        return counter_secure_kernel_variables
+
     def get_count_all_kernel_variables(self, parameters):
-         sum = 0
-         if isinstance(parameters, list):
+        sum = 0
+        if isinstance(parameters, list):
             for argv_item in parameters:
                 is_variable = self.has_variable(argv_item)
                 if is_variable:
                     sum = sum + 1
-         elif isinstance(parameters, dict):
+        elif isinstance(parameters, dict):
             for env_key, env_item in parameters.items():
                 is_variable = self.has_variable(env_item)
                 if is_variable:
                     sum = sum + 1
-         return sum
+        return sum
 
-        
     def has_variable(self, string):
-         pattern = re.compile(r"\{connection_file\}")
-         match = pattern.match(string)
-         if match is None:
+        pattern = re.compile(r"\{connection_file\}")
+        match = pattern.match(string)
+        if match is None:
             pattern = re.compile(r"\{([A-Za-z0-9_]+)\}")
             match = pattern.match(string)
             if match.group(1):
                 return True
-            else: 
+            else:
                 return False
-         else: 
-             return False
-                
+        else:
+            return False
+
     def check_kernel_custom_all_default_values(self, kspec):
-        print('yess')
+        print("yess")
         if (
             kspec.metadata
             and isinstance(kspec.metadata, dict)
@@ -346,17 +348,15 @@ class KernelSpecManager(LoggingConfigurable):
             and "properties" in kspec.metadata["parameters"]
             and isinstance(kspec.metadata["parameters"]["properties"], dict)
         ):
-            print('yesstart')
+            print("yesstart")
             propetries = kspec.metadata["parameters"]["properties"].items()
-            print('propetries')
+            print("propetries")
             print(propetries)
             for property_key, property_value in propetries:
                 if "default" in property_value:
-                    kspec = self.replaceByDefault(
-                        kspec, property_key, property_value["default"]
-                    )
+                    kspec = self.replaceByDefault(kspec, property_key, property_value["default"])
         else:
-            return ""#
+            return ""  #
 
     def replace_spec_parameter(self, variable, value, spec) -> str:
         regexp = r"\{" + variable + "\\}"
@@ -370,9 +370,9 @@ class KernelSpecManager(LoggingConfigurable):
         env = kspec.env
         argv = kspec.argv
 
-        print('replaceByDefault env')
+        print("replaceByDefault env")
         print(env)
-        print('replaceByDefault argv')
+        print("replaceByDefault argv")
         print()
         # check and replace env variables
         for env_key, env_item in env.items():

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -282,14 +282,16 @@ class KernelSpecManager(LoggingConfigurable):
             and "properties" in kspec.metadata["parameters"]
             and isinstance(kspec.metadata["parameters"]["properties"], dict)
         ):
-            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0)
-            
+            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(
+                obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0
+            )
+
             if counter_secure_kernel_variables == total_sum_kernel_variables:
                 is_secure = True
             else:
                 is_secure = False
         else:
-            # check if there are kernel variables even metadata.parameters are empty 
+            # check if there are kernel variables even metadata.parameters are empty
             if total_sum_kernel_variables > 0:
                 is_secure = False
             else:

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -231,7 +231,7 @@ class KernelSpecManager(LoggingConfigurable):
         # TODO: Caching?
 
     def allow_insecure_kernelspec_params(self, is_allowed_insecure_kernel_specs):
-        print('is_allowed_insecure_kernel_specs')
+        print("is_allowed_insecure_kernel_specs")
         print(is_allowed_insecure_kernel_specs)
         self._is_allowed_insecure_kernel_specs = is_allowed_insecure_kernel_specs
 
@@ -241,7 +241,7 @@ class KernelSpecManager(LoggingConfigurable):
         if self._is_allowed_insecure_kernel_specs == True:
             return kspec
         else:
-            print('yess')
+            print("yess")
             if (
                 kspec.metadata
                 and isinstance(kspec.metadata, dict)
@@ -250,9 +250,9 @@ class KernelSpecManager(LoggingConfigurable):
                 and "properties" in kspec.metadata["parameters"]
                 and isinstance(kspec.metadata["parameters"]["properties"], dict)
             ):
-                print('yesstart')
+                print("yesstart")
                 propetries = kspec.metadata["parameters"]["properties"].items()
-                print('propetries')
+                print("propetries")
                 print(propetries)
                 for property_key, property_value in propetries:
                     if "default" in property_value:
@@ -276,11 +276,9 @@ class KernelSpecManager(LoggingConfigurable):
 
         # check and replace env variables
         for env_key, env_item in env.items():
-            new_env_item = self.replace_spec_parameter(
-                kernel_variable, default_value, env_item
-            )
+            new_env_item = self.replace_spec_parameter(kernel_variable, default_value, env_item)
             new_env[env_key] = new_env_item
-            
+
         if len(new_env) > 0:
             kspec["env"] = new_env
 

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -273,6 +273,7 @@ class KernelSpecManager(LoggingConfigurable):
     def check_kernel_is_secure(self, kspec):
         print('check_kernel_is_secure')
         is_secure = False
+        total_sum_kernel_variables = self.get_argv_env_kernel_variables(kspec=kspec)
         if (
             kspec.metadata
             and isinstance(kspec.metadata, dict)
@@ -283,14 +284,16 @@ class KernelSpecManager(LoggingConfigurable):
         ):
             counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0)
             
-            total_sum_kernel_variables = self.get_argv_env_kernel_variables(kspec=kspec)
-
             if counter_secure_kernel_variables == total_sum_kernel_variables:
                 is_secure = True
             else:
                 is_secure = False
         else:
-            is_secure = True
+            # check if there are kernel variables even metadata.parameters are empty 
+            if total_sum_kernel_variables > 0:
+                is_secure = False
+            else:
+                is_secure = True
         return is_secure
 
     def get_argv_env_kernel_variables(self, kspec):

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -231,11 +231,58 @@ class KernelSpecManager(LoggingConfigurable):
     def allow_parameterized_kernels(self, isParameterizedKernel):
         self.isParameterizedKernel = isParameterizedKernel
 
-    def _checkParameterizedKernel(self, kspec:KernelSpec)->KernelSpec:
+    def _check_parameterized_kernel(self, kspec:KernelSpec)->KernelSpec:
         print('kspec')
         print(kspec)
-        if not self.isParameterizedKernel:
+        if self.isParameterizedKernel:
             return kspec
+        else:
+            if (
+                kspec.metadata
+                and isinstance(kspec.metadata, dict)
+                and "parameters" in kspec.metadata
+                and isinstance(kspec.metadata["parameters"], dict)
+                and "properties" in kspec.metadata["parameters"]
+                and isinstance(kspec.metadata["parameters"]["properties"], dict)
+            ):
+                propetries = kspec.metadata["parameters"]["properties"].items()
+                for property_key, property_value in propetries:
+                    if "default" in property_value:
+                        kspec = self.replaceByDefault(kspec, property_key, property_value['default'])
+            else:
+                return kspec
+            
+    def replace_spec_parameter(self, variable, value, spec) -> str:
+        regexp = r"\{" + variable + "\\}"
+        pattern = re.compile(regexp)
+        return pattern.sub(value, spec)
+    
+    def replaceByDefault(self, kspec, kernel_variable, default_value):
+         new_env = {}
+         new_argv = []
+
+         env = kspec['env']
+         argv = kspec['argv']
+
+         # check and replace env variables
+         for env_key, env_item in env.items():
+            new_env_item = self.replace_spec_parameter(
+                kernel_variable, default_value, env_item
+                )
+            new_env[env_key] = new_env_item
+         if len(new_env) > 0 :
+             kspec['env'] = new_env
+
+        # check and replace argv parameters
+         for argv_item in argv:
+            new_argv_item = self.replace_spec_parameter(
+                kernel_variable, default_value, argv_item
+                )
+            new_argv.append(new_argv_item)
+
+         if len(new_argv)>0:
+            kspec['argv'] = new_argv
+         return kspec
 
     def _get_kernel_spec_by_name(self, kernel_name: str, resource_dir: str) -> KernelSpec:
         """Returns a :class:`KernelSpec` instance for a given kernel_name
@@ -258,7 +305,7 @@ class KernelSpecManager(LoggingConfigurable):
         if not KPF.instance(parent=self.parent).is_provisioner_available(kspec):
             raise NoSuchKernel(kernel_name)
         
-        kspec = self._checkParameterizedKernel(kspec)
+        #kspec = self._check_parameterized_kernel(kspec)
 
         return kspec
 

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -231,8 +231,8 @@ class KernelSpecManager(LoggingConfigurable):
     def allow_parameterized_kernels(self, isParameterizedKernel):
         self.isParameterizedKernel = isParameterizedKernel
 
-    def _checkParameterizedKernel(self, kspec:KernelSpec)->KernelSpec:
-        print('kspec')
+    def _checkParameterizedKernel(self, kspec: KernelSpec) -> KernelSpec:
+        print("kspec")
         print(kspec)
         if not self.isParameterizedKernel:
             return kspec
@@ -257,7 +257,7 @@ class KernelSpecManager(LoggingConfigurable):
 
         if not KPF.instance(parent=self.parent).is_provisioner_available(kspec):
             raise NoSuchKernel(kernel_name)
-        
+
         kspec = self._checkParameterizedKernel(kspec)
 
         return kspec

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -248,41 +248,39 @@ class KernelSpecManager(LoggingConfigurable):
                 propetries = kspec.metadata["parameters"]["properties"].items()
                 for property_key, property_value in propetries:
                     if "default" in property_value:
-                        kspec = self.replaceByDefault(kspec, property_key, property_value['default'])
+                        kspec = self.replaceByDefault(
+                            kspec, property_key, property_value["default"]
+                        )
             else:
                 return kspec
-            
+
     def replace_spec_parameter(self, variable, value, spec) -> str:
         regexp = r"\{" + variable + "\\}"
         pattern = re.compile(regexp)
         return pattern.sub(value, spec)
-    
+
     def replaceByDefault(self, kspec, kernel_variable, default_value):
-         new_env = {}
-         new_argv = []
+        new_env = {}
+        new_argv = []
 
-         env = kspec['env']
-         argv = kspec['argv']
+        env = kspec["env"]
+        argv = kspec["argv"]
 
-         # check and replace env variables
-         for env_key, env_item in env.items():
-            new_env_item = self.replace_spec_parameter(
-                kernel_variable, default_value, env_item
-                )
+        # check and replace env variables
+        for env_key, env_item in env.items():
+            new_env_item = self.replace_spec_parameter(kernel_variable, default_value, env_item)
             new_env[env_key] = new_env_item
-         if len(new_env) > 0 :
-             kspec['env'] = new_env
+        if len(new_env) > 0:
+            kspec["env"] = new_env
 
         # check and replace argv parameters
-         for argv_item in argv:
-            new_argv_item = self.replace_spec_parameter(
-                kernel_variable, default_value, argv_item
-                )
+        for argv_item in argv:
+            new_argv_item = self.replace_spec_parameter(kernel_variable, default_value, argv_item)
             new_argv.append(new_argv_item)
 
-         if len(new_argv)>0:
-            kspec['argv'] = new_argv
-         return kspec
+        if len(new_argv) > 0:
+            kspec["argv"] = new_argv
+        return kspec
 
     def _get_kernel_spec_by_name(self, kernel_name: str, resource_dir: str) -> KernelSpec:
         """Returns a :class:`KernelSpec` instance for a given kernel_name

--- a/jupyter_client/kernelspec.py
+++ b/jupyter_client/kernelspec.py
@@ -269,8 +269,10 @@ class KernelSpecManager(LoggingConfigurable):
             and "properties" in kspec.metadata["parameters"]
             and isinstance(kspec.metadata["parameters"]["properties"], dict)
         ):
-            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0)
-            if total_sum_kernel_variables>0:
+            counter_secure_kernel_variables = self.get_count_secure_kernel_variables(
+                obj=kspec.metadata["parameters"], counter_secure_kernel_variables=0
+            )
+            if total_sum_kernel_variables > 0:
                 if counter_secure_kernel_variables == total_sum_kernel_variables:
                     is_secure = True
                 else:
@@ -315,7 +317,7 @@ class KernelSpecManager(LoggingConfigurable):
                         else:
                             is_secure = False
                     elif property_value.get("type") == "array":
-                        print('Type of JSON Schema data is array and it is not supported now')
+                        print("Type of JSON Schema data is array and it is not supported now")
                         is_secure = False
                     elif property_value.get("enum"):
                         counter_secure_kernel_variables = counter_secure_kernel_variables + 1

--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -78,7 +78,6 @@ def launch_kernel(
 
     env = env if (env is not None) else os.environ.copy()
 
-
     kwargs = kw.copy()
     main_args = {
         "stdin": _stdin,

--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -62,6 +62,9 @@ def launch_kernel(
 
     if "custom_kernel_specs" in kw:
         del kw["custom_kernel_specs"]
+
+    print("----kw----")
+    print(kw)
     redirect_in = True
     _stdin = PIPE if stdin is None else stdin
 
@@ -76,6 +79,9 @@ def launch_kernel(
         _stdout, _stderr = stdout, stderr
 
     env = env if (env is not None) else os.environ.copy()
+
+
+    print("launcher---------------")
 
     kwargs = kw.copy()
     main_args = {

--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -59,6 +59,9 @@ def launch_kernel(
     # If this process has been backgrounded, our stdin is invalid. Since there
     # is no compelling reason for the kernel to inherit our stdin anyway, we'll
     # place this one safe and always redirect.
+
+    if "custom_kernel_specs" in kw:
+        del kw["custom_kernel_specs"]
     redirect_in = True
     _stdin = PIPE if stdin is None else stdin
 

--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -63,8 +63,6 @@ def launch_kernel(
     if "custom_kernel_specs" in kw:
         del kw["custom_kernel_specs"]
 
-    print("----kw----")
-    print(kw)
     redirect_in = True
     _stdin = PIPE if stdin is None else stdin
 
@@ -80,8 +78,6 @@ def launch_kernel(
 
     env = env if (env is not None) else os.environ.copy()
 
-
-    print("launcher---------------")
 
     kwargs = kw.copy()
     main_args = {

--- a/jupyter_client/launcher.py
+++ b/jupyter_client/launcher.py
@@ -61,8 +61,7 @@ def launch_kernel(
     # is no compelling reason for the kernel to inherit our stdin anyway, we'll
     # place this one safe and always redirect.
 
-    if "custom_kernel_specs" in kw:
-        del kw["custom_kernel_specs"]
+    kw.pop("custom_kernel_specs", None)
 
     redirect_in = True
     _stdin = PIPE if stdin is None else stdin

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -303,9 +303,9 @@ class KernelManager(ConnectionFileMixin):
         ):
             # if self._launch_args["env"] has custom kernel variable for env but env does not have then we have to fill env with it
             if "custom_kernel_specs" in self._launch_args:
-                 saved_env = self._launch_args.get("env", {}) 
-                 custom_kernel_dict = self._launch_args["custom_kernel_specs"]
-                 if isinstance(custom_kernel_dict, dict):
+                saved_env = self._launch_args.get("env", {})
+                custom_kernel_dict = self._launch_args["custom_kernel_specs"]
+                if isinstance(custom_kernel_dict, dict):
                     for key, value in custom_kernel_dict.items():
                         if key in saved_env and key not in env:
                             env[key] = saved_env[key]
@@ -328,16 +328,18 @@ class KernelManager(ConnectionFileMixin):
         elif self.custom_kernel_default_value:
             # if not but default values are present into a kernel.json file then we have to take them
             custom_kernel_dict = self.custom_kernel_default_value
-           
+
         if isinstance(custom_kernel_dict, dict) and len(custom_kernel_dict) > 0:
             for custom_kernel_spec, custom_kernel_spec_value in custom_kernel_dict.items():
                 for env_key, env_item in env.items():
-                    kernel_spec_item = self.replace_spec_parameter(custom_kernel_spec, custom_kernel_spec_value, env_item)
-                    newEnv[env_key]=kernel_spec_item
+                    kernel_spec_item = self.replace_spec_parameter(
+                        custom_kernel_spec, custom_kernel_spec_value, env_item
+                    )
+                    newEnv[env_key] = kernel_spec_item
         else:
-                # check whether there are custom kernel spec variables into kernel.json, 
-                # if yes but a user has not configured them and default ones are not present ,
-                # we should clean them
+            # check whether there are custom kernel spec variables into kernel.json,
+            # if yes but a user has not configured them and default ones are not present ,
+            # we should clean them
             newEnv = self.clear_custom_kernel_parameters(env)
 
         if len(newEnv) > 0:
@@ -346,45 +348,42 @@ class KernelManager(ConnectionFileMixin):
             env = self.clear_custom_kernel_parameters(env)
 
         return env
-    
-    def replace_spec_parameter(self, variable, value, spec)->str:
+
+    def replace_spec_parameter(self, variable, value, spec) -> str:
         regexp = r"\{" + variable + "\\}"
         pattern = re.compile(regexp)
         return pattern.sub(value, spec)
-    
-    def check_existence_custom_kernel_spec(self, item:str):
+
+    def check_existence_custom_kernel_spec(self, item: str):
         pattern = re.compile(r"\{([A-Za-z0-9_]+)\}")
         matches = pattern.findall(item)
         isMatch = False
         if len(matches) > 0:
             isMatch = True
         return isMatch
-    
+
     # Clear kernel specs files if user has not configured them themselves
     # we shoud return only that has not kernel custom variables
     # if there are no metadata specification for custom kernel
 
-    def clear_custom_kernel_parameters(self, kernel_parameters: t.Any)->t.Any:
+    def clear_custom_kernel_parameters(self, kernel_parameters: t.Any) -> t.Any:
         clean_parameters = None
         if isinstance(kernel_parameters, list):
-       
             clean_parameters = []
             for argv_item in kernel_parameters:
                 isMatch = self.check_existence_custom_kernel_spec(argv_item)
                 if not isMatch:
                     clean_parameters.append(argv_item)
         elif isinstance(kernel_parameters, dict):
-           
             clean_parameters = {}
             for env_key, env_item in kernel_parameters.items():
-              
                 isMatch = self.check_existence_custom_kernel_spec(env_item)
                 if not isMatch:
                     clean_parameters[env_key] = env_item
         if len(clean_parameters) == 0:
             clean_parameters = kernel_parameters
         return clean_parameters
-    
+
     def get_default_custom_kernel_specs_value(self):
         assert self.kernel_spec is not None
         custom_kernel_default_value = {}
@@ -395,13 +394,12 @@ class KernelManager(ConnectionFileMixin):
             and isinstance(self.kernel_spec.metadata["parameters"], dict)
             and "properties" in self.kernel_spec.metadata["parameters"]
             and isinstance(self.kernel_spec.metadata["parameters"]["properties"], dict)
-           ):
-           propetries = self.kernel_spec.metadata["parameters"]["properties"].items()
-           for property_key, property_value in propetries:
-               if "default" in property_value:
-                   custom_kernel_default_value[property_key] = property_value["default"]
+        ):
+            propetries = self.kernel_spec.metadata["parameters"]["properties"].items()
+            for property_key, property_value in propetries:
+                if "default" in property_value:
+                    custom_kernel_default_value[property_key] = property_value["default"]
         self.custom_kernel_default_value = custom_kernel_default_value
-
 
     def format_kernel_cmd(self, extra_arguments: t.Optional[t.List[str]] = None) -> t.List[str]:
         """Replace templated args (e.g. {connection_file})"""
@@ -436,9 +434,9 @@ class KernelManager(ConnectionFileMixin):
         if "custom_kernel_specs" in self._launch_args:
             custom_kernel_dict = self._launch_args["custom_kernel_specs"]
             if self.custom_kernel_default_value:
-                    for key, value in self.custom_kernel_default_value.items():
-                        if isinstance(custom_kernel_dict, dict) and key not in custom_kernel_dict:
-                            custom_kernel_dict[key] = value
+                for key, value in self.custom_kernel_default_value.items():
+                    if isinstance(custom_kernel_dict, dict) and key not in custom_kernel_dict:
+                        custom_kernel_dict[key] = value
         elif self.custom_kernel_default_value:
             # if not but default values are present into a kernel.json file then we have to take them
             custom_kernel_dict = self.custom_kernel_default_value
@@ -521,8 +519,8 @@ class KernelManager(ConnectionFileMixin):
         kw = await self.provisioner.pre_launch(**kw)
         # update env
         if "env" in kw:
-           kw["env"] = self.update_custom_env_parameters(env=kw["env"])
-           self._launch_args["env"].update(kw["env"])
+            kw["env"] = self.update_custom_env_parameters(env=kw["env"])
+            self._launch_args["env"].update(kw["env"])
         kernel_cmd = kw.pop("cmd")
         if "custom_kernel_specs" in kw:
             del kw["custom_kernel_specs"]

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -301,6 +301,8 @@ class KernelManager(ConnectionFileMixin):
             and "env" in self._launch_args
             and isinstance(self._launch_args["env"], dict)  # type: ignore [unreachable]
         ):
+            print('update env -----------------------------------j')
+            print(self._launch_args["env"])
             # check whether env has custom kernel spec variables
             env = self.update_custom_env_parameters(env=env)
             print('yes')
@@ -323,6 +325,9 @@ class KernelManager(ConnectionFileMixin):
             custom_kernel_dict = self.custom_kernel_default_value
         print('custom_kernel_dict')
         print(custom_kernel_dict)
+
+        print('update_custom_env_parameters env before-----')
+        print(env)
            
         if len(custom_kernel_dict) > 0:
             for custom_kernel_spec, custom_kernel_spec_value in custom_kernel_dict.items():
@@ -339,7 +344,7 @@ class KernelManager(ConnectionFileMixin):
             env = self.clear_custom_kernel_parameters(newEnv)
         else:
             env = self.clear_custom_kernel_parameters(env)
-        print('update_custom_env_parameters env')
+        print('update_custom_env_parameters env after ---')
         print(env)
         return env
     
@@ -469,6 +474,8 @@ class KernelManager(ConnectionFileMixin):
         #
         assert self.provisioner is not None
         connection_info = await self.provisioner.launch_kernel(kernel_cmd, **kw)
+        print('connection_info')
+        print(connection_info)
         assert self.provisioner.has_process
         # Provisioner provides the connection information.  Load into kernel manager
         # and write the connection file, if not already done.
@@ -524,6 +531,8 @@ class KernelManager(ConnectionFileMixin):
         if "env" in kw:
            print('update!!!')
            kw["env"] = self.update_custom_env_parameters(env=kw["env"])
+           print('skw["env"]')
+           print(kw["env"])
         kernel_cmd = kw.pop("cmd")
         if "custom_kernel_specs" in kw:
             del kw["custom_kernel_specs"]

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -363,7 +363,7 @@ class KernelManager(ConnectionFileMixin):
         return isMatch
 
     # Clear kernel specs files if user has not configured them themselves
-    # we shoud return only that has not kernel custom variables
+    # we should return only that has not kernel custom variables
     # if there are no metadata specification for custom kernel
 
     def clear_custom_kernel_parameters(self, kernel_parameters: t.Any) -> t.Any:
@@ -515,7 +515,6 @@ class KernelManager(ConnectionFileMixin):
                 self.kernel_spec,
                 parent=self,
             )
-        print(self.provisioner)
         kw = await self.provisioner.pre_launch(**kw)
         # update env
         if "env" in kw:
@@ -558,7 +557,14 @@ class KernelManager(ConnectionFileMixin):
              and launching the kernel (e.g. Popen kwargs).
         """
         self._attempted_start = True
+        print('kw')
+        print(kw)
         kernel_cmd, kw = await self._async_pre_start_kernel(**kw)
+        print('kernel_cmd')
+        print(kernel_cmd)
+
+        print('self._launch_args')
+        print(self._launch_args)
 
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)
@@ -718,6 +724,7 @@ class KernelManager(ConnectionFileMixin):
 
         # Start new kernel.
         self._launch_args.update(kw)
+        print('restart')
         print(self._launch_args)
         await self._async_start_kernel(**self._launch_args)
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -557,14 +557,8 @@ class KernelManager(ConnectionFileMixin):
              and launching the kernel (e.g. Popen kwargs).
         """
         self._attempted_start = True
-        print("kw")
-        print(kw)
-        kernel_cmd, kw = await self._async_pre_start_kernel(**kw)
-        print("kernel_cmd")
-        print(kernel_cmd)
 
-        print("self._launch_args")
-        print(self._launch_args)
+        kernel_cmd, kw = await self._async_pre_start_kernel(**kw)
 
         # launch the kernel subprocess
         self.log.debug("Starting kernel: %s", kernel_cmd)
@@ -724,8 +718,7 @@ class KernelManager(ConnectionFileMixin):
 
         # Start new kernel.
         self._launch_args.update(kw)
-        print("restart")
-        print(self._launch_args)
+
         await self._async_start_kernel(**self._launch_args)
 
     restart_kernel = run_sync(_async_restart_kernel)

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -557,13 +557,13 @@ class KernelManager(ConnectionFileMixin):
              and launching the kernel (e.g. Popen kwargs).
         """
         self._attempted_start = True
-        print('kw')
+        print("kw")
         print(kw)
         kernel_cmd, kw = await self._async_pre_start_kernel(**kw)
-        print('kernel_cmd')
+        print("kernel_cmd")
         print(kernel_cmd)
 
-        print('self._launch_args')
+        print("self._launch_args")
         print(self._launch_args)
 
         # launch the kernel subprocess
@@ -724,7 +724,7 @@ class KernelManager(ConnectionFileMixin):
 
         # Start new kernel.
         self._launch_args.update(kw)
-        print('restart')
+        print("restart")
         print(self._launch_args)
         await self._async_start_kernel(**self._launch_args)
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -400,8 +400,6 @@ class KernelManager(ConnectionFileMixin):
            for property_key, property_value in propetries:
                if "default" in property_value:
                    custom_kernel_default_value[property_key] = property_value["default"]
-        print("custom_kernel_default_value")
-        print(custom_kernel_default_value)
         self.custom_kernel_default_value = custom_kernel_default_value
 
 
@@ -506,7 +504,6 @@ class KernelManager(ConnectionFileMixin):
              keyword arguments that are passed down to build the kernel_cmd
              and launching the kernel (e.g. Popen kwargs).
         """
-        print("---_async_pre_start_kernel---")
         self.shutting_down = False
         self.kernel_id = self.kernel_id or kw.pop("kernel_id", str(uuid.uuid4()))
         # save kwargs for use in restart
@@ -520,7 +517,6 @@ class KernelManager(ConnectionFileMixin):
                 self.kernel_spec,
                 parent=self,
             )
-        print("---self.provisioner---")
         print(self.provisioner)
         kw = await self.provisioner.pre_launch(**kw)
         # update env
@@ -530,11 +526,7 @@ class KernelManager(ConnectionFileMixin):
         kernel_cmd = kw.pop("cmd")
         if "custom_kernel_specs" in kw:
             del kw["custom_kernel_specs"]
-       # if "custom_kernel_specs" in self._launch_args:
-       #     del self._launch_args['custom_kernel_specs']
 
-        #print("_async_pre_start_kernel- km---after deletinh")
-       # print(kw)
         return kernel_cmd, kw
 
     pre_start_kernel = run_sync(_async_pre_start_kernel)
@@ -675,20 +667,16 @@ class KernelManager(ConnectionFileMixin):
         self.stop_restarter()
 
         if self.has_kernel:
-            print("---self.has_kernel--")
             await self._async_interrupt_kernel()
 
         if now:
-            print("---_async_kill_kernel---")
             await self._async_kill_kernel()
         else:
-            print("---_async_request_shutdown---")
             await self._async_request_shutdown(restart=restart)
             # Don't send any additional kernel kill messages immediately, to give
             # the kernel a chance to properly execute shutdown actions. Wait for at
             # most 1s, checking every 0.1s.
             await self._async_finish_shutdown(restart=restart)
-        print("---_async_cleanup_resources---")
         await self._async_cleanup_resources(restart=restart)
 
     shutdown_kernel = run_sync(_async_shutdown_kernel)
@@ -728,12 +716,10 @@ class KernelManager(ConnectionFileMixin):
         await self._async_shutdown_kernel(now=now, restart=True)
 
         if newports:
-            print("---cleanup_random_ports---")
             self.cleanup_random_ports()
 
         # Start new kernel.
         self._launch_args.update(kw)
-        print("----self._launch_args---- after")
         print(self._launch_args)
         await self._async_start_kernel(**self._launch_args)
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -303,9 +303,10 @@ class KernelManager(ConnectionFileMixin):
             newEnv = {}
             if self._launch_args["custom_kernel_specs"]:
                 for custom_kernel_spec, custom_kernel_spec_value in self._launch_args["custom_kernel_specs"].items():
-                    for env_key, env_item in env.items():
-                        kernel_spec_item = self.replace_spec_parameter(custom_kernel_spec, custom_kernel_spec_value, env_item)
-                        newEnv[env_key]=kernel_spec_item
+                    if custom_kernel_spec_value != "":
+                        for env_key, env_item in env.items():
+                            kernel_spec_item = self.replace_spec_parameter(custom_kernel_spec, custom_kernel_spec_value, env_item)
+                            newEnv[env_key]=kernel_spec_item
             else:
                 # check whether there are custom kernel spec variables into kernel.json, 
                 # if yes but a user has not configured them,
@@ -314,6 +315,8 @@ class KernelManager(ConnectionFileMixin):
           
             if len(newEnv) > 0:
                 env = newEnv
+            else:
+                env = self.clear_custom_kernel_parameters(env)
             self._launch_args["env"].update(env)  # type: ignore [unreachable]
         
     
@@ -384,7 +387,8 @@ class KernelManager(ConnectionFileMixin):
         #Updating ns if there is custom kernel specs variables
         if self._launch_args["custom_kernel_specs"]:
             for custom_kernel_spec_key, custom_kernel_spec_value in self._launch_args["custom_kernel_specs"].items():
-                ns[custom_kernel_spec_key] = custom_kernel_spec_value
+                if custom_kernel_spec_value != "":
+                    ns[custom_kernel_spec_key] = custom_kernel_spec_value
         if self.kernel_spec:  # type:ignore[truthy-bool]
             ns["resource_dir"] = self.kernel_spec.resource_dir
         assert isinstance(self._launch_args, dict)
@@ -645,6 +649,7 @@ class KernelManager(ConnectionFileMixin):
             msg = "Cannot restart the kernel. No previous call to 'start_kernel'."
             raise RuntimeError(msg)
 
+        print('££££?  REstart ----')
         # Stop currently running kernel.
         await self._async_shutdown_kernel(now=now, restart=True)
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -313,7 +313,7 @@ class KernelManager(ConnectionFileMixin):
     def update_custom_env_parameters(self, env: t.Dict[str, str]) -> t.Dict[str, str]:
         newEnv = {}
         custom_kernel_dict = {}
-        if self._launch_args["custom_kernel_specs"]:
+        if "custom_kernel_specs" in self._launch_args:
             custom_kernel_dict = self._launch_args["custom_kernel_specs"]
             # check is custom kernel variables are full if not then we should take default ones
             if self.custom_kernel_default_value:
@@ -325,9 +325,6 @@ class KernelManager(ConnectionFileMixin):
             custom_kernel_dict = self.custom_kernel_default_value
         print('custom_kernel_dict')
         print(custom_kernel_dict)
-
-        print('update_custom_env_parameters env before-----')
-        print(env)
            
         if len(custom_kernel_dict) > 0:
             for custom_kernel_spec, custom_kernel_spec_value in custom_kernel_dict.items():
@@ -344,8 +341,7 @@ class KernelManager(ConnectionFileMixin):
             env = self.clear_custom_kernel_parameters(newEnv)
         else:
             env = self.clear_custom_kernel_parameters(env)
-        print('update_custom_env_parameters env after ---')
-        print(env)
+
         return env
     
     def replace_spec_parameter(self, variable, value, spec)->str:
@@ -436,7 +432,7 @@ class KernelManager(ConnectionFileMixin):
 
         # Updating ns if there are custom kernel specs variables
         custom_kernel_dict = {}
-        if self._launch_args["custom_kernel_specs"]:
+        if "custom_kernel_specs" in self._launch_args:
             custom_kernel_dict = self._launch_args["custom_kernel_specs"]
             if self.custom_kernel_default_value:
                     for key, value in self.custom_kernel_default_value.items():
@@ -453,7 +449,8 @@ class KernelManager(ConnectionFileMixin):
         if self.kernel_spec:  # type:ignore[truthy-bool]
             ns["resource_dir"] = self.kernel_spec.resource_dir
         assert isinstance(self._launch_args, dict)
-
+        print('----ns[custom_kernel_spec_key]----')
+        print(ns)
         ns.update(self._launch_args)
 
         pat = re.compile(r"\{([A-Za-z0-9_]+)\}")
@@ -531,8 +528,8 @@ class KernelManager(ConnectionFileMixin):
         if "env" in kw:
            print('update!!!')
            kw["env"] = self.update_custom_env_parameters(env=kw["env"])
-           print('skw["env"]')
-           print(kw["env"])
+           #print('skw["env"]')
+           #print(kw["env"])
         kernel_cmd = kw.pop("cmd")
         if "custom_kernel_specs" in kw:
             del kw["custom_kernel_specs"]

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -320,7 +320,7 @@ class KernelManager(ConnectionFileMixin):
             env = self.update_custom_env_parameters(env=env)
 
             self._launch_args["env"].update(env)  # type: ignore [unreachable]
-    
+
     def update_custom_env_parameters(self, env: t.Dict[str, str]) -> t.Dict[str, str]:
         newEnv = {}
         custom_kernel_dict = {}

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -222,12 +222,14 @@ class MultiKernelManager(LoggingConfigurable):
 
         .. version-added: 8.5
         """
+        print("update_env ----- here- multi")
         if kernel_id in self:
             self._kernels[kernel_id].update_env(env=env)
 
     async def _add_kernel_when_ready(
         self, kernel_id: str, km: KernelManager, kernel_awaitable: t.Awaitable
     ) -> None:
+        #
         try:
             await kernel_awaitable
             self._kernels[kernel_id] = km

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -259,6 +259,7 @@ class MultiKernelManager(LoggingConfigurable):
 
         The kernel ID for the newly started kernel is returned.
         """
+        #here
         km, kernel_name, kernel_id = self.pre_start_kernel(kernel_name, kwargs)
         if not isinstance(km, KernelManager):
             self.log.warning(  # type:ignore[unreachable]

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -271,6 +271,9 @@ class MultiKernelManager(LoggingConfigurable):
             )
         kwargs["kernel_id"] = kernel_id  # Make kernel_id available to manager and provisioner
 
+
+        print("---_async_start_kernel--")
+        print("kwargs",kwargs)
         starter = ensure_async(km.start_kernel(**kwargs))
         task = asyncio.create_task(self._add_kernel_when_ready(kernel_id, km, starter))
         self._pending_kernels[kernel_id] = task

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -281,12 +281,14 @@ class MultiKernelManager(LoggingConfigurable):
 
         The kernel ID for the newly started kernel is returned.
         """
-        
+
         if "custom_kernel_specs" in kwargs:
             custom_kernel_specs = kwargs.get("custom_kernel_specs")
-            if custom_kernel_specs is None or (isinstance(custom_kernel_specs, dict) and len(custom_kernel_specs) == 0):
+            if custom_kernel_specs is None or (
+                isinstance(custom_kernel_specs, dict) and len(custom_kernel_specs) == 0
+            ):
                 del kwargs["custom_kernel_specs"]
-        if hasattr(self, '_launch_args') and self._launch_args:
+        if hasattr(self, "_launch_args") and self._launch_args:
             if "custom_kernel_specs" in self._launch_args:
                 if "custom_kernel_specs" not in kwargs:
                     del self._launch_args["custom_kernel_specs"]
@@ -300,7 +302,7 @@ class MultiKernelManager(LoggingConfigurable):
                 )
             )
         kwargs["kernel_id"] = kernel_id  # Make kernel_id available to manager and provisioner
-        print('kwargs')
+        print("kwargs")
         print(kwargs)
         starter = ensure_async(km.start_kernel(**kwargs))
         task = asyncio.create_task(self._add_kernel_when_ready(kernel_id, km, starter))

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import re
 import os
+import re
 import socket
 import typing as t
 import uuid
@@ -223,7 +223,7 @@ class MultiKernelManager(LoggingConfigurable):
 
         .. version-added: 8.5
         """
-        
+
         if kernel_id in self:
             self._kernels[kernel_id].update_env(env=env)
 
@@ -253,23 +253,25 @@ class MultiKernelManager(LoggingConfigurable):
         this multikernelmanager is using pending kernels or not
         """
         return getattr(self, "use_pending_kernels", False)
-    
-    def validate(self, string)->str:
-       sanitazed_string = re.sub(r'[;&|$#]', '', string)
-       match = re.match(r"'", sanitazed_string)
-       if match:
-           sanitazed_string = "'" + re.sub(r"'", "'\''", sanitazed_string) +"'"
-       return sanitazed_string
-    
-    def validate_kernel_parameters(self, kwargs: t.Any)-> None:
+
+    def validate(self, string) -> str:
+        sanitazed_string = re.sub(r"[;&|$#]", "", string)
+        match = re.match(r"'", sanitazed_string)
+        if match:
+            sanitazed_string = "'" + re.sub(r"'", "'''", sanitazed_string) + "'"
+        return sanitazed_string
+
+    def validate_kernel_parameters(self, kwargs: t.Any) -> None:
         if "custom_kernel_specs" in kwargs:
-             custom_kernel_specs =  kwargs.get("custom_kernel_specs")
-             if custom_kernel_specs is not None:
-                for custom_kernel_spec, custom_kernel_spec_value in kwargs["custom_kernel_specs"].items():
+            custom_kernel_specs = kwargs.get("custom_kernel_specs")
+            if custom_kernel_specs is not None:
+                for custom_kernel_spec, custom_kernel_spec_value in kwargs[
+                    "custom_kernel_specs"
+                ].items():
                     sanitazed_string = self.validate(custom_kernel_spec_value)
-                    if (sanitazed_string !=''):
+                    if sanitazed_string != "":
                         kwargs["custom_kernel_specs"][custom_kernel_spec] = sanitazed_string
-        return kwargs            
+        return kwargs
 
     async def _async_start_kernel(self, *, kernel_name: str | None = None, **kwargs: t.Any) -> str:
         """Start a new kernel.
@@ -290,7 +292,6 @@ class MultiKernelManager(LoggingConfigurable):
             )
         kwargs["kernel_id"] = kernel_id  # Make kernel_id available to manager and provisioner
 
-   
         starter = ensure_async(km.start_kernel(**kwargs))
         task = asyncio.create_task(self._add_kernel_when_ready(kernel_id, km, starter))
         self._pending_kernels[kernel_id] = task

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -281,6 +281,15 @@ class MultiKernelManager(LoggingConfigurable):
 
         The kernel ID for the newly started kernel is returned.
         """
+        
+        if "custom_kernel_specs" in kwargs:
+            custom_kernel_specs = kwargs.get("custom_kernel_specs")
+            if custom_kernel_specs is None or (isinstance(custom_kernel_specs, dict) and len(custom_kernel_specs) == 0):
+                del kwargs["custom_kernel_specs"]
+        if hasattr(self, '_launch_args') and self._launch_args:
+            if "custom_kernel_specs" in self._launch_args:
+                if "custom_kernel_specs" not in kwargs:
+                    del self._launch_args["custom_kernel_specs"]
 
         kwargs = self.validate_kernel_parameters(kwargs)
         km, kernel_name, kernel_id = self.pre_start_kernel(kernel_name, kwargs)
@@ -291,7 +300,8 @@ class MultiKernelManager(LoggingConfigurable):
                 )
             )
         kwargs["kernel_id"] = kernel_id  # Make kernel_id available to manager and provisioner
-
+        print('kwargs')
+        print(kwargs)
         starter = ensure_async(km.start_kernel(**kwargs))
         task = asyncio.create_task(self._add_kernel_when_ready(kernel_id, km, starter))
         self._pending_kernels[kernel_id] = task

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -288,6 +288,8 @@ class MultiKernelManager(LoggingConfigurable):
         The kernel ID for the newly started kernel is returned.
         """
         #here
+        print('----validate_kernel_parameters----')
+        print(kwargs)
         kwargs = self.validate_kernel_parameters(kwargs)
         km, kernel_name, kernel_id = self.pre_start_kernel(kernel_name, kwargs)
         if not isinstance(km, KernelManager):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -194,6 +194,8 @@ class MultiKernelManager(LoggingConfigurable):
         self, kernel_name: str | None, kwargs: t.Any
     ) -> tuple[KernelManager, str, str]:
         # kwargs should be mutable, passing it as a dict argument.
+        print('----kwargs---')
+        print(kwargs)
         kernel_id = kwargs.pop("kernel_id", self.new_kernel_id(**kwargs))
         if kernel_id in self:
             raise DuplicateKernelError("Kernel already exists: %s" % kernel_id)
@@ -288,8 +290,8 @@ class MultiKernelManager(LoggingConfigurable):
         The kernel ID for the newly started kernel is returned.
         """
         #here
-        print('----validate_kernel_parameters----')
-        print(kwargs)
+        #print('----validate_kernel_parameters----')
+        #print(kwargs)
         kwargs = self.validate_kernel_parameters(kwargs)
         km, kernel_name, kernel_id = self.pre_start_kernel(kernel_name, kwargs)
         if not isinstance(km, KernelManager):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -223,7 +223,7 @@ class MultiKernelManager(LoggingConfigurable):
 
         .. version-added: 8.5
         """
-        print("update_env ----- here- multi")
+        
         if kernel_id in self:
             self._kernels[kernel_id].update_env(env=env)
 
@@ -290,8 +290,6 @@ class MultiKernelManager(LoggingConfigurable):
             )
         kwargs["kernel_id"] = kernel_id  # Make kernel_id available to manager and provisioner
 
-
-        print("---_async_start_kernel--")
    
         starter = ensure_async(km.start_kernel(**kwargs))
         task = asyncio.create_task(self._add_kernel_when_ready(kernel_id, km, starter))

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -194,8 +194,6 @@ class MultiKernelManager(LoggingConfigurable):
         self, kernel_name: str | None, kwargs: t.Any
     ) -> tuple[KernelManager, str, str]:
         # kwargs should be mutable, passing it as a dict argument.
-        print('----kwargs---')
-        print(kwargs)
         kernel_id = kwargs.pop("kernel_id", self.new_kernel_id(**kwargs))
         if kernel_id in self:
             raise DuplicateKernelError("Kernel already exists: %s" % kernel_id)
@@ -215,9 +213,6 @@ class MultiKernelManager(LoggingConfigurable):
             kernel_name=kernel_name,
             **constructor_kwargs,
         )
-        print('pre_start_kernel')
-        print('---km---')
-        print(km)
         return km, kernel_name, kernel_id
 
     def update_env(self, *, kernel_id: str, env: t.Dict[str, str]) -> None:
@@ -261,13 +256,9 @@ class MultiKernelManager(LoggingConfigurable):
     
     def validate(self, string)->str:
        sanitazed_string = re.sub(r'[;&|$#]', '', string)
-       #print('----sanitazed_string-------')
-       #print(sanitazed_string)
        match = re.match(r"'", sanitazed_string)
        if match:
            sanitazed_string = "'" + re.sub(r"'", "'\''", sanitazed_string) +"'"
-       else:
-            print('----does  not match-------')
        return sanitazed_string
     
     def validate_kernel_parameters(self, kwargs: t.Any)-> None:
@@ -277,7 +268,6 @@ class MultiKernelManager(LoggingConfigurable):
                 for custom_kernel_spec, custom_kernel_spec_value in kwargs["custom_kernel_specs"].items():
                     sanitazed_string = self.validate(custom_kernel_spec_value)
                     if (sanitazed_string !=''):
-                        print('----sanitazed_string is not null------')
                         kwargs["custom_kernel_specs"][custom_kernel_spec] = sanitazed_string
         return kwargs            
 
@@ -289,9 +279,7 @@ class MultiKernelManager(LoggingConfigurable):
 
         The kernel ID for the newly started kernel is returned.
         """
-        #here
-        #print('----validate_kernel_parameters----')
-        #print(kwargs)
+
         kwargs = self.validate_kernel_parameters(kwargs)
         km, kernel_name, kernel_id = self.pre_start_kernel(kernel_name, kwargs)
         if not isinstance(km, KernelManager):

--- a/jupyter_client/multikernelmanager.py
+++ b/jupyter_client/multikernelmanager.py
@@ -302,8 +302,7 @@ class MultiKernelManager(LoggingConfigurable):
                 )
             )
         kwargs["kernel_id"] = kernel_id  # Make kernel_id available to manager and provisioner
-        print("kwargs")
-        print(kwargs)
+
         starter = ensure_async(km.start_kernel(**kwargs))
         task = asyncio.create_task(self._add_kernel_when_ready(kernel_id, km, starter))
         self._pending_kernels[kernel_id] = task

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -193,9 +193,8 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
                 km.control_port = lpc.find_available_port(km.ip)
                 self.ports_cached = True
             if "env" in kwargs:
-                print('pre_launch update env ----')
-                #update env if there is custom kernel specs variables for env
-               # km.update_env(env=kwargs["env"])
+                # update env if there is custom kernel specs variables for env
+                km.update_env(env=kwargs["env"])
    
                 jupyter_session = kwargs["env"].get("JPY_SESSION_NAME", "")
                 km.write_connection_file(jupyter_session=jupyter_session)
@@ -222,7 +221,6 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
         """Launch a kernel with a command."""
         scrubbed_kwargs = LocalProvisioner._scrub_kwargs(kwargs)
-        print('local provisioner launch_kernel')
         self.process = launch_kernel(cmd, **scrubbed_kwargs)
         pgid = None
         if hasattr(os, "getpgid"):

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -214,8 +214,6 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
        
         if "custom_kernel_specs" in kwargs:
             del kwargs["custom_kernel_specs"]
-        #print("--After deleting--kwargs----")
-        #print(kwargs)
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)
 
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -195,7 +195,7 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
             if "env" in kwargs:
                 # update env if there is custom kernel specs variables for env
                 km.update_env(env=kwargs["env"])
-   
+
                 jupyter_session = kwargs["env"].get("JPY_SESSION_NAME", "")
                 km.write_connection_file(jupyter_session=jupyter_session)
             else:
@@ -210,8 +210,8 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
             kernel_cmd = self.kernel_spec.argv + extra_arguments
 
         kernel_cmd = km.clear_custom_kernel_parameters(kernel_cmd)
-        print("cmd--------",kernel_cmd)
-       
+        print("cmd--------", kernel_cmd)
+
         if "custom_kernel_specs" in kwargs:
             del kwargs["custom_kernel_specs"]
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -208,6 +208,8 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
             extra_arguments = kwargs.pop("extra_arguments", [])
             kernel_cmd = self.kernel_spec.argv + extra_arguments
 
+        kernel_cmd = km.clear_custom_kernel_parameters(kernel_cmd)
+        print("cmd--------",kernel_cmd)
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)
 
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
@@ -228,7 +230,7 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
     @staticmethod
     def _scrub_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """Remove any keyword arguments that Popen does not tolerate."""
-        keywords_to_scrub: List[str] = ["extra_arguments", "kernel_id"]
+        keywords_to_scrub: List[str] = ["extra_arguments", "kernel_id", "custom_kernel_specs"]
         scrubbed_kwargs = kwargs.copy()
         for kw in keywords_to_scrub:
             scrubbed_kwargs.pop(kw, None)

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -155,6 +155,7 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
                 lpc.return_port(port)
 
     async def pre_launch(self, **kwargs: Any) -> Dict[str, Any]:
+        #
         """Perform any steps in preparation for kernel process launch.
 
         This includes applying additional substitutions to the kernel launch command and env.
@@ -166,6 +167,8 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
         # This should be considered temporary until a better division of labor can be defined.
         km = self.parent
         if km:
+            if "custom_kernel_specs" in kwargs:
+               km.update_kernel_specs(kwargs["custom_kernel_specs"])
             if km.transport == "tcp" and not is_local_ip(km.ip):
                 msg = (
                     "Can only launch a kernel on a local interface. "
@@ -207,6 +210,7 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
         """Launch a kernel with a command."""
         scrubbed_kwargs = LocalProvisioner._scrub_kwargs(kwargs)
+        #
         self.process = launch_kernel(cmd, **scrubbed_kwargs)
         pgid = None
         if hasattr(os, "getpgid"):

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -167,8 +167,9 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
         # This should be considered temporary until a better division of labor can be defined.
         km = self.parent
         if km:
-            #if "custom_kernel_specs" in kwargs:
-            #    self.kernel_spec = km.update_kernel_specs(kwargs["custom_kernel_specs"])
+            # Get default values from kernel.json file if there is a custom kernel
+            km.get_default_custom_kernel_specs_value()
+
             if km.transport == "tcp" and not is_local_ip(km.ip):
                 msg = (
                     "Can only launch a kernel on a local interface. "
@@ -209,13 +210,12 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
             kernel_cmd = self.kernel_spec.argv + extra_arguments
 
         kernel_cmd = km.clear_custom_kernel_parameters(kernel_cmd)
-
         print("cmd--------",kernel_cmd)
        
         if "custom_kernel_specs" in kwargs:
             del kwargs["custom_kernel_specs"]
-        print("--After deleting--kwargs----")
-        print(kwargs)
+        #print("--After deleting--kwargs----")
+        #print(kwargs)
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)
 
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -193,8 +193,9 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
                 km.control_port = lpc.find_available_port(km.ip)
                 self.ports_cached = True
             if "env" in kwargs:
+                print('pre_launch update env ----')
                 #update env if there is custom kernel specs variables for env
-                km.update_env(env=kwargs["env"])
+               # km.update_env(env=kwargs["env"])
    
                 jupyter_session = kwargs["env"].get("JPY_SESSION_NAME", "")
                 km.write_connection_file(jupyter_session=jupyter_session)
@@ -221,6 +222,7 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
         """Launch a kernel with a command."""
         scrubbed_kwargs = LocalProvisioner._scrub_kwargs(kwargs)
+        print('local provisioner launch_kernel')
         self.process = launch_kernel(cmd, **scrubbed_kwargs)
         pgid = None
         if hasattr(os, "getpgid"):

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -167,8 +167,8 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
         # This should be considered temporary until a better division of labor can be defined.
         km = self.parent
         if km:
-            if "custom_kernel_specs" in kwargs:
-               km.update_kernel_specs(kwargs["custom_kernel_specs"])
+            #if "custom_kernel_specs" in kwargs:
+            #    self.kernel_spec = km.update_kernel_specs(kwargs["custom_kernel_specs"])
             if km.transport == "tcp" and not is_local_ip(km.ip):
                 msg = (
                     "Can only launch a kernel on a local interface. "
@@ -192,6 +192,9 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
                 km.control_port = lpc.find_available_port(km.ip)
                 self.ports_cached = True
             if "env" in kwargs:
+                #update env if there is custom kernel specs variables for env
+                km.update_env(env=kwargs["env"])
+   
                 jupyter_session = kwargs["env"].get("JPY_SESSION_NAME", "")
                 km.write_connection_file(jupyter_session=jupyter_session)
             else:
@@ -210,7 +213,6 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
         """Launch a kernel with a command."""
         scrubbed_kwargs = LocalProvisioner._scrub_kwargs(kwargs)
-        #
         self.process = launch_kernel(cmd, **scrubbed_kwargs)
         pgid = None
         if hasattr(os, "getpgid"):

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -209,7 +209,13 @@ class LocalProvisioner(KernelProvisionerBase):  # type:ignore[misc]
             kernel_cmd = self.kernel_spec.argv + extra_arguments
 
         kernel_cmd = km.clear_custom_kernel_parameters(kernel_cmd)
+
         print("cmd--------",kernel_cmd)
+       
+        if "custom_kernel_specs" in kwargs:
+            del kwargs["custom_kernel_specs"]
+        print("--After deleting--kwargs----")
+        print(kwargs)
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)
 
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -219,8 +219,7 @@ class LocalProvisioner(KernelProvisionerBase):
         kernel_cmd = km.clear_custom_kernel_parameters(kernel_cmd)
         print("cmd--------", kernel_cmd)
 
-        if "custom_kernel_specs" in kwargs:
-            del kwargs["custom_kernel_specs"]
+        kwargs.pop("custom_kernel_specs", None)
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)
 
     async def launch_kernel(self, cmd: list[str], **kwargs: Any) -> KernelConnectionInfo:

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -155,6 +155,7 @@ class KernelProvisionerBase(  # type:ignore[misc]
         :meth:`launch_kernel()`.
         """
         env = kwargs.pop("env", os.environ).copy()
+        # here!!!
         env.update(self.__apply_env_substitutions(env))
         self._finalize_env(env)
         kwargs["env"] = env

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -157,9 +157,9 @@ class KernelProvisionerBase(  # type:ignore[misc]
         env = kwargs.pop("env", os.environ).copy()
         # here!!!
         env.update(self.__apply_env_substitutions(env))
-        
+
         self._finalize_env(env)
-       
+
         kwargs["env"] = env
 
         return kwargs

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -154,6 +154,7 @@ class KernelProvisionerBase(  # type:ignore[misc]
         Returns the (potentially updated) keyword arguments that are passed to
         :meth:`launch_kernel()`.
         """
+        print("---provisiioning base---")
         env = kwargs.pop("env", os.environ).copy()
         # here!!!
         env.update(self.__apply_env_substitutions(env))

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -154,7 +154,6 @@ class KernelProvisionerBase(  # type:ignore[misc]
         Returns the (potentially updated) keyword arguments that are passed to
         :meth:`launch_kernel()`.
         """
-        print("---provisiioning base---")
         env = kwargs.pop("env", os.environ).copy()
         # here!!!
         env.update(self.__apply_env_substitutions(env))

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -238,7 +238,6 @@ class KernelProvisionerBase(  # type:ignore[misc]
             env.pop("PYTHONEXECUTABLE", None)
 
     def __apply_env_substitutions(self, substitution_values: Dict[str, str]) -> Dict[str, str]:
-        print('????')
         """
         Walks entries in the kernelspec's env stanza and applies substitutions from current env.
 

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -160,9 +160,7 @@ class KernelProvisionerBase(  # type:ignore[misc]
         env.update(self.__apply_env_substitutions(env))
         
         self._finalize_env(env)
-        
-        print('new env')
-        print(env)
+       
         kwargs["env"] = env
 
         return kwargs

--- a/jupyter_client/provisioning/provisioner_base.py
+++ b/jupyter_client/provisioning/provisioner_base.py
@@ -158,7 +158,11 @@ class KernelProvisionerBase(  # type:ignore[misc]
         env = kwargs.pop("env", os.environ).copy()
         # here!!!
         env.update(self.__apply_env_substitutions(env))
+        
         self._finalize_env(env)
+        
+        print('new env')
+        print(env)
         kwargs["env"] = env
 
         return kwargs
@@ -236,6 +240,7 @@ class KernelProvisionerBase(  # type:ignore[misc]
             env.pop("PYTHONEXECUTABLE", None)
 
     def __apply_env_substitutions(self, substitution_values: Dict[str, str]) -> Dict[str, str]:
+        print('????')
         """
         Walks entries in the kernelspec's env stanza and applies substitutions from current env.
 


### PR DESCRIPTION
## References

This work is in progress as JEP [jupyter/enhancement-proposals#87](https://github.com/jupyter/enhancement-proposals/pull/87).
This PR should be reviewed when the JEP has been accepted

## Code changes
 
 - Replacing kernel spec variables for arg and env that are in `kernel.json` on values from `custom_kernel_specs` parameter which is configured by a user.  `custom_kernel_specs` is passed from Jupyter Lab through jupyter_server.
 - Clearing kernel spec variables that are in `kernel.json` if they are present into this file but `custom_kernel_specs` parameter is missed
 - Adding basic validation to check whether custom_kernel_specs does not include anything wrong
 - Adding support if a kernel.json file includes customization for a kernel but a user has not selected anything then a parameterized kernel will be run by using default values from its kernel.json file

## How to run
 - Please use this PR with next PRs together:
   https://github.com/jupyterlab/jupyterlab/pull/16487
   https://github.com/jupyter-server/jupyter_server/pull/1431

