### PR TITLE
Revert test changes of PR 1034

### DIFF
--- a/tests/signalkernel.py
+++ b/tests/signalkernel.py
@@ -30,7 +30,7 @@ class SignalTestKernel(Kernel):
         if os.environ.get("NO_SHUTDOWN_REPLY") != "1":
             await super().shutdown_request(stream, ident, parent)
 
-    async def do_execute(
+    def do_execute(
         self, code, silent, store_history=True, user_expressions=None, allow_stdin=False
     ):
         code = code.strip()
@@ -47,31 +47,12 @@ class SignalTestKernel(Kernel):
         elif code == "env":
             reply["user_expressions"]["env"] = os.getenv("TEST_VARS", "")
         elif code == "sleep":
-            import ipykernel
-
-            if ipykernel.version_info < (7, 0):
-                # ipykernel before anyio.
-                try:
-                    time.sleep(10)
-                except KeyboardInterrupt:
-                    reply["user_expressions"]["interrupted"] = True
-                else:
-                    reply["user_expressions"]["interrupted"] = False
+            try:
+                time.sleep(10)
+            except KeyboardInterrupt:
+                reply["user_expressions"]["interrupted"] = True
             else:
-                # ipykernel after anyio.
-                from anyio import create_task_group, open_signal_receiver, sleep
-
-                async def signal_handler(cancel_scope, reply):
-                    with open_signal_receiver(signal.SIGINT) as signals:
-                        async for _ in signals:
-                            reply["user_expressions"]["interrupted"] = True
-                            cancel_scope.cancel()
-                            return
-
                 reply["user_expressions"]["interrupted"] = False
-                async with create_task_group() as tg:
-                    tg.start_soon(signal_handler, tg.cancel_scope, reply)
-                    tg.start_soon(sleep, 10)
         else:
             reply["status"] = "error"
             reply["ename"] = "Error"


### PR DESCRIPTION
This reverts the test changes made in #1034, to fix #1066.

The changes were all in a single test and only applied to `ipykernel >= 7` which at the time was expected to use `anyio`. Now `ipykernel 7` will not include `anyio` so the changes are no longer required.

This is tested in the `ipykernel` downstream CI tests, which will fail until this is merged to `main` here.

As the changes are all in test code they are not user-facing so there are no ramifications for releases.