### PR TITLE
Set protocol version to 5.4

### DIFF
--- a/jupyter_client/_version.py
+++ b/jupyter_client/_version.py
@@ -16,5 +16,5 @@ else:
 version_info = tuple(parts)
 
 
-protocol_version_info = (5, 3)
+protocol_version_info = (5, 4)
 protocol_version = "%i.%i" % protocol_version_info


### PR DESCRIPTION
I believe this was incorrectly left as 5.3 since the blocking and async clients both expect the shutdown message to come on the control channel, e.g. https://github.com/jupyter/jupyter_client/blob/6ea834d69d9404b9b67fbc066ee8bdf1d7d2ede6/jupyter_client/blocking/client.py#L70-L71