### PR TITLE
use simpler isoparse from dateutil to parse ISO-8601 timestamps

### DIFF
--- a/jupyter_client/jsonutil.py
+++ b/jupyter_client/jsonutil.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable
 from datetime import datetime
 from typing import Any, Optional, Union
 
-from dateutil.parser import parse as _dateutil_parse
+from dateutil.parser import isoparse as _dateutil_parse
 from dateutil.tz import tzlocal
 
 next_attr_name = "__next__"  # Not sure what downstream library uses this, but left it to be safe


### PR DESCRIPTION
avoids more complex behavior of general parser, which we don't need since we are already specifying the general format spec as ISO-8601. Also, the general `parse_date` behavior seems to be vulnerable to problems:

- closes https://github.com/ipython/ipykernel/issues/1259
- closes https://github.com/jupyterlab/jupyterlab/issues/16268
