### PR TITLE
Add messaging docs for optional features and kernel subshells

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -118,6 +118,8 @@ so that frontends can label the various messages in a meaningful way.
         "msg_type": str,
         # the message protocol version
         "version": "5.0",
+        # Optional subshell_id
+        "subshell_id": str | None,
     }
 
 .. note::
@@ -139,6 +141,11 @@ so that frontends can label the various messages in a meaningful way.
     from the kernel have a different kernel session id than prior to the disconnect,
     the client should assume that the kernel was restarted.
 
+    The ``subshell_id`` is only used in shell messages of kernels that support
+    subshells (:ref:`kernel_subshells`). If it is not included or is ``None`` then the
+    shell message is handled by the parent subshell (main shell), if it is a string
+    subshell id then it is handled by the subshell with that id.
+
 .. versionchanged:: 5.0
 
     ``version`` key added to the header.
@@ -149,6 +156,10 @@ so that frontends can label the various messages in a meaningful way.
     but it has always been in the canonical implementation,
     so implementers are strongly encouraged to include it.
     It will be mandatory in 5.1.
+
+.. versionchanged:: 5.5
+
+    ``subshell_id`` added to the header.
 
 Parent header
 -------------
@@ -997,7 +1008,8 @@ Message type: ``kernel_info_reply``::
         'banner': str,
 
         # A boolean flag which tells if the kernel supports debugging in the notebook.
-        # Default is False
+        # Default is False.
+        # Deprecated as replaced by 'supported_features'=['debugger'] (see below).
         'debugger': bool,
 
         # Optional: A list of dictionaries, each with keys 'text' and 'url'.
@@ -1005,6 +1017,11 @@ Message type: ``kernel_info_reply``::
         'help_links': [
             {'text': str, 'url': str}
         ],
+
+        # Optional: A list of optional features such as 'debugger' and
+        # 'kernel subshells'. Introduced by Jupyter Enhancement Proposal 92
+        # https://github.com/jupyter/enhancement-proposals/pull/92
+        'supported_features': [str]
     }
 
 Refer to the lists of available `Pygments lexers <http://pygments.org/docs/lexers/>`_
@@ -1030,6 +1047,10 @@ and `codemirror modes <http://codemirror.net/mode/index.html>`_ for those fields
 .. versionchanged:: 5.0
 
     ``language`` moved to ``language_info.name``
+
+.. versionchanged:: 5.5
+
+    ``supported_features`` added and ``debugger`` deprecated.
 
 Messages on the Control (ROUTER/DEALER) channel
 ===============================================
@@ -1309,6 +1330,86 @@ of the debugger to the ``global`` scope to inspect it after debug session.
             'type': str,
             'variablesReference': int
         }
+    }
+
+.. versionadded:: 5.5
+
+.. _kernel_subshells:
+
+Kernel subshells
+----------------
+
+Kernel subshells are separate threads of execution within the same kernel process that
+were introduced by
+`Jupyter Enhancement Proposal 91 <https://github.com/jupyter/enhancement-proposals/pull/91>`_.
+Kernels supporting subshells must return ``'supported_features'=['kernel subshells']``
+in :ref:`kernel info <msging_kernel_info>` reply messages.
+
+Create subshell
+~~~~~~~~~~~~~~~
+
+In a kernel that supports subshells, this creates a new subshell (running in a separate thread)
+and returns its unique id. In a kernel that does not support subshells an error is logged and
+no reply is sent.
+
+Message type: ``create_subshell_request``::
+
+    content = {
+    }
+
+Message type: ``create_subshell_reply``::
+
+    content = {
+        # 'ok' if the request succeeded or 'error', with error information as in all other replies.
+        'status' : 'ok',
+
+        # The id of the subshell, unique within the kernel.
+        'subshell_id': str,
+    }
+
+.. versionadded:: 5.5
+
+Delete subshell
+~~~~~~~~~~~~~~~
+
+In a kernel that supports subshells, this deletes a subshell identified by its unique id.
+In a kernel that does not support subshells an error is logged and no reply is sent.
+
+Message type: ``delete_subshell_request``::
+
+    content = {
+        # The id of the subshell.
+        'subshell_id': str
+    }
+
+Message type: ``delete_subshell_reply``::
+
+    content = {
+        # 'ok' if the request succeeded or 'error', with error information as in all other replies.
+        'status': 'ok',
+    }
+
+.. versionadded:: 5.5
+
+List subshell
+~~~~~~~~~~~~~
+
+In a kernel that supports subshells, this returns a list of the ids of all subshells that exist
+in that kernel. In a kernel that does not support subshells an error is logged and no reply is sent.
+
+Message type: ``list_subshell_request``::
+
+    content = {
+    }
+
+Message type: ``list_subshell_reply``::
+
+    content = {
+        # 'ok' if the request succeeded or 'error', with error information as in all other replies.
+        'status': 'ok',
+
+        # A list of subshell ids.
+        'subshell_id': [str]
     }
 
 .. versionadded:: 5.5
@@ -1755,6 +1856,10 @@ Changelog
 
 - Added ``debug_request/reply`` messages
 - Added ``debug_event`` message
+- Added ``supported_features`` in :ref:`kernel info <msging_kernel_info>` reply messages.
+- Deprecated ``debugger`` in :ref:`kernel info <msging_kernel_info>` reply messages as
+  replaced with ``supported_features``.
+- Added ``create_subshell``, ``delete_subshell`` and ``list_subshell`` messages.
 
 5.4
 ---

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -97,7 +97,7 @@ Message Header
 --------------
 
 The message ``header`` contains information about the message,
-such as unique identifiers for the originating session and the actual message id,
+such as unique identifiers for the originating session and the actual message ID,
 the type of message, the version of the Jupyter protocol,
 and the date the message was created.
 In addition, there is a username field, e.g. for the process that generated the
@@ -124,27 +124,27 @@ so that frontends can label the various messages in a meaningful way.
 
 .. note::
 
-    The ``session`` id in a message header identifies a unique entity with state,
+    The ``session`` ID in a message header identifies a unique entity with state,
     such as a kernel process or client process.
 
-    A client session id, in message headers from a client, should be unique among
+    A client session ID, in message headers from a client, should be unique among
     all clients connected to a kernel. When a client reconnects to a kernel, it
-    should use the same client session id in its message headers. When a client
-    restarts, it should generate a new client session id.
+    should use the same client session ID in its message headers. When a client
+    restarts, it should generate a new client session ID.
 
-    A kernel session id, in message headers from a kernel, should identify a
-    particular kernel process. If a kernel is restarted, the kernel session id
+    A kernel session ID, in message headers from a kernel, should identify a
+    particular kernel process. If a kernel is restarted, the kernel session ID
     should be regenerated.
 
-    The session id in a message header can be used to identify the sending entity.
+    The session ID in a message header can be used to identify the sending entity.
     For example, if a client disconnects and reconnects to a kernel, and messages
-    from the kernel have a different kernel session id than prior to the disconnect,
+    from the kernel have a different kernel session ID than prior to the disconnect,
     the client should assume that the kernel was restarted.
 
     The ``subshell_id`` is only used in shell messages of kernels that support
     subshells (:ref:`kernel_subshells`). If it is not included or is ``None`` then the
     shell message is handled by the parent subshell (main shell), if it is a string
-    subshell id then it is handled by the subshell with that id.
+    subshell ID then it is handled by the subshell with that ID.
 
 .. versionchanged:: 5.0
 
@@ -924,7 +924,7 @@ Message type: ``comm_info_reply``::
         # 'ok' if the request succeeded or 'error', with error information as in all other replies.
         'status' : 'ok',
 
-        # A dictionary of the comms, indexed by uuids.
+        # A dictionary of the comms, indexed by UUIDs.
         'comms': {
             comm_id: {
                 'target_name': str,
@@ -1349,7 +1349,7 @@ Create subshell
 ~~~~~~~~~~~~~~~
 
 In a kernel that supports subshells, this creates a new subshell (running in a separate thread)
-and returns its unique id. In a kernel that does not support subshells an error is logged and
+and returns its unique ID. In a kernel that does not support subshells an error is logged and
 no reply is sent.
 
 Message type: ``create_subshell_request``::
@@ -1363,7 +1363,7 @@ Message type: ``create_subshell_reply``::
         # 'ok' if the request succeeded or 'error', with error information as in all other replies.
         'status' : 'ok',
 
-        # The id of the subshell, unique within the kernel.
+        # The ID of the subshell, unique within the kernel.
         'subshell_id': str,
     }
 
@@ -1372,13 +1372,13 @@ Message type: ``create_subshell_reply``::
 Delete subshell
 ~~~~~~~~~~~~~~~
 
-In a kernel that supports subshells, this deletes a subshell identified by its unique id.
+In a kernel that supports subshells, this deletes a subshell identified by its unique ID.
 In a kernel that does not support subshells an error is logged and no reply is sent.
 
 Message type: ``delete_subshell_request``::
 
     content = {
-        # The id of the subshell.
+        # The ID of the subshell.
         'subshell_id': str
     }
 
@@ -1394,7 +1394,7 @@ Message type: ``delete_subshell_reply``::
 List subshell
 ~~~~~~~~~~~~~
 
-In a kernel that supports subshells, this returns a list of the ids of all subshells that exist
+In a kernel that supports subshells, this returns a list of the IDs of all subshells that exist
 in that kernel. In a kernel that does not support subshells an error is logged and no reply is sent.
 
 Message type: ``list_subshell_request``::
@@ -1408,7 +1408,7 @@ Message type: ``list_subshell_reply``::
         # 'ok' if the request succeeded or 'error', with error information as in all other replies.
         'status': 'ok',
 
-        # A list of subshell ids.
+        # A list of subshell IDs.
         'subshell_id': [str]
     }
 

--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1342,7 +1342,7 @@ Kernel subshells
 Kernel subshells are separate threads of execution within the same kernel process that
 were introduced by
 `Jupyter Enhancement Proposal 91 <https://github.com/jupyter/enhancement-proposals/pull/91>`_.
-Kernels supporting subshells must return ``'supported_features'=['kernel subshells']``
+Kernels supporting subshells must include ``'kernel subshells'`` in ``'supported_features'``
 in :ref:`kernel info <msging_kernel_info>` reply messages.
 
 Create subshell


### PR DESCRIPTION
This adds messaging documentation for optional features [JEP92](https://github.com/jupyter/enhancement-proposals/pull/92) and kernel subshells [JEP91](https://github.com/jupyter/enhancement-proposals/pull/91/files).

Summary of changes:

- Optional features [JEP92](https://github.com/jupyter/enhancement-proposals/pull/92):
  - Return optional `supported_features` in `kernel_info_reply`.
  - Deprecate use of `debugger` in `kernel_info_reply` as this is replaced by `supported_features=['debugger']`. It will have to be a long deprecation period whilst other libraries in the Jupyter ecosystem adopt use of `supported_features`.

- Kernel subshells [JEP91](https://github.com/jupyter/enhancement-proposals/pull/91/files):
  - Return `supported_features=['kernel subshells']` in `kernel_info_reply`.
  - New control request/reply messages for `create`, `delete` and `list` subshells.
  - Add optional `subshell_id` to message header. 

The version added/changed for all of these is 5.5. I am unsure of the protocol around official releases here.