### PR TITLE
Some tests import anyio (depending on ipykernel version).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Source = "https://github.com/jupyter/jupyter_client"
 
 [project.optional-dependencies]
 test = [
+    "anyio",
     "coverage",
     "ipykernel>=6.14",
     "mypy",


### PR DESCRIPTION
This makes some downstream test fail when installing [test]