### PR TITLE
Bugfix / Correct stopping async cell execution

### DIFF
--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -572,10 +572,10 @@ class KernelClient(ConnectionFileMixin):
             if msg["header"]["msg_type"] == "status":
                 state = msg["content"]["execution_state"]
                 # allow to stop
-                if state == 'busy':
-                    can_stop = True                
+                if state == "busy":
+                    can_stop = True
                 # stop on idle
-                if state == 'idle' and can_stop:
+                if state == "idle" and can_stop:
                     break
 
         # output is done, get the reply

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -569,8 +569,8 @@ class KernelClient(ConnectionFileMixin):
                 continue
             output_hook(msg)
 
-            state = msg["content"]["execution_state"]
             if msg["header"]["msg_type"] == "status":
+                state = msg["content"]["execution_state"]
                 # allow to stop
                 if state == 'busy':
                     can_stop = True                

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -544,6 +544,7 @@ class KernelClient(ConnectionFileMixin):
             stdin_socket = None
 
         # wait for output and redisplay it
+        can_stop = False
         while True:
             if timeout is not None:
                 timeout = max(0, deadline - time.monotonic())
@@ -568,12 +569,14 @@ class KernelClient(ConnectionFileMixin):
                 continue
             output_hook(msg)
 
-            # stop on idle
-            if (
-                msg["header"]["msg_type"] == "status"
-                and msg["content"]["execution_state"] == "idle"
-            ):
-                break
+            state = msg["content"]["execution_state"]
+            if msg["header"]["msg_type"] == "status":
+                # allow to stop
+                if state == 'busy':
+                    can_stop = True                
+                # stop on idle
+                if state == 'idle' and can_stop:
+                    break
 
         # output is done, get the reply
         if timeout is not None:


### PR DESCRIPTION
Regarding document:
https://github.com/jupyter/jupyter_client/blob/eb96748e0afb970c806653824540dbadc83ffc84/docs/messaging.rst?plain=1#L1634-L1639

Context:
The async cell execution stopped too early because it hit the below condition while the cell is being executed. This also means there was a moment when iopub message satisfied both `msg["parent_header"].get("msg_id") == msg_id` and `execution_state='idle'`
https://github.com/jupyter/jupyter_client/blob/eb96748e0afb970c806653824540dbadc83ffc84/jupyter_client/client.py#L560-L572

This PR aims to set a flag to allow stopping the cell execution only when it saw 'busy' state, which forces the stop condition to run after cell execution starts.
