### PR TITLE
test: ensure async recv reply raises TimeoutError on timeout

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,6 @@ TIMEOUT = 60
 pjoin = os.path.join
 
 import asyncio
-import pytest
 from queue import Empty
 
 from jupyter_client.client import KernelClient
@@ -29,7 +28,7 @@ from jupyter_client.client import KernelClient
 class _NeverReplyChannel:
     async def get_msg(self, *args, **kwargs):
         raise Empty()
-    
+
 
 class TestKernelClient(TestCase):
     def setUp(self):
@@ -344,6 +343,7 @@ def test_validate_string_dict():
         validate_string_dict(dict(a=1))  # type:ignore
     with pytest.raises(ValueError):
         validate_string_dict({1: "a"})  # type:ignore
+
 
 @pytest.mark.asyncio
 async def test_async_recv_reply_timeout():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,17 @@ TIMEOUT = 60
 
 pjoin = os.path.join
 
+import asyncio
+import pytest
+from queue import Empty
+
+from jupyter_client.client import KernelClient
+
+
+class _NeverReplyChannel:
+    async def get_msg(self, *args, **kwargs):
+        raise Empty()
+    
 
 class TestKernelClient(TestCase):
     def setUp(self):
@@ -333,3 +344,11 @@ def test_validate_string_dict():
         validate_string_dict(dict(a=1))  # type:ignore
     with pytest.raises(ValueError):
         validate_string_dict({1: "a"})  # type:ignore
+
+@pytest.mark.asyncio
+async def test_async_recv_reply_timeout():
+    kc = KernelClient()
+    kc._shell_channel = _NeverReplyChannel()
+
+    with pytest.raises(TimeoutError):
+        await kc._async_recv_reply("fake-id", timeout=0.01)


### PR DESCRIPTION
Adds a focused async test verifying that KernelClient._async_recv_reply raises TimeoutError when no reply is received before the timeout.

The test uses a minimal fake channel to simulate a non-responsive kernel and asserts the timeout behavior.
