### PR TITLE
Faster message serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements made
 
 - Support psutil for finding network addresses [#1033](https://github.com/jupyter/jupyter_client/pull/1033) ([@juliangilbey](https://github.com/juliangilbey))
+- Add new functions `orjson_packer` and `orjson_unpacker`.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Enhancements made
 
 - Support psutil for finding network addresses [#1033](https://github.com/jupyter/jupyter_client/pull/1033) ([@juliangilbey](https://github.com/juliangilbey))
-- Add new functions `orjson_packer` and `orjson_unpacker`.
+- Add new functions `orjson_packer`, `orjson_unpacker`, `msgpack_packer` and `msgpack_unpacker`
 
 ### Bugs fixed
 

--- a/jupyter_client/session.py
+++ b/jupyter_client/session.py
@@ -132,16 +132,11 @@ except ModuleNotFoundError:
     _default_packer_unpacker = "json", "json"
     _default_pack_unpack = (json_packer, json_unpacker)
 else:
+    import functools
 
-    def orjson_packer(obj: t.Any) -> bytes:
-        """Convert a json object to a bytes using orjson with a fallback to json_packer."""
-        try:
-            return orjson.dumps(
-                obj, default=json_default, option=orjson.OPT_NAIVE_UTC | orjson.OPT_UTC_Z
-            )
-        except (TypeError, ValueError):
-            return json_packer(obj)
-
+    orjson_packer = functools.partial(
+        orjson.dumps, default=json_default, option=orjson.OPT_NAIVE_UTC | orjson.OPT_UTC_Z
+    )
     orjson_unpacker = orjson.loads
     _default_packer_unpacker = "orjson", "orjson"
     _default_pack_unpack = (orjson_packer, orjson_unpacker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ requires-python = ">=3.9"
 dependencies = [
     "importlib_metadata>=4.8.3;python_version<\"3.10\"",
     "jupyter_core>=4.12,!=5.0.*",
+    "orjson>=3.10.18; implementation_name == 'cpython'",
     "python-dateutil>=2.8.2",
     "pyzmq>=23.0",
     "tornado>=6.2",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -47,6 +47,8 @@ serializers = [
 ]
 if ss.orjson:
     serializers.append(("orjson", ss.orjson_packer, ss.orjson_unpacker))
+if ss.msgpack:
+    serializers.append(("msgpack", ss.msgpack_packer, ss.msgpack_unpacker))
 
 
 @pytest.mark.usefixtures("no_copy_threshold")
@@ -537,7 +539,7 @@ def test_serialize_objects(packer, pack, unpack, description, data):
         warnings.simplefilter("ignore")
         value = pack(data_in)
     unpacked = unpack(value)
-    if (description == "infinite") and (packer == "pickle"):
+    if (description == "infinite") and (packer in ["pickle", "msgpack"]):
         assert math.isinf(unpacked)
         return
     assert unpacked in data_out_options
@@ -552,7 +554,7 @@ def test_cannot_serialize(session, packer, pack, unpack):
 
 @pytest.mark.parametrize("mode", ["packer", "unpacker"])
 @pytest.mark.parametrize(["packer", "pack", "unpack"], serializers)
-def test_packer_unpacker(session, packer, pack, unpack, mode):
+def test_pack_unpack(session, packer, pack, unpack, mode):
     s: ss.Session = session
     s.set_trait(mode, packer)
     assert s.pack is pack


### PR DESCRIPTION
This PR provides faster pack and unpack defaults by utilizing orjson to pack and unpack data.

## orjson
  new two functions  `orjson_packer` and `orjson_unpacker`  to use [`orjson`](https://pypi.org/project/orjson/) a **"fast, correct JSON library"** for packing and unpacking data.

Session.pack and Session.unpack traits now default to use `orjson_packer` and `orjson_unpacker` respectively when orjson is installed. orjson is added as a dependency for `implementation_name = 'cpython'`.

## msgpack
[msgpack](https://pypi.org/project/msgpack/) support has also been added with the functions `msgpack_packer`  and msgpack_unpacker` .


## Performance
![image](https://github.com/user-attachments/assets/a7a597b3-fcee-446f-827f-febaea3eec8c)
