### PR TITLE
Set event manual reset flag to true

### DIFF
--- a/jupyter_client/win_interrupt.py
+++ b/jupyter_client/win_interrupt.py
@@ -40,6 +40,7 @@ def create_interrupt_event() -> Any:
         manual_reset = False
         try:
             from ipykernel.parentpoller import ParentPollerWindows
+
             if hasattr(ParentPollerWindows, "reset_event"):
                 manual_reset = True
         except ImportError:

--- a/jupyter_client/win_interrupt.py
+++ b/jupyter_client/win_interrupt.py
@@ -32,10 +32,26 @@ def create_interrupt_event() -> Any:
     sa.nLength = ctypes.sizeof(SECURITY_ATTRIBUTES)
     sa.lpSecurityDescriptor = 0
     sa.bInheritHandle = 1
+    # ensure backward compatibility with older ParentPollerWindows
+    # implementations which relied on bManualReset to be set to False
+    # upon event creation
+    MANUAL_RESET_ATTR = "manual_reset"
+    if not hasattr(create_interrupt_event, MANUAL_RESET_ATTR):
+        manual_reset = False
+        try:
+            from ipykernel.parentpoller import ParentPollerWindows
+            if hasattr(ParentPollerWindows, "reset_event"):
+                manual_reset = True
+        except ImportError:
+            pass
+        finally:
+            setattr(create_interrupt_event, MANUAL_RESET_ATTR, manual_reset)
+    else:
+        manual_reset = getattr(create_interrupt_event, MANUAL_RESET_ATTR)
 
     return ctypes.windll.kernel32.CreateEventA(  # type:ignore[attr-defined]
         sa_p,
-        True,
+        manual_reset,
         False,
         "",  # lpEventAttributes  # bManualReset  # bInitialState
     )  # lpName

--- a/jupyter_client/win_interrupt.py
+++ b/jupyter_client/win_interrupt.py
@@ -35,7 +35,7 @@ def create_interrupt_event() -> Any:
 
     return ctypes.windll.kernel32.CreateEventA(  # type:ignore[attr-defined]
         sa_p,
-        False,
+        True,
         False,
         "",  # lpEventAttributes  # bManualReset  # bInitialState
     )  # lpName


### PR DESCRIPTION
Currently, a long-running C Python module executed on Windows in a Jupyter kernel can only be interrupted by sending twice the "Interrupt kernel" signal.
This happens because the first interrupt signal is intercepted by `ipykernel/parentpoller.py` and as it is set to auto-reset, it will not reach a C Python module  listening for the same signal. At the time, the `interrupt_main()` call scheduled by `ipykernel/parentpoller.py`  will not be executed as the main Python thread is blocked by the long-running C Python module.
Only when the "Interrupt kernel" is issued again the C Python module will be interrupted.

This PR sets the `CreateEvent` `bManualReset` Boolean flag to `true`, thus requiring the interrupt event to be manually reset by the receiver. This makes it possible for a listening C Python module to be reached by the signal and hence be interrupted, without requiring the interrupt signal to be issued twice.

This can be conveniently tested through the attached `waitloop` test Python module, which can be installed on all platforms supported by Jupyter by unzipping [waitloop_module.zip](https://github.com/user-attachments/files/22448160/waitloop_module.zip) and then running `pip install .` in the `waitloop_module` directory:

### Python interpreter - all platforms
```python
>>> import waitloop
>>> waitloop.run()

[Press CTRL+C on your keyboard to interrupt the loop]

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyboardInterrupt
```

### Jupyter notebook - Windows platform
```
[1]: import waitloop

[2]: waitloop.run()

[Issue Kernel->Interrupt kernel once - waitloop keeps running]
[Issue Kernel->Interrupt kernel again - waitloop stops running]
```

### Jupyter notebook - non-Windows platforms
```
[1]: import waitloop

[2]: waitloop.run()

[Issue Kernel->Interrupt kernel once - waitloop stops running]
```

WIth the current Jupyter version, on Windows it is necessary to issue "Interrupt kernel" twice to interrupt `waitloop`, whereas on non-Windows platforms it is sufficient to issue the command once,

After merging this PR and the sister [PR #1434](https://github.com/ipython/ipykernel/pull/1434) in the `ipykernel` repo, a single "Interrupt kernel" will stop `waitloop` also on Windows, as expected.
