### PR TITLE
Fix #1061: Pass restart argument in _async_finish_shutdown

### DIFF
--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -483,7 +483,7 @@ class KernelManager(ConnectionFileMixin):
         except asyncio.TimeoutError:
             self.log.debug("Kernel is taking too long to finish, terminating")
             self._shutdown_status = _ShutdownStatus.SigtermRequest
-            await self._async_send_kernel_sigterm()
+            await self._async_send_kernel_sigterm(restart=restart)
 
         try:
             await asyncio.wait_for(


### PR DESCRIPTION
This PR fixes issue #1061. I have updated the _async_finish_shutdown method in manager.py to ensure that the restart argument is correctly passed to both _async_send_kernel_sigterm() and _async_kill_kernel().