### PR TITLE
[Docs] Use extension:filetype mapping in sphinx configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'


### PR DESCRIPTION
This is possible since sphinx 1.8, and avoid the message:
>  "Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`"
at docs build time. See https://www.sphinx-doc.org/en/master/usage/configuration.html\#confv