### PR TITLE
Support ipykernel's use of anyio in test_signal_kernel_subprocesses

### DIFF
--- a/tests/signalkernel.py
+++ b/tests/signalkernel.py
@@ -30,7 +30,7 @@ class SignalTestKernel(Kernel):
         if os.environ.get("NO_SHUTDOWN_REPLY") != "1":
             await super().shutdown_request(stream, ident, parent)
 
-    def do_execute(
+    async def do_execute(
         self, code, silent, store_history=True, user_expressions=None, allow_stdin=False
     ):
         code = code.strip()
@@ -47,12 +47,30 @@ class SignalTestKernel(Kernel):
         elif code == "env":
             reply["user_expressions"]["env"] = os.getenv("TEST_VARS", "")
         elif code == "sleep":
-            try:
-                time.sleep(10)
-            except KeyboardInterrupt:
-                reply["user_expressions"]["interrupted"] = True
+            import ipykernel
+            if ipykernel.version_info < (7, 0):
+                # ipykernel before anyio.
+                try:
+                    time.sleep(10)
+                except KeyboardInterrupt:
+                    reply["user_expressions"]["interrupted"] = True
+                else:
+                    reply["user_expressions"]["interrupted"] = False
             else:
+                # ipykernel after anyio.
+                from anyio import open_signal_receiver, create_task_group, sleep
+
+                async def signal_handler(cancel_scope, reply):
+                    with open_signal_receiver(signal.SIGINT) as signals:
+                        async for _ in signals:
+                            reply["user_expressions"]["interrupted"] = True
+                            cancel_scope.cancel()
+                            return
+
                 reply["user_expressions"]["interrupted"] = False
+                async with create_task_group() as tg:
+                    tg.start_soon(signal_handler, tg.cancel_scope, reply)
+                    tg.start_soon(sleep, 10)
         else:
             reply["status"] = "error"
             reply["ename"] = "Error"


### PR DESCRIPTION
Following the switch in ipykernel to use anyio (ipython/ipykernel#1079 and subsequent PRs) its downstream testing against jupyter_client fails with a timeout in the test 
```
tests/test_kernelmanager.py::TestKernelManager::test_signal_kernel_subprocesses
```
A recent example CI run is https://github.com/ipython/ipykernel/actions/runs/10416809602/job/28849785992.

The failure occurs in
https://github.com/jupyter/jupyter_client/blob/8ca76ea1e67c9732a67cab812f8129b68671b9cd/tests/signalkernel.py#L50-L55
because we can no longer catch a `KeyboardInterrupt` interrupt in this way as anyio's support for this requires it to be implemented in a specific way as documented at https://anyio.readthedocs.io/en/stable/signals.html#handling-keyboardinterrupt-and-systemexit to support all the various async backends.

The problem occurs in test code only, so this PR changes that test code so for ipykernel >= 7 it uses the recommended anyio solution and otherwise falls back to the current implementation. This passes locally for me on both Linux and macOS. There is no explicit testing of jupyter_client CI against ipykernel main branch, so to test this we either just merge it and rerun ipykernel's downstream tests, or we have to add an extra temporary CI to use ipykernel main branch.

There may well be other failures in CI once this passes as it currently stops on this failure. I see different subsequent failures on Linux and macOS so we will have to see what happens in CI!