### PR TITLE
Add ZMQ Curve for transport encryption

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run the tests
         run: |
-          hatch run ${HATCH_ENV}:test tests/test_transport_security.py::test_enabled_without_curve_kernelspec_skips_keys -s
+          hatch run ${HATCH_ENV}:test
         env:
           PYTHONTRACEMALLOC: "10"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run the tests
         run: |
-          hatch run ${HATCH_ENV}:test
+          hatch run ${HATCH_ENV}:test tests/test_transport_security.py::test_enabled_without_curve_kernelspec_skips_keys -s
         env:
           PYTHONTRACEMALLOC: "10"
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ with Jupyter kernels.
    wrapperkernels
    provisioning
    pending-kernels
+   security
 
 .. toctree::
    :maxdepth: 2

--- a/docs/kernels.rst
+++ b/docs/kernels.rst
@@ -64,6 +64,19 @@ New ports are chosen at random for each kernel started.
 that other users on the system can't send code to run in this kernel. See
 :ref:`wire_protocol` for the details of how this signature is calculated.
 
+When transport encryption is enabled, two additional fields are present:
+
+``curve_publickey``
+    Z85-encoded 40-character ASCII string holding the server's CurveZMQ
+    public key. Kernels must apply this to their ZMQ sockets before binding.
+
+``curve_secretkey``
+    Z85-encoded 40-character ASCII string holding the server's CurveZMQ
+    secret key. Kernels must apply this to their ZMQ sockets before binding.
+
+See :ref:`security` for full details on how to enable transport encryption
+and how kernels should handle these fields.
+
 Handling messages
 =================
 
@@ -163,6 +176,12 @@ JSON serialised dictionary containing the following keys and values:
 - **metadata** (optional): A dictionary of additional attributes about this
   kernel; used by clients to aid in kernel selection. Metadata added
   here should be namespaced for the tool reading and writing that metadata.
+  The following key is recognised by ``jupyter_client`` itself:
+
+  - **supported_encryption** (optional): Set to ``"curve"`` to declare that
+    this kernel can handle CurveZMQ keys in its connection file. Required
+    when ``KernelManager.transport_encryption`` is ``'required'``, and used
+    as a gate when it is ``'auto'``. See :ref:`security` for details.
 
 For example, the kernel.json file for IPython looks like this::
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,0 +1,162 @@
+.. _security:
+
+================================
+Transport security for kernels
+================================
+
+.. versionadded:: 8.9
+
+By default, the ZMQ sockets used to communicate with kernels (shell, IOPub,
+stdin, control, heartbeat) are bound to local TCP ports with no
+transport-level encryption. Any process on the same host that can reach
+those ports can connect and read messages, including all IOPub output.
+
+`CurveZMQ <https://rfc.zeromq.org/spec/26/>`_ adds elliptic-curve
+encryption and authentication at the ZMQ transport layer. When enabled, the
+``KernelManager`` generates a keypair, writes it into the kernel's connection
+file, and configures all sockets as a CurveZMQ server. Clients must present
+the correct server public key to connect; unauthenticated connections are
+silently dropped before any data is delivered.
+
+.. note::
+
+    CurveZMQ is only available when pyzmq was compiled against a libzmq that
+    includes libsodium. You can verify this with::
+
+        python -c "import zmq; print(zmq.has('curve'))"
+
+    If this prints ``False``, the ``transport_encryption`` setting has no
+    effect and attempts to set it to ``'auto'`` or ``'required'`` will raise
+    a :exc:`traitlets.TraitError`.
+
+.. note::
+
+    ``transport_encryption`` applies to TCP transport only. IPC sockets
+    already rely on filesystem permissions for access control and do not
+    support CurveZMQ.
+
+
+The ``transport_encryption`` setting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Transport encryption is controlled by the
+``KernelManager.transport_encryption`` traitlet, which accepts three values:
+
+``'disabled'`` (default)
+    No CurveZMQ keys are generated. All kernel sockets are unencrypted.
+
+``'auto'``
+    Keys are generated **only when the kernelspec declares support** via
+    ``metadata.supported_encryption: 'curve'``. Kernelspecs that do not
+    declare this field are started without encryption, so the setting is safe
+    to enable globally without breaking existing kernels.
+
+``'required'``
+    Keys are always generated. Startup fails with a :exc:`RuntimeError` if
+    the kernelspec does not declare ``metadata.supported_encryption: 'curve'``,
+    so kernels that have not been updated to handle the connection-file keys
+    are never started unencrypted.
+
+To enable encryption for all kernels that support it, add the following to
+your configuration:
+
+.. code:: python
+
+    c.KernelManager.transport_encryption = "auto"
+
+To enforce encryption and refuse to start kernels that do not declare support:
+
+.. code:: python
+
+    c.KernelManager.transport_encryption = "required"
+
+
+Kernelspec requirements
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A kernel must declare CurveZMQ support in its ``kernel.json`` before the
+``KernelManager`` will provision keys for it:
+
+.. code:: JSON
+
+    {
+        "argv": ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+        "display_name": "Python 3",
+        "language": "python",
+        "metadata": {
+            "supported_encryption": "curve"
+        }
+    }
+
+When ``transport_encryption`` is ``'auto'``, kernelspecs without this field
+are started normally without encryption. When it is ``'required'``, their
+startup is refused.
+
+.. note::
+
+    When updating a previously installed kernel to a version that supports
+    encryption you may need to re-install the kernelspec or manually add the
+    ``supported_encryption`` metadata field. If you subsequently decide to
+    downgrade, you will need to remove this field as otherwise the kernel will
+    silently fail to connect.
+
+
+Connection file fields
+~~~~~~~~~~~~~~~~~~~~~~
+
+When ``transport_encryption`` is active the connection file written to disk
+will contain two additional fields alongside the usual port and key fields:
+
+``curve_publickey``
+    Z85-encoded 40-character ASCII string holding the server's CurveZMQ
+    public key.
+
+``curve_secretkey``
+    Z85-encoded 40-character ASCII string holding the server's CurveZMQ
+    secret key.
+
+Kernel implementations must read these fields from the connection file and
+apply them to their ZMQ sockets before binding. See :ref:`kernels` for the
+full description of the connection file format.
+
+
+Implementing curve support in a kernel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A kernel that wants to be compatible with ``transport_encryption`` must apply
+the keypair to every socket it binds. In Python, using pyzmq, that looks like:
+
+.. code:: python
+
+    import json
+    import zmq
+
+    with open(connection_file_path) as f:
+        cfg = json.load(f)
+
+    ctx = zmq.Context()
+    shell = ctx.socket(zmq.ROUTER)
+
+    if "curve_publickey" in cfg and "curve_secretkey" in cfg:
+        shell.curve_secretkey = cfg["curve_secretkey"].encode()
+        shell.curve_publickey = cfg["curve_publickey"].encode()
+        shell.curve_server = True
+
+    shell.bind(f"tcp://{cfg['ip']}:{cfg['shell_port']}")
+
+The same pattern applies to the IOPub, stdin, control, and heartbeat sockets.
+Setting ``curve_server = True`` on a bound socket causes ZMQ to require
+CurveZMQ authentication on every incoming connection; unauthenticated clients
+are rejected automatically.
+
+Kernels based on `ipykernel <https://ipykernel.readthedocs.io/>`_ v7.3+ handle
+this automatically when the connection file contains the curve fields.
+
+.. seealso::
+
+   :ref:`kernels`
+     Connection file format and kernelspec reference.
+
+   :ref:`provisioning`
+     How ``LocalProvisioner`` generates and injects curve keys during
+     kernel startup.

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -69,7 +69,7 @@ class HBChannel(Thread):
         address : zmq url
             Standard (ip, port) tuple that the kernel is listening on.
         curve_serverkey : bytes, optional
-            CurveZMQ server public key (Z85).  When provided, the
+            CurveZMQ server public key (Z85). When provided, the
             heartbeat REQ socket is configured as a CurveZMQ client so it
             can communicate with a CurveZMQ-enabled kernel.
         """

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -55,6 +55,8 @@ class HBChannel(Thread):
         context: zmq.Context | None = None,
         session: Session | None = None,
         address: t.Union[t.Tuple[str, int], str] = "",
+        *,
+        curve_serverkey: bytes | None = None,
     ) -> None:
         """Create the heartbeat monitor thread.
 
@@ -66,12 +68,17 @@ class HBChannel(Thread):
             The session to use.
         address : zmq url
             Standard (ip, port) tuple that the kernel is listening on.
+        curve_serverkey : bytes, optional
+            Z85-encoded CurveZMQ server public key.  When provided, the
+            heartbeat REQ socket is configured as a CurveZMQ client so it
+            can communicate with a CurveZMQ-enabled kernel.
         """
         super().__init__()
         self.daemon = True
 
         self.context = context
         self.session = session
+        self.curve_serverkey = curve_serverkey
         if isinstance(address, tuple):
             if address[1] == 0:
                 message = "The port number for a channel cannot be 0."
@@ -104,6 +111,13 @@ class HBChannel(Thread):
         assert self.context is not None
         self.socket = self.context.socket(zmq.REQ)
         self.socket.linger = 1000
+        if self.curve_serverkey is not None:
+            # Generate a fresh ephemeral keypair for each socket; only the
+            # server public key (curve_serverkey) is needed for authentication.
+            client_pub, client_sec = zmq.curve_keypair()
+            self.socket.curve_secretkey = client_sec
+            self.socket.curve_publickey = client_pub
+            self.socket.curve_serverkey = self.curve_serverkey
         assert self.address is not None
         self.socket.connect(self.address)
 

--- a/jupyter_client/channels.py
+++ b/jupyter_client/channels.py
@@ -69,7 +69,7 @@ class HBChannel(Thread):
         address : zmq url
             Standard (ip, port) tuple that the kernel is listening on.
         curve_serverkey : bytes, optional
-            Z85-encoded CurveZMQ server public key.  When provided, the
+            CurveZMQ server public key (Z85).  When provided, the
             heartbeat REQ socket is configured as a CurveZMQ client so it
             can communicate with a CurveZMQ-enabled kernel.
         """

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -393,8 +393,8 @@ class KernelClient(ConnectionFileMixin):
             url = self._make_url("hb")
             self.log.debug("connecting heartbeat channel to %s", url)
             hb_kwargs = {}
-            if self._curve_publickey:
-                hb_kwargs["curve_serverkey"] = self._curve_publickey
+            if self.curve_publickey:
+                hb_kwargs["curve_serverkey"] = self.curve_publickey
             try:
                 self._hb_channel = self.hb_channel_class(  # type:ignore[call-arg,abstract]
                     self.context,

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -392,11 +392,21 @@ class KernelClient(ConnectionFileMixin):
         if self._hb_channel is None:
             url = self._make_url("hb")
             self.log.debug("connecting heartbeat channel to %s", url)
+            hb_supports_curve = (
+                "curve_serverkey" in inspect.signature(self.hb_channel_class.__init__).parameters
+            )
+            if self._curve_publickey is not None and not hb_supports_curve:
+                msg = (
+                    f"{self.hb_channel_class.__name__} does not support the "
+                    "'curve_serverkey' parameter. Upgrade the heartbeat channel "
+                    "class or disable CurveZMQ encryption."
+                )
+                raise RuntimeError(msg)
             self._hb_channel = self.hb_channel_class(  # type:ignore[call-arg,abstract]
                 self.context,
                 self.session,
                 url,
-                curve_serverkey=self._curve_publickey,
+                **({"curve_serverkey": self._curve_publickey} if hb_supports_curve else {}),
             )
         return self._hb_channel
 

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -393,7 +393,10 @@ class KernelClient(ConnectionFileMixin):
             url = self._make_url("hb")
             self.log.debug("connecting heartbeat channel to %s", url)
             self._hb_channel = self.hb_channel_class(  # type:ignore[call-arg,abstract]
-                self.context, self.session, url
+                self.context,
+                self.session,
+                url,
+                curve_serverkey=self._curve_publickey,
             )
         return self._hb_channel
 

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -392,22 +392,26 @@ class KernelClient(ConnectionFileMixin):
         if self._hb_channel is None:
             url = self._make_url("hb")
             self.log.debug("connecting heartbeat channel to %s", url)
-            hb_supports_curve = (
-                "curve_serverkey" in inspect.signature(self.hb_channel_class.__init__).parameters
-            )
-            if self._curve_publickey is not None and not hb_supports_curve:
-                msg = (
-                    f"{self.hb_channel_class.__name__} does not support the "
-                    "'curve_serverkey' parameter. Upgrade the heartbeat channel "
-                    "class or disable CurveZMQ encryption."
+            hb_kwargs = {}
+            if self._curve_publickey:
+                hb_kwargs["curve_serverkey"] = self._curve_publickey
+            try:
+                self._hb_channel = self.hb_channel_class(  # type:ignore[call-arg,abstract]
+                    self.context,
+                    self.session,
+                    url,
+                    **hb_kwargs,
                 )
-                raise RuntimeError(msg)
-            self._hb_channel = self.hb_channel_class(  # type:ignore[call-arg,abstract]
-                self.context,
-                self.session,
-                url,
-                **({"curve_serverkey": self._curve_publickey} if hb_supports_curve else {}),
-            )
+            except TypeError as e:
+                if "curve_serverkey" in str(e):
+                    msg = (
+                        f"{self.hb_channel_class.__name__} does not support the "
+                        "'curve_serverkey' parameter. Upgrade the heartbeat channel "
+                        "class or disable CurveZMQ encryption."
+                    )
+                    raise RuntimeError(msg) from e
+                else:
+                    raise
         return self._hb_channel
 
     @property

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -601,8 +601,8 @@ class ConnectionFileMixin(LoggingConfigurable):
         if "curve_publickey" in info and "curve_secretkey" in info:
             pub = info["curve_publickey"]
             sec = info["curve_secretkey"]
-            self.curve_publickey = pub.encode() if isinstance(pub, str) else pub  # type: ignore[redundant-expr,unreachable]
-            self.curve_secretkey = sec.encode() if isinstance(sec, str) else sec  # type: ignore[redundant-expr,unreachable]
+            self.curve_publickey = pub.encode() if isinstance(pub, str) else pub  # type: ignore[redundant-expr]
+            self.curve_secretkey = sec.encode() if isinstance(sec, str) else sec  # type: ignore[redundant-expr]
 
     def _reconcile_connection_info(self, info: KernelConnectionInfo) -> None:
         """Reconciles the connection information returned from the Provisioner.

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -573,6 +573,8 @@ class ConnectionFileMixin(LoggingConfigurable):
         if "curve_publickey" in info and "curve_secretkey" in info:
             pub = info["curve_publickey"]
             sec = info["curve_secretkey"]
+            assert isinstance(pub, (str, bytes))
+            assert isinstance(sec, (str, bytes))
             self._curve_publickey = pub.encode() if isinstance(pub, str) else pub
             self._curve_secretkey = sec.encode() if isinstance(sec, str) else sec
 

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -23,7 +23,7 @@ import zmq
 from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
 from traitlets import Bool, CaselessStrEnum, Instance, Integer, Type, Unicode, observe
 from traitlets.config import LoggingConfigurable, SingletonConfigurable
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import TypedDict
 
 from .localinterfaces import localhost
 from .utils import _filefind
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 # Define custom type for kernel connection info
 
 
-class KernelConnectionInfo(TypedDict, extra_items=str | bytes | int):  # type: ignore[call-arg]
+class KernelConnectionInfo(TypedDict, extra_items=str | bytes | int, total=False):  # type: ignore[call-arg]
     shell_port: int
     iopub_port: int
     stdin_port: int
@@ -47,9 +47,9 @@ class KernelConnectionInfo(TypedDict, extra_items=str | bytes | int):  # type: i
     transport: str
     signature_scheme: str
     kernel_name: str
-    session: NotRequired[Session]
-    curve_publickey: NotRequired[str]
-    curve_secretkey: NotRequired[str]
+    session: Session
+    curve_publickey: str
+    curve_secretkey: str
 
 
 def write_connection_file(
@@ -591,11 +591,8 @@ class ConnectionFileMixin(LoggingConfigurable):
 
         if "key" in info:
             key = info["key"]
-            if isinstance(key, str):
-                key = key.encode()
-            assert isinstance(key, bytes)
-
-            self.session.key = key
+            key_bytes = key if isinstance(key, bytes) else key.encode()  # type: ignore[redundant-expr,unreachable]
+            self.session.key = key_bytes
         if "signature_scheme" in info:
             self.session.signature_scheme = info["signature_scheme"]
         if "curve_publickey" in info and "curve_secretkey" in info:

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import zmq
 from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
-from traitlets import Bool, CaselessStrEnum, Instance, Integer, Type, Unicode, observe
+from traitlets import Bool, Bytes, CaselessStrEnum, Instance, Integer, Type, Unicode, observe
 from traitlets.config import LoggingConfigurable, SingletonConfigurable
 from typing_extensions import TypedDict
 
@@ -346,11 +346,6 @@ port_names = ["%s_port" % channel for channel in ("shell", "stdin", "iopub", "hb
 class ConnectionFileMixin(LoggingConfigurable):
     """Mixin for configurable classes that work with connection files"""
 
-    # Optional CurveZMQ keys loaded from the connection file (Z85-encoded bytes).
-    # None when the kernel was not started with CurveZMQ enabled.
-    curve_publickey: bytes | None = None
-    curve_secretkey: bytes | None = None
-
     data_dir: str | Unicode = Unicode()
 
     def _data_dir_default(self) -> str:
@@ -403,6 +398,11 @@ class ConnectionFileMixin(LoggingConfigurable):
     iopub_port = Integer(0, config=True, help="set the iopub (PUB) port [default: random]")
     stdin_port = Integer(0, config=True, help="set the stdin (ROUTER) port [default: random]")
     control_port = Integer(0, config=True, help="set the control (ROUTER) port [default: random]")
+
+    # Optional CurveZMQ keys loaded from the connection file (Z85-encoded bytes).
+    # None when the kernel was not started with CurveZMQ enabled.
+    curve_publickey: Bytes | None = Bytes(allow_none=True, default_value=None)
+    curve_secretkey: Bytes | None = Bytes(allow_none=True, default_value=None)
 
     # names of the ports with random assignment
     _random_port_names: list[str] | None = None

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -318,6 +318,11 @@ port_names = ["%s_port" % channel for channel in ("shell", "stdin", "iopub", "hb
 class ConnectionFileMixin(LoggingConfigurable):
     """Mixin for configurable classes that work with connection files"""
 
+    # Optional CurveZMQ keys loaded from the connection file (Z85-encoded bytes).
+    # None when the kernel was not started with CurveZMQ enabled.
+    _curve_publickey: bytes | None = None
+    _curve_secretkey: bytes | None = None
+
     data_dir: str | Unicode = Unicode()
 
     def _data_dir_default(self) -> str:
@@ -565,6 +570,11 @@ class ConnectionFileMixin(LoggingConfigurable):
             self.session.key = key
         if "signature_scheme" in info:
             self.session.signature_scheme = info["signature_scheme"]
+        if "curve_publickey" in info and "curve_secretkey" in info:
+            pub = info["curve_publickey"]
+            sec = info["curve_secretkey"]
+            self._curve_publickey = pub.encode() if isinstance(pub, str) else pub
+            self._curve_secretkey = sec.encode() if isinstance(sec, str) else sec
 
     def _reconcile_connection_info(self, info: KernelConnectionInfo) -> None:
         """Reconciles the connection information returned from the Provisioner.
@@ -657,6 +667,14 @@ class ConnectionFileMixin(LoggingConfigurable):
         sock.linger = 1000
         if identity:
             sock.identity = identity
+        if self._curve_publickey is not None:
+            # The connection file already carries this keypair, so reusing it
+            # avoids introducing an additional key-distribution mechanism here.
+            # curve_serverkey authenticates the server; the keypair configures
+            # encrypted communication for the client socket.
+            sock.curve_secretkey = self._curve_secretkey
+            sock.curve_publickey = self._curve_publickey
+            sock.curve_serverkey = self._curve_publickey
         sock.connect(url)
         return sock
 

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -348,8 +348,8 @@ class ConnectionFileMixin(LoggingConfigurable):
 
     # Optional CurveZMQ keys loaded from the connection file (Z85-encoded bytes).
     # None when the kernel was not started with CurveZMQ enabled.
-    _curve_publickey: bytes | None = None
-    _curve_secretkey: bytes | None = None
+    curve_publickey: bytes | None = None
+    curve_secretkey: bytes | None = None
 
     data_dir: str | Unicode = Unicode()
 
@@ -459,6 +459,9 @@ class ConnectionFileMixin(LoggingConfigurable):
                     "key": self.session.key,
                 }
             )
+        if self.curve_publickey is not None and self.curve_secretkey is not None:
+            info["curve_publickey"] = self.curve_publickey.decode()
+            info["curve_secretkey"] = self.curve_secretkey.decode()
         return info
 
     # factory for blocking clients
@@ -598,8 +601,8 @@ class ConnectionFileMixin(LoggingConfigurable):
         if "curve_publickey" in info and "curve_secretkey" in info:
             pub = info["curve_publickey"]
             sec = info["curve_secretkey"]
-            self._curve_publickey = pub.encode()
-            self._curve_secretkey = sec.encode()
+            self.curve_publickey = pub.encode() if isinstance(pub, str) else pub
+            self.curve_secretkey = sec.encode() if isinstance(sec, str) else sec
 
     def _reconcile_connection_info(self, info: KernelConnectionInfo) -> None:
         """Reconciles the connection information returned from the Provisioner.
@@ -624,10 +627,6 @@ class ConnectionFileMixin(LoggingConfigurable):
             # Prior to the following comparison, we need to adjust the value of "key" to
             # be bytes, otherwise the comparison below will fail.
             file_info["key"] = file_info["key"].encode()
-            if "curve_publickey" in file_info:
-                file_info["curve_publickey"] = file_info["curve_publickey"].encode()
-            if "curve_secretkey" in file_info:
-                file_info["curve_secretkey"] = file_info["curve_secretkey"].encode()
             if not self._equal_connections(info, file_info):
                 os.remove(self.connection_file)  # Contents mismatch - remove the file
                 self._connection_file_written = False
@@ -698,14 +697,14 @@ class ConnectionFileMixin(LoggingConfigurable):
         sock.linger = 1000
         if identity:
             sock.identity = identity
-        if self._curve_publickey is not None:
+        if self.curve_publickey is not None:
             # The connection file already carries this keypair, so reusing it
             # avoids introducing an additional key-distribution mechanism here.
             # curve_serverkey authenticates the server; the keypair configures
             # encrypted communication for the client socket.
-            sock.curve_secretkey = self._curve_secretkey
-            sock.curve_publickey = self._curve_publickey
-            sock.curve_serverkey = self._curve_publickey
+            sock.curve_secretkey = self.curve_secretkey
+            sock.curve_publickey = self.curve_publickey
+            sock.curve_serverkey = self.curve_publickey
         sock.connect(url)
         return sock
 

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -17,12 +17,13 @@ import stat
 import tempfile
 import warnings
 from getpass import getpass
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import zmq
 from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
 from traitlets import Bool, CaselessStrEnum, Instance, Integer, Type, Unicode, observe
 from traitlets.config import LoggingConfigurable, SingletonConfigurable
+from typing_extensions import TypedDict
 
 from .localinterfaces import localhost
 from .utils import _filefind
@@ -33,7 +34,11 @@ if TYPE_CHECKING:
     from .session import Session
 
 # Define custom type for kernel connection info
-KernelConnectionInfo = dict[str, Union[int, str, bytes]]
+
+
+class KernelConnectionInfo(TypedDict, extra_items=str | bytes | int):
+    curve_publickey: str
+    curve_secretkey: str
 
 
 def write_connection_file(
@@ -48,6 +53,8 @@ def write_connection_file(
     transport: str = "tcp",
     signature_scheme: str = "hmac-sha256",
     kernel_name: str = "",
+    curve_publickey: bytes | None = None,
+    curve_secretkey: bytes | None = None,
     **kwargs: Any,
 ) -> tuple[str, KernelConnectionInfo]:
     """Generates a JSON config file, including the selection of random ports.
@@ -76,7 +83,7 @@ def write_connection_file(
     ip  : str, optional
         The ip address the kernel will bind to.
 
-    key : str, optional
+    key : bytes, optional
         The Session key used for message authentication.
 
     signature_scheme : str, optional
@@ -89,6 +96,12 @@ def write_connection_file(
 
     kernel_name : str, optional
         The name of the kernel currently connected to.
+
+    curve_publickey : bytes, optional
+        CurveZMQ public key (Z85).
+
+    curve_secretkey : bytes, optional
+        CurveZMQ secret key (Z85).
     """
     if not ip:
         ip = localhost()
@@ -149,6 +162,10 @@ def write_connection_file(
     cfg["transport"] = transport
     cfg["signature_scheme"] = signature_scheme
     cfg["kernel_name"] = kernel_name
+    if curve_publickey is not None:
+        cfg["curve_publickey"] = curve_publickey.decode("ascii")
+    if curve_secretkey is not None:
+        cfg["curve_secretkey"] = curve_secretkey.decode("ascii")
     cfg.update(kwargs)
 
     # Only ever write this file as user read/writeable
@@ -573,10 +590,8 @@ class ConnectionFileMixin(LoggingConfigurable):
         if "curve_publickey" in info and "curve_secretkey" in info:
             pub = info["curve_publickey"]
             sec = info["curve_secretkey"]
-            assert isinstance(pub, (str, bytes))
-            assert isinstance(sec, (str, bytes))
-            self._curve_publickey = pub.encode() if isinstance(pub, str) else pub
-            self._curve_secretkey = sec.encode() if isinstance(sec, str) else sec
+            self._curve_publickey = pub.encode()
+            self._curve_secretkey = sec.encode()
 
     def _reconcile_connection_info(self, info: KernelConnectionInfo) -> None:
         """Reconciles the connection information returned from the Provisioner.
@@ -601,6 +616,10 @@ class ConnectionFileMixin(LoggingConfigurable):
             # Prior to the following comparison, we need to adjust the value of "key" to
             # be bytes, otherwise the comparison below will fail.
             file_info["key"] = file_info["key"].encode()
+            if "curve_publickey" in file_info:
+                file_info["curve_publickey"] = file_info["curve_publickey"].encode()
+            if "curve_secretkey" in file_info:
+                file_info["curve_secretkey"] = file_info["curve_secretkey"].encode()
             if not self._equal_connections(info, file_info):
                 os.remove(self.connection_file)  # Contents mismatch - remove the file
                 self._connection_file_written = False
@@ -630,6 +649,8 @@ class ConnectionFileMixin(LoggingConfigurable):
 
         pertinent_keys = [
             "key",
+            "curve_publickey",
+            "curve_secretkey",
             "ip",
             "stdin_port",
             "iopub_port",

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -601,8 +601,8 @@ class ConnectionFileMixin(LoggingConfigurable):
         if "curve_publickey" in info and "curve_secretkey" in info:
             pub = info["curve_publickey"]
             sec = info["curve_secretkey"]
-            self.curve_publickey = pub.encode() if isinstance(pub, str) else pub
-            self.curve_secretkey = sec.encode() if isinstance(sec, str) else sec
+            self.curve_publickey = pub.encode() if isinstance(pub, str) else pub  # type: ignore[redundant-expr,unreachable]
+            self.curve_secretkey = sec.encode() if isinstance(sec, str) else sec  # type: ignore[redundant-expr,unreachable]
 
     def _reconcile_connection_info(self, info: KernelConnectionInfo) -> None:
         """Reconciles the connection information returned from the Provisioner.

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -23,7 +23,7 @@ import zmq
 from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
 from traitlets import Bool, CaselessStrEnum, Instance, Integer, Type, Unicode, observe
 from traitlets.config import LoggingConfigurable, SingletonConfigurable
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from .localinterfaces import localhost
 from .utils import _filefind
@@ -36,9 +36,20 @@ if TYPE_CHECKING:
 # Define custom type for kernel connection info
 
 
-class KernelConnectionInfo(TypedDict, extra_items=str | bytes | int):
-    curve_publickey: str
-    curve_secretkey: str
+class KernelConnectionInfo(TypedDict, extra_items=str | bytes | int):  # type: ignore[call-arg]
+    shell_port: int
+    iopub_port: int
+    stdin_port: int
+    control_port: int
+    hb_port: int
+    ip: str
+    key: str
+    transport: str
+    signature_scheme: str
+    kernel_name: str
+    session: NotRequired[Session]
+    curve_publickey: NotRequired[str]
+    curve_secretkey: NotRequired[str]
 
 
 def write_connection_file(
@@ -166,7 +177,7 @@ def write_connection_file(
         cfg["curve_publickey"] = curve_publickey.decode("ascii")
     if curve_secretkey is not None:
         cfg["curve_secretkey"] = curve_secretkey.decode("ascii")
-    cfg.update(kwargs)
+    cfg.update(kwargs)  # type: ignore[typeddict-item]
 
     # Only ever write this file as user read/writeable
     # This would otherwise introduce a vulnerability as a file has secrets
@@ -427,7 +438,7 @@ class ConnectionFileMixin(LoggingConfigurable):
         connect_info : dict
             dictionary of connection information.
         """
-        info = {
+        info: KernelConnectionInfo = {
             "transport": self.transport,
             "ip": self.ip,
             "shell_port": self.shell_port,
@@ -537,7 +548,7 @@ class ConnectionFileMixin(LoggingConfigurable):
         # write_connection_file also sets default ports:
         self._record_random_port_names()
         for name in port_names:
-            setattr(self, name, cfg[name])
+            setattr(self, name, cast(int, cfg.get(name)))
 
         self._connection_file_written = True
 
@@ -570,13 +581,13 @@ class ConnectionFileMixin(LoggingConfigurable):
             See the connection_file spec for details.
         """
         self.transport = info.get("transport", self.transport)
-        self.ip = info.get("ip", self._ip_default())  # type:ignore[assignment]
+        self.ip = info.get("ip", self._ip_default())
 
         self._record_random_port_names()
         for name in port_names:
             if getattr(self, name) == 0 and name in info:
                 # not overridden by config or cl_args
-                setattr(self, name, info[name])
+                setattr(self, name, cast(int, info.get(name)))
 
         if "key" in info:
             key = info["key"]

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -182,9 +182,14 @@ class KernelManager(ConnectionFileMixin):
     def _kernel_supports_curve_encryption(self) -> bool:
         """Whether kernelspec metadata declares support for Curve transport encryption."""
         if self.kernel_spec is None:
+            print("DEBUG _kernel_supports_curve_encryption: kernel_spec is None, returning False")  # noqa: T201
             return False
         metadata = getattr(self.kernel_spec, "metadata", {}) or {}
         supported_encryption = metadata.get("supported_encryption")
+        print(  # noqa: T201
+            f"DEBUG _kernel_supports_curve_encryption: kernel_spec={self.kernel_spec!r} "
+            f"metadata={metadata!r} supported_encryption={supported_encryption!r}"
+        )
         if supported_encryption is None:
             return False
         if isinstance(supported_encryption, str):

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -21,6 +21,7 @@ from jupyter_core.utils import run_sync
 from traitlets import (
     Any,
     Bool,
+    CaselessStrEnum,
     Dict,
     DottedObjectName,
     Float,
@@ -140,15 +141,46 @@ class KernelManager(ConnectionFileMixin):
     )
     client_factory: Type = Type(klass=KernelClient, config=True)
 
-    transport_encryption: Bool = Bool(
-        False,
+    transport_encryption: CaselessStrEnum = CaselessStrEnum(
+        ["disabled", "enabled", "required"],
+        default_value="disabled",
         config=True,
         help=(
-            "Enable transport encryption using manager-side provisioning of CurveZMQ server keys for kernels. "
-            "When True, the provisioner launch path issues and writes Curve credentials "
-            "before the kernel process starts."
+            "Transport encryption policy for manager-side provisioning of CurveZMQ server keys for kernels. "
+            "'disabled' (default) does not provision Curve credentials, 'enabled' provisions when available, "
+            "and 'required' enforces provisioning and fails startup if transport encryption cannot be applied."
         ),
     )
+
+    def _transport_encryption_policy(self, value: str | bool | None = None) -> str:
+        """Normalize transport encryption input into one of the supported policy values."""
+        if value is None:
+            value = self.transport_encryption
+        if isinstance(value, bool):
+            return "enabled" if value else "disabled"
+        normalized = str(value).lower()
+        if normalized not in {"disabled", "enabled", "required"}:
+            msg = (
+                "transport_encryption must be one of: 'disabled', 'enabled', 'required' "
+                f"(got: {value!r})"
+            )
+            raise ValueError(msg)
+        return normalized
+
+    def _kernel_supports_curve_encryption(self) -> bool:
+        """Whether kernelspec metadata declares support for Curve transport encryption."""
+        if self.kernel_spec is None:
+            return False
+        metadata = getattr(self.kernel_spec, "metadata", {}) or {}
+        supported_encryption = metadata.get("supported_encryption")
+        if supported_encryption is None:
+            return False
+        if isinstance(supported_encryption, str):
+            return supported_encryption.strip().lower() == "curve"
+        if isinstance(supported_encryption, (list, tuple, set)):
+            normalized = {str(item).strip().lower() for item in supported_encryption}
+            return "curve" in normalized
+        return False
 
     @default("client_factory")
     def _client_factory_default(self) -> Type:
@@ -389,7 +421,7 @@ class KernelManager(ConnectionFileMixin):
         self._control_socket = None
 
     async def _async_pre_start_kernel(
-        self, *, transport_encryption: bool | None = None, **kw: t.Any
+        self, *, transport_encryption: str | bool | None = None, **kw: t.Any
     ) -> t.Tuple[t.List[str], t.Dict[str, t.Any]]:
         """Prepares a kernel for startup in a separate process.
 
@@ -404,11 +436,20 @@ class KernelManager(ConnectionFileMixin):
         """
         self.shutting_down = False
         if transport_encryption is not None:
-            self.transport_encryption = transport_encryption
+            self.transport_encryption = self._transport_encryption_policy(transport_encryption)
         self.kernel_id = self.kernel_id or kw.pop("kernel_id", str(uuid.uuid4()))
         # save kwargs for use in restart
         # assigning Traitlets Dicts to Dict make mypy unhappy but is ok
         self._launch_args = kw.copy()
+        if (
+            self._transport_encryption_policy() == "required"
+            and not self._kernel_supports_curve_encryption()
+        ):
+            msg = (
+                "transport_encryption='required' but kernelspec does not declare "
+                "metadata.supported_encryption='curve'."
+            )
+            raise RuntimeError(msg)
         if self.provisioner is None:  # will not be None on restarts
             self.provisioner = KPF.instance(parent=self.parent).create_provisioner_instance(
                 self.kernel_id,

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -389,7 +389,7 @@ class KernelManager(ConnectionFileMixin):
         self._control_socket = None
 
     async def _async_pre_start_kernel(
-        self, **kw: t.Any
+        self, *, transport_encryption: bool | None = None, **kw: t.Any
     ) -> t.Tuple[t.List[str], t.Dict[str, t.Any]]:
         """Prepares a kernel for startup in a separate process.
 
@@ -403,9 +403,8 @@ class KernelManager(ConnectionFileMixin):
              and launching the kernel (e.g. Popen kwargs).
         """
         self.shutting_down = False
-        # Consume manager-level curve toggle so it does not leak into subprocess kwargs.
-        # Provisioners can read this from the manager instance.
-        self.transport_encryption = bool(kw.pop("transport_encryption", self.transport_encryption))
+        if transport_encryption is not None:
+            self.transport_encryption = transport_encryption
         self.kernel_id = self.kernel_id or kw.pop("kernel_id", str(uuid.uuid4()))
         # save kwargs for use in restart
         # assigning Traitlets Dicts to Dict make mypy unhappy but is ok

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -182,14 +182,9 @@ class KernelManager(ConnectionFileMixin):
     def _kernel_supports_curve_encryption(self) -> bool:
         """Whether kernelspec metadata declares support for Curve transport encryption."""
         if self.kernel_spec is None:
-            print("DEBUG _kernel_supports_curve_encryption: kernel_spec is None, returning False")  # noqa: T201
             return False
         metadata = getattr(self.kernel_spec, "metadata", {}) or {}
         supported_encryption = metadata.get("supported_encryption")
-        print(  # noqa: T201
-            f"DEBUG _kernel_supports_curve_encryption: kernel_spec={self.kernel_spec!r} "
-            f"metadata={metadata!r} supported_encryption={supported_encryption!r}"
-        )
         if supported_encryption is None:
             return False
         if isinstance(supported_encryption, str):

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -144,20 +144,21 @@ class KernelManager(ConnectionFileMixin):
     client_factory: Type = Type(klass=KernelClient, config=True)
 
     transport_encryption: CaselessStrEnum = CaselessStrEnum(
-        ["disabled", "enabled", "required"],
+        ["disabled", "auto", "required"],
         default_value="disabled",
         config=True,
         help=(
             "Transport encryption policy for manager-side provisioning of CurveZMQ server keys for kernels. "
-            "'disabled' (default) does not provision Curve credentials, 'enabled' provisions when available, "
-            "and 'required' enforces provisioning and fails startup if transport encryption cannot be applied."
+            "'disabled' (default) does not provision Curve credentials, 'auto' provisions when the kernelspec "
+            "declares support, and 'required' enforces provisioning and fails startup if transport encryption "
+            "cannot be applied."
         ),
     )
 
     @validate("transport_encryption")
     def _validate_transport_encryption(self, proposal: dict) -> str:
         value = proposal["value"]
-        if value in ("enabled", "required") and not zmq.has("curve"):
+        if value in ("auto", "required") and not zmq.has("curve"):
             msg = (
                 f"transport_encryption={value!r} requires CurveZMQ support, "
                 "but zmq.has('curve') returned False. "
@@ -171,9 +172,9 @@ class KernelManager(ConnectionFileMixin):
         if value is None:
             value = self.transport_encryption
         normalized = str(value).lower()
-        if normalized not in {"disabled", "enabled", "required"}:
+        if normalized not in {"disabled", "auto", "required"}:
             msg = (
-                "transport_encryption must be one of: 'disabled', 'enabled', 'required' "
+                "transport_encryption must be one of: 'disabled', 'auto', 'required' "
                 f"(got: {value!r})"
             )
             raise ValueError(msg)

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -152,12 +152,10 @@ class KernelManager(ConnectionFileMixin):
         ),
     )
 
-    def _transport_encryption_policy(self, value: str | bool | None = None) -> str:
+    def _transport_encryption_policy(self, value: str | None = None) -> str:
         """Normalize transport encryption input into one of the supported policy values."""
         if value is None:
             value = self.transport_encryption
-        if isinstance(value, bool):
-            return "enabled" if value else "disabled"
         normalized = str(value).lower()
         if normalized not in {"disabled", "enabled", "required"}:
             msg = (
@@ -421,7 +419,7 @@ class KernelManager(ConnectionFileMixin):
         self._control_socket = None
 
     async def _async_pre_start_kernel(
-        self, *, transport_encryption: str | bool | None = None, **kw: t.Any
+        self, *, transport_encryption: str | None = None, **kw: t.Any
     ) -> t.Tuple[t.List[str], t.Dict[str, t.Any]]:
         """Prepares a kernel for startup in a separate process.
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -140,6 +140,16 @@ class KernelManager(ConnectionFileMixin):
     )
     client_factory: Type = Type(klass=KernelClient, config=True)
 
+    transport_encryption: Bool = Bool(
+        False,
+        config=True,
+        help=(
+            "Enable transport encryption using manager-side provisioning of CurveZMQ server keys for kernels. "
+            "When True, the provisioner launch path issues and writes Curve credentials "
+            "before the kernel process starts."
+        ),
+    )
+
     @default("client_factory")
     def _client_factory_default(self) -> Type:
         return import_item(self.client_class)
@@ -393,6 +403,9 @@ class KernelManager(ConnectionFileMixin):
              and launching the kernel (e.g. Popen kwargs).
         """
         self.shutting_down = False
+        # Consume manager-level curve toggle so it does not leak into subprocess kwargs.
+        # Provisioners can read this from the manager instance.
+        self.transport_encryption = bool(kw.pop("transport_encryption", self.transport_encryption))
         self.kernel_id = self.kernel_id or kw.pop("kernel_id", str(uuid.uuid4()))
         # save kwargs for use in restart
         # assigning Traitlets Dicts to Dict make mypy unhappy but is ok

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -26,11 +26,13 @@ from traitlets import (
     DottedObjectName,
     Float,
     Instance,
+    TraitError,
     Type,
     Unicode,
     default,
     observe,
     observe_compat,
+    validate,
 )
 from traitlets.utils.importstring import import_item
 
@@ -151,6 +153,18 @@ class KernelManager(ConnectionFileMixin):
             "and 'required' enforces provisioning and fails startup if transport encryption cannot be applied."
         ),
     )
+
+    @validate("transport_encryption")
+    def _validate_transport_encryption(self, proposal: dict) -> str:
+        value = proposal["value"]
+        if value in ("enabled", "required") and not zmq.has("curve"):
+            msg = (
+                f"transport_encryption={value!r} requires CurveZMQ support, "
+                "but zmq.has('curve') returned False. "
+                "Install pyzmq with libzmq compiled with libsodium to enable CurveZMQ."
+            )
+            raise TraitError(msg)
+        return value
 
     def _transport_encryption_policy(self, value: str | None = None) -> str:
         """Normalize transport encryption input into one of the supported policy values."""

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -215,9 +215,15 @@ class LocalProvisioner(KernelProvisionerBase):
                 self.ports_cached = True
 
             if encryption_enabled and km.transport == "tcp":
-                curve_publickey, curve_secretkey = zmq.curve_keypair()
-                km.curve_publickey = curve_publickey
-                km.curve_secretkey = curve_secretkey
+                kernel_curve_ok = (
+                    encryption_required  # already validated in pre_start_kernel
+                    or not hasattr(km, "_kernel_supports_curve_encryption")
+                    or km._kernel_supports_curve_encryption()
+                )
+                if kernel_curve_ok:
+                    curve_publickey, curve_secretkey = zmq.curve_keypair()
+                    km.curve_publickey = curve_publickey
+                    km.curve_secretkey = curve_secretkey
             if "env" in kwargs:
                 jupyter_session = kwargs["env"].get("JPY_SESSION_NAME", "")
                 km.write_connection_file(

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -215,12 +215,16 @@ class LocalProvisioner(KernelProvisionerBase):
                 self.ports_cached = True
 
             if encryption_enabled and km.transport == "tcp":
-                kernel_curve_ok = (
-                    encryption_required  # already validated in pre_start_kernel
-                    or (
-                        hasattr(km, "_kernel_supports_curve_encryption")
-                        and km._kernel_supports_curve_encryption()
-                    )
+                _has_method = hasattr(km, "_kernel_supports_curve_encryption")
+                _supports = _has_method and km._kernel_supports_curve_encryption()
+                kernel_curve_ok = encryption_required or _supports
+                print(  # noqa: T201
+                    f"DEBUG pre_launch: encryption_enabled={encryption_enabled} "
+                    f"encryption_required={encryption_required} "
+                    f"transport_encryption_policy={transport_encryption_policy!r} "
+                    f"km.transport={km.transport!r} "
+                    f"has_method={_has_method} supports_curve={_supports} "
+                    f"kernel_curve_ok={kernel_curve_ok}"
                 )
                 if kernel_curve_ok:
                     curve_publickey, curve_secretkey = zmq.curve_keypair()

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -176,11 +176,21 @@ class LocalProvisioner(KernelProvisionerBase):
         # This should be considered temporary until a better division of labor can be defined.
         km = self.parent
         if km:
-            transport_encryption = bool(
-                kwargs.pop("transport_encryption", getattr(km, "transport_encryption", False))
+            transport_encryption = kwargs.pop(
+                "transport_encryption", getattr(km, "transport_encryption", "disabled")
             )
+            transport_encryption_policy = (
+                km._transport_encryption_policy(transport_encryption)
+                if hasattr(km, "_transport_encryption_policy")
+                else ("enabled" if bool(transport_encryption) else "disabled")
+            )
+            encryption_required = transport_encryption_policy == "required"
+            encryption_enabled = transport_encryption_policy in {"enabled", "required"}
             curve_publickey: bytes | None = None
             curve_secretkey: bytes | None = None
+            if encryption_required and km.transport != "tcp":
+                msg = "transport_encryption='required' is only supported when transport='tcp'."
+                raise RuntimeError(msg)
             if km.transport == "tcp" and not is_local_ip(km.ip):
                 msg = (
                     "Can only launch a kernel on a local interface. "
@@ -204,7 +214,7 @@ class LocalProvisioner(KernelProvisionerBase):
                 km.control_port = lpc.find_available_port(km.ip)
                 self.ports_cached = True
 
-            if transport_encryption:
+            if encryption_enabled and km.transport == "tcp":
                 curve_publickey, curve_secretkey = zmq.curve_keypair()
                 km.curve_publickey = curve_publickey
                 km.curve_secretkey = curve_secretkey

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -182,10 +182,10 @@ class LocalProvisioner(KernelProvisionerBase):
             transport_encryption_policy = (
                 km._transport_encryption_policy(transport_encryption)
                 if hasattr(km, "_transport_encryption_policy")
-                else ("enabled" if bool(transport_encryption) else "disabled")
+                else ("auto" if bool(transport_encryption) else "disabled")
             )
             encryption_required = transport_encryption_policy == "required"
-            encryption_enabled = transport_encryption_policy in {"enabled", "required"}
+            encryption_enabled = transport_encryption_policy in {"auto", "required"}
             curve_publickey: bytes | None = None
             curve_secretkey: bytes | None = None
             if encryption_required and km.transport != "tcp":

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -215,16 +215,9 @@ class LocalProvisioner(KernelProvisionerBase):
                 self.ports_cached = True
 
             if encryption_enabled and km.transport == "tcp":
-                _has_method = hasattr(km, "_kernel_supports_curve_encryption")
-                _supports = _has_method and km._kernel_supports_curve_encryption()
-                kernel_curve_ok = encryption_required or _supports
-                print(  # noqa: T201
-                    f"DEBUG pre_launch: encryption_enabled={encryption_enabled} "
-                    f"encryption_required={encryption_required} "
-                    f"transport_encryption_policy={transport_encryption_policy!r} "
-                    f"km.transport={km.transport!r} "
-                    f"has_method={_has_method} supports_curve={_supports} "
-                    f"kernel_curve_ok={kernel_curve_ok}"
+                kernel_curve_ok = encryption_required or (
+                    hasattr(km, "_kernel_supports_curve_encryption")
+                    and km._kernel_supports_curve_encryption()
                 )
                 if kernel_curve_ok:
                     curve_publickey, curve_secretkey = zmq.curve_keypair()

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -217,8 +217,10 @@ class LocalProvisioner(KernelProvisionerBase):
             if encryption_enabled and km.transport == "tcp":
                 kernel_curve_ok = (
                     encryption_required  # already validated in pre_start_kernel
-                    or not hasattr(km, "_kernel_supports_curve_encryption")
-                    or km._kernel_supports_curve_encryption()
+                    or (
+                        hasattr(km, "_kernel_supports_curve_encryption")
+                        and km._kernel_supports_curve_encryption()
+                    )
                 )
                 if kernel_curve_ok:
                     curve_publickey, curve_secretkey = zmq.curve_keypair()

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -9,6 +9,8 @@ import signal
 import sys
 from typing import TYPE_CHECKING, Any
 
+import zmq
+
 from ..connect import KernelConnectionInfo, LocalPortCache
 from ..launcher import launch_kernel
 from ..localinterfaces import is_local_ip, local_ips
@@ -174,6 +176,11 @@ class LocalProvisioner(KernelProvisionerBase):
         # This should be considered temporary until a better division of labor can be defined.
         km = self.parent
         if km:
+            transport_encryption = bool(
+                kwargs.pop("transport_encryption", getattr(km, "transport_encryption", False))
+            )
+            curve_publickey: bytes | None = None
+            curve_secretkey: bytes | None = None
             if km.transport == "tcp" and not is_local_ip(km.ip):
                 msg = (
                     "Can only launch a kernel on a local interface. "
@@ -196,11 +203,23 @@ class LocalProvisioner(KernelProvisionerBase):
                 km.hb_port = lpc.find_available_port(km.ip)
                 km.control_port = lpc.find_available_port(km.ip)
                 self.ports_cached = True
+
+            if transport_encryption:
+                curve_publickey, curve_secretkey = zmq.curve_keypair()
+                km.curve_publickey = curve_publickey
+                km.curve_secretkey = curve_secretkey
             if "env" in kwargs:
                 jupyter_session = kwargs["env"].get("JPY_SESSION_NAME", "")
-                km.write_connection_file(jupyter_session=jupyter_session)
+                km.write_connection_file(
+                    jupyter_session=jupyter_session,
+                    curve_publickey=curve_publickey,
+                    curve_secretkey=curve_secretkey,
+                )
             else:
-                km.write_connection_file()
+                km.write_connection_file(
+                    curve_publickey=curve_publickey,
+                    curve_secretkey=curve_secretkey,
+                )
             self.connection_info = km.get_connection_info()
 
             kernel_cmd = km.format_kernel_cmd(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "python-dateutil>=2.8.2",
     "pyzmq>=25.0",
     "tornado>=6.4.1",
+    "typing-extensions>=4.13.0",
     "traitlets>=5.3",
 ]
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -84,6 +84,21 @@ def test_write_connection_file():
     assert info == sample_info
 
 
+def test_write_connection_file_normalizes_curve_key_kwargs_to_strings():
+    with TemporaryDirectory() as d:
+        cf = os.path.join(d, "kernel.json")
+        _fname, cfg = connect.write_connection_file(
+            cf,
+            **sample_info,
+            curve_publickey=b"A" * 40,
+            curve_secretkey=b"B" * 40,
+        )
+
+        assert isinstance(cfg["key"], str)
+        assert isinstance(cfg["curve_publickey"], str)
+        assert isinstance(cfg["curve_secretkey"], str)
+
+
 def test_load_connection_file_session():
     """test load_connection_file() after"""
     session = Session()

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -306,3 +306,23 @@ def test_reconcile_connection_info(file_exists, km_matches):
         km._reconcile_connection_info(provisioner_info)
         km_info = km.get_connection_info()
         assert km._equal_connections(km_info, provisioner_info)
+
+
+def test_reconcile_connection_info_with_curve_keys():
+    with TemporaryDirectory() as connection_dir:
+        cf = os.path.join(connection_dir, "kernel.json")
+        km = KernelManager()
+        km.connection_file = cf
+
+        _, provisioner_info = connect.write_connection_file(
+            cf,
+            **sample_info,
+            curve_publickey=b"A" * 40,
+            curve_secretkey=b"B" * 40,
+        )
+        provisioner_info["key"] = provisioner_info["key"].encode()  # type:ignore
+
+        km.load_connection_info(provisioner_info)
+        km._reconcile_connection_info(provisioner_info)
+        km_info = km.get_connection_info()
+        assert km._equal_connections(km_info, provisioner_info)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -2,12 +2,15 @@
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import asyncio
 import os
 import tempfile
 from unittest import mock
 
+import pytest
+
 from jupyter_client.kernelspec import KernelSpec
-from jupyter_client.manager import KernelManager
+from jupyter_client.manager import AsyncKernelManager, KernelManager
 
 
 def test_connection_file_real_path():
@@ -63,3 +66,43 @@ def test_env_update_launch_args_env_dic():
     km._launch_args = {"env": {}}
     km.update_env(env={"E": "E"})
     assert km._launch_args["env"]["E"] == "E"
+
+
+def test_kernel_supports_curve_encryption_from_kernelspec_metadata():
+    km = KernelManager(
+        connection_file=os.path.join(tempfile.gettempdir(), "kernel-test-support.json"),
+        kernel_name="test_kernel",
+    )
+    km._kernel_spec = KernelSpec(
+        resource_dir="test",
+        **{
+            "argv": ["python", "-m", "test_kernel", "-f", "{connection_file}"],
+            "env": {},
+            "display_name": "test_kernel",
+            "language": "python",
+            "metadata": {"supported_encryption": "curve"},
+        },
+    )
+
+    assert km._kernel_supports_curve_encryption()
+
+
+def test_required_transport_encryption_needs_kernelspec_feature():
+    km = AsyncKernelManager(
+        connection_file=os.path.join(tempfile.gettempdir(), "kernel-test-required.json"),
+        kernel_name="test_kernel",
+    )
+    km._kernel_spec = KernelSpec(
+        resource_dir="test",
+        **{
+            "argv": ["python", "-m", "test_kernel", "-f", "{connection_file}"],
+            "env": {},
+            "display_name": "test_kernel",
+            "language": "python",
+            "metadata": {},
+        },
+    )
+    km.transport_encryption = "required"
+
+    with pytest.raises(RuntimeError, match="supported_encryption"):
+        asyncio.run(km._async_pre_start_kernel())

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -101,9 +101,22 @@ class CustomTestProvisioner(KernelProvisionerBase):  # type:ignore
             km._launch_args = kwargs.copy()
             # build the Popen cmd
             extra_arguments = kwargs.pop("extra_arguments", [])
+            transport_encryption = bool(
+                kwargs.pop("transport_encryption", getattr(km, "transport_encryption", False))
+            )
+            curve_publickey: bytes | None = None
+            curve_secretkey: bytes | None = None
+            if transport_encryption:
+                import zmq
 
+                curve_publickey, curve_secretkey = zmq.curve_keypair()
+                km.curve_publickey = curve_publickey
+                km.curve_secretkey = curve_secretkey
             # write connection file / get default ports
-            km.write_connection_file()
+            km.write_connection_file(
+                curve_publickey=curve_publickey,
+                curve_secretkey=curve_secretkey,
+            )
             self.connection_info = km.get_connection_info()
 
             kernel_cmd = km.format_kernel_cmd(

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -15,7 +15,7 @@ from jupyter_core import paths
 from traitlets import Int, Unicode
 
 from jupyter_client.connect import KernelConnectionInfo
-from jupyter_client.kernelspec import KernelSpecManager, NoSuchKernel
+from jupyter_client.kernelspec import KernelSpec, KernelSpecManager, NoSuchKernel
 from jupyter_client.launcher import launch_kernel
 from jupyter_client.manager import AsyncKernelManager
 from jupyter_client.provisioning import (
@@ -101,12 +101,17 @@ class CustomTestProvisioner(KernelProvisionerBase):  # type:ignore
             km._launch_args = kwargs.copy()
             # build the Popen cmd
             extra_arguments = kwargs.pop("extra_arguments", [])
-            transport_encryption = bool(
-                kwargs.pop("transport_encryption", getattr(km, "transport_encryption", False))
+            transport_encryption = kwargs.pop(
+                "transport_encryption", getattr(km, "transport_encryption", "disabled")
+            )
+            transport_encryption_policy = (
+                km._transport_encryption_policy(transport_encryption)
+                if hasattr(km, "_transport_encryption_policy")
+                else ("enabled" if bool(transport_encryption) else "disabled")
             )
             curve_publickey: bytes | None = None
             curve_secretkey: bytes | None = None
-            if transport_encryption:
+            if transport_encryption_policy in {"enabled", "required"}:
                 import zmq
 
                 curve_publickey, curve_secretkey = zmq.curve_keypair()
@@ -295,7 +300,7 @@ class TestRuntime:
     ):
         """When transport encryption is enabled, LocalProvisioner seeds curve keys before launch."""
         km = AsyncKernelManager(connection_file=str(tmp_path / "kernel.json"))
-        km.transport_encryption = True
+        km.transport_encryption = "enabled"
         await km._async_pre_start_kernel()
         assert km.provisioner is not None
         assert isinstance(km.provisioner, LocalProvisioner)
@@ -309,6 +314,26 @@ class TestRuntime:
 
         assert km.provisioner.connection_info["curve_publickey"] == "A" * 40
         assert km.provisioner.connection_info["curve_secretkey"] == "B" * 40
+
+    async def test_local_provisioner_pre_launch_requires_tcp_for_required_transport_encryption(
+        self, tmp_path
+    ):
+        """Required transport encryption rejects non-TCP transports."""
+        km = AsyncKernelManager(connection_file=str(tmp_path / "kernel.json"))
+        km._kernel_spec = KernelSpec(
+            resource_dir="test",
+            **{
+                "argv": [sys.executable, "-m", "tests.signalkernel", "-f", "{connection_file}"],
+                "env": {},
+                "display_name": "test_kernel",
+                "language": "python",
+                "metadata": {"supported_encryption": "curve"},
+            },
+        )
+        km.transport = "ipc"
+        km.transport_encryption = "required"
+        with pytest.raises(RuntimeError, match="transport='tcp'"):
+            await km._async_pre_start_kernel()
 
     async def test_existing(self, kpf, akm):
         await self.akm_test(akm)

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -300,6 +300,16 @@ class TestRuntime:
     ):
         """When transport encryption is enabled, LocalProvisioner seeds curve keys before launch."""
         km = AsyncKernelManager(connection_file=str(tmp_path / "kernel.json"))
+        km._kernel_spec = KernelSpec(
+            resource_dir="test",
+            **{
+                "argv": [sys.executable, "-c", "pass"],
+                "env": {},
+                "display_name": "test_kernel",
+                "language": "python",
+                "metadata": {"supported_encryption": "curve"},
+            },
+        )
         km.transport_encryption = "enabled"
         await km._async_pre_start_kernel()
         assert km.provisioner is not None

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -264,6 +264,7 @@ class TestRuntime:
         """Starts a kernel, validates the associated provisioner's config, shuts down kernel"""
 
         assert kernel_mgr.provisioner is None
+
         if kernel_mgr.kernel_name == "missing_provisioner":
             with pytest.raises(NoSuchKernel):
                 await kernel_mgr.start_kernel()
@@ -275,6 +276,27 @@ class TestRuntime:
             await kernel_mgr.shutdown_kernel()
             assert kernel_mgr.provisioner is not None
             assert kernel_mgr.provisioner.has_process is False
+
+    @pytest.mark.asyncio
+    async def test_local_provisioner_pre_launch_generates_curve_keys_under_transport_encryption(
+        self, monkeypatch, tmp_path
+    ):
+        """When transport encryption is enabled, LocalProvisioner seeds curve keys before launch."""
+        km = AsyncKernelManager(connection_file=str(tmp_path / "kernel.json"))
+        km.transport_encryption = True
+        await km._async_pre_start_kernel()
+        assert km.provisioner is not None
+        assert isinstance(km.provisioner, LocalProvisioner)
+
+        monkeypatch.setattr(
+            "jupyter_client.provisioning.local_provisioner.zmq.curve_keypair",
+            lambda: (b"A" * 40, b"B" * 40),
+        )
+
+        await km.provisioner.pre_launch()
+
+        assert km.provisioner.connection_info["curve_publickey"] == "A" * 40
+        assert km.provisioner.connection_info["curve_secretkey"] == "B" * 40
 
     async def test_existing(self, kpf, akm):
         await self.akm_test(akm)

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -248,7 +248,9 @@ def kpf(monkeypatch):
     )
     monkeypatch.setattr(KernelProvisionerFactory, "_get_provisioner", mock_get_provisioner)
     factory = KernelProvisionerFactory.instance()
-    return factory
+    yield factory
+    KernelProvisionerFactory.clear_instance()
+    KernelProvisionerFactory.provisioners.clear()
 
 
 class TestDiscovery:

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -107,11 +107,11 @@ class CustomTestProvisioner(KernelProvisionerBase):  # type:ignore
             transport_encryption_policy = (
                 km._transport_encryption_policy(transport_encryption)
                 if hasattr(km, "_transport_encryption_policy")
-                else ("enabled" if bool(transport_encryption) else "disabled")
+                else ("auto" if bool(transport_encryption) else "disabled")
             )
             curve_publickey: bytes | None = None
             curve_secretkey: bytes | None = None
-            if transport_encryption_policy in {"enabled", "required"}:
+            if transport_encryption_policy in {"auto", "required"}:
                 import zmq
 
                 curve_publickey, curve_secretkey = zmq.curve_keypair()
@@ -312,7 +312,7 @@ class TestRuntime:
                 "metadata": {"supported_encryption": "curve"},
             },
         )
-        km.transport_encryption = "enabled"
+        km.transport_encryption = "auto"
         await km._async_pre_start_kernel()
         assert km.provisioner is not None
         assert isinstance(km.provisioner, LocalProvisioner)

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -277,7 +277,6 @@ class TestRuntime:
             assert kernel_mgr.provisioner is not None
             assert kernel_mgr.provisioner.has_process is False
 
-    @pytest.mark.asyncio
     async def test_local_provisioner_pre_launch_generates_curve_keys_under_transport_encryption(
         self, monkeypatch, tmp_path
     ):

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -13,19 +13,21 @@ from jupyter_client.session import Session
 
 
 @pytest.mark.parametrize(
-    ("enable_curve", "expect_plaintext_visible"),
+    "enable_curve",
     [
-        (False, True),
-        (True, False),
+        False,
+        True,
     ],
 )
-def test_iopub_plaintext_visibility_depends_on_curve(enable_curve, expect_plaintext_visible):
+def test_iopub_plaintext_visibility_depends_on_curve(enable_curve):
     """An unauthenticated subscriber sees plaintext only when Curve is disabled."""
 
     ctx = zmq.Context()
     session = Session(key=b"secret-hmac-key")
     server = ctx.socket(zmq.XPUB)
     eavesdropper = ctx.socket(zmq.SUB)
+
+    expect_plaintext_visible = not enable_curve
 
     if enable_curve:
         pub, sec = zmq.curve_keypair()

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -1,0 +1,161 @@
+"""Tests for the ZMQ transport security."""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import pytest
+import zmq
+
+from jupyter_client.connect import ConnectionFileMixin
+from jupyter_client.session import Session
+
+
+@pytest.mark.parametrize(
+    ("enable_curve", "expect_plaintext_visible"),
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+def test_iopub_plaintext_visibility_depends_on_curve(enable_curve, expect_plaintext_visible):
+    """An unauthenticated subscriber sees plaintext only when Curve is disabled."""
+
+    ctx = zmq.Context()
+    session = Session(key=b"secret-hmac-key")
+    server = ctx.socket(zmq.XPUB)
+    eavesdropper = ctx.socket(zmq.SUB)
+
+    if enable_curve:
+        pub, sec = zmq.curve_keypair()
+        server.curve_secretkey = sec
+        server.curve_publickey = pub
+        server.curve_server = True
+
+    try:
+        port = server.bind_to_random_port("tcp://127.0.0.1")
+
+        # Eavesdropper connects with no authentication or curve keys at all.
+        eavesdropper.setsockopt(zmq.SUBSCRIBE, b"")
+        eavesdropper.connect(f"tcp://127.0.0.1:{port}")
+
+        # In non-Curve mode, XPUB receives the subscription and we drain it.
+        # In Curve mode, unauthenticated peers are rejected so no event arrives.
+        sub_poller = zmq.Poller()
+        sub_poller.register(server, zmq.POLLIN)
+        sub_events = dict(sub_poller.poll(timeout=1000))
+        if server in sub_events:
+            server.recv()  # discard subscription frame
+
+        # Simulate a kernel publishing stream messages via Session
+        # (HMAC-signed, but not encrypted at the transport layer).
+        sensitive_content = {"name": "stdout", "text": "top_secret_output_12345"}
+        session.send(server, "stream", sensitive_content, ident=b"kernel.stream.stdout")
+
+        # Check if an unauthenticated subscriber can read plaintext payload,
+        # using the same event polling behavior in both modes.
+        recv_poller = zmq.Poller()
+        recv_poller.register(eavesdropper, zmq.POLLIN)
+        events = dict(recv_poller.poll(timeout=1000))
+
+        did_receive = eavesdropper in events
+        assert did_receive is expect_plaintext_visible, (
+            "Unexpected unauthenticated visibility result for IOPub payload"
+        )
+        if expect_plaintext_visible:
+            # Demonstrates that the message content is visible in plaintext frames when Curve is disabled.
+            raw_frames = eavesdropper.recv_multipart()
+            raw_bytes = b"".join(raw_frames)
+            assert b"top_secret_output_12345" in raw_bytes, (
+                f"Expected plaintext content in raw frames.\nRaw bytes: {raw_bytes!r}"
+            )
+            assert b"stream" in raw_bytes, "msg_type 'stream' should be visible in plaintext frames"
+
+    finally:
+        server.close(linger=0)
+        eavesdropper.close(linger=0)
+        ctx.term()
+
+
+def test_connect_shell_to_curve_server_with_curve_keys_succeeds():
+    """Public API path: load_connection_info + connect_shell works with curve keys."""
+    pub, sec = zmq.curve_keypair()
+
+    # Set up a CurveZMQ server socket (simulating the kernel side).
+    ctx = zmq.Context()
+    server = ctx.socket(zmq.ROUTER)
+    server.curve_secretkey = sec
+    server.curve_publickey = pub
+    server.curve_server = True
+    port = server.bind_to_random_port("tcp://127.0.0.1")
+
+    try:
+        # Configure through the same public parsing path used for
+        # connection-file content.
+        info = {
+            "ip": "127.0.0.1",
+            "transport": "tcp",
+            "shell_port": port,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+            "curve_publickey": pub.decode("ascii"),
+            "curve_secretkey": sec.decode("ascii"),
+        }
+        mixin = ConnectionFileMixin()
+        mixin.context = ctx
+        mixin.load_connection_info(info)
+
+        client_sock = mixin.connect_shell()
+        try:
+            client_sock.send(b"probe", flags=zmq.NOBLOCK)
+
+            poller = zmq.Poller()
+            poller.register(server, zmq.POLLIN)
+            events = dict(poller.poll(timeout=1000))
+            assert server in events, (
+                "Authenticated client message was not received - "
+                "connect_shell() did not produce a working Curve-authenticated socket"
+            )
+        finally:
+            client_sock.close(linger=0)
+    finally:
+        server.close(linger=0)
+        ctx.term()
+
+
+def test_connect_shell_to_curve_server_without_curve_keys_is_rejected():
+    """Public API path: without curve keys, shell traffic to a Curve server is dropped."""
+    pub, sec = zmq.curve_keypair()
+
+    ctx = zmq.Context()
+    server = ctx.socket(zmq.ROUTER)
+    server.curve_secretkey = sec
+    server.curve_publickey = pub
+    server.curve_server = True
+    port = server.bind_to_random_port("tcp://127.0.0.1")
+
+    try:
+        info = {
+            "ip": "127.0.0.1",
+            "transport": "tcp",
+            "shell_port": port,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+        }
+        mixin = ConnectionFileMixin()
+        mixin.context = ctx
+        mixin.load_connection_info(info)
+
+        client_sock = mixin.connect_shell()
+        try:
+            client_sock.send(b"probe", flags=zmq.NOBLOCK)
+            poller = zmq.Poller()
+            poller.register(server, zmq.POLLIN)
+            events = dict(poller.poll(timeout=300))
+            assert server not in events, (
+                "Unauthenticated message reached Curve server - expected drop without curve keys"
+            )
+        finally:
+            client_sock.close(linger=0)
+    finally:
+        server.close(linger=0)
+        ctx.term()

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -3,6 +3,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import json
+
 import pytest
 import zmq
 
@@ -10,6 +12,7 @@ from jupyter_client import KernelManager
 from jupyter_client.channels import HBChannel
 from jupyter_client.client import KernelClient
 from jupyter_client.connect import ConnectionFileMixin
+from jupyter_client.kernelspec import KernelSpecManager
 from jupyter_client.session import Session
 
 
@@ -24,7 +27,26 @@ from jupyter_client.session import Session
 def test_iopub_plaintext_visibility_depends_on_curve(transport_encryption, tmp_path):
     """An unauthenticated subscriber sees plaintext only when Curve is disabled."""
 
-    km = KernelManager(connection_file=str(tmp_path / "kernel.json"))
+    kernel_name = "curve-test"
+    kernels_dir = tmp_path / "kernels"
+    kernel_dir = kernels_dir / kernel_name
+    kernel_dir.mkdir(parents=True)
+    with (kernel_dir / "kernel.json").open("w") as f:
+        json.dump(
+            {
+                "argv": ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+                "display_name": "curve-test",
+                "language": "python",
+                "metadata": {"supported_encryption": "curve"},
+            },
+            f,
+        )
+
+    km = KernelManager(
+        connection_file=str(tmp_path / "kernel.json"),
+        kernel_name=kernel_name,
+        kernel_spec_manager=KernelSpecManager(kernel_dirs=[str(kernels_dir)]),
+    )
     km.cache_ports = False
     km.transport_encryption = transport_encryption
     km.pre_start_kernel()

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -136,6 +136,70 @@ def test_transport_encryption_disabled_does_not_require_curve():
         assert km.transport_encryption == "disabled"
 
 
+def _make_km_with_kernelspec(tmp_path, *, supported_encryption, transport_encryption):
+    """Helper: build a KernelManager backed by a kernelspec with the given metadata."""
+    kernel_name = "test-kernel"
+    kernel_dir = tmp_path / "kernels" / kernel_name
+    kernel_dir.mkdir(parents=True)
+    metadata = {}
+    if supported_encryption is not None:
+        metadata["supported_encryption"] = supported_encryption
+    with (kernel_dir / "kernel.json").open("w") as f:
+        json.dump(
+            {
+                "argv": ["python", "-c", "pass"],
+                "display_name": kernel_name,
+                "language": "python",
+                "metadata": metadata,
+            },
+            f,
+        )
+    km = KernelManager(
+        connection_file=str(tmp_path / "kernel.json"),
+        kernel_name=kernel_name,
+        kernel_spec_manager=KernelSpecManager(kernel_dirs=[str(tmp_path / "kernels")]),
+    )
+    km.cache_ports = False
+    km.transport_encryption = transport_encryption
+    return km
+
+
+def test_enabled_without_curve_kernelspec_skips_keys(tmp_path):
+    """transport_encryption='enabled' skips key provisioning when kernelspec lacks curve support."""
+    km = _make_km_with_kernelspec(
+        tmp_path, supported_encryption=None, transport_encryption="enabled"
+    )
+    km.pre_start_kernel()
+    info = km.get_connection_info()
+    assert "curve_publickey" not in info
+    assert "curve_secretkey" not in info
+    km.cleanup_connection_file()
+    km.context.term()
+
+
+def test_enabled_with_curve_kernelspec_provisions_keys(tmp_path):
+    """transport_encryption='enabled' provisions keys when kernelspec declares curve support."""
+    km = _make_km_with_kernelspec(
+        tmp_path, supported_encryption="curve", transport_encryption="enabled"
+    )
+    km.pre_start_kernel()
+    info = km.get_connection_info()
+    assert "curve_publickey" in info
+    assert "curve_secretkey" in info
+    km.cleanup_connection_file()
+    km.context.term()
+
+
+def test_required_without_curve_kernelspec_raises(tmp_path):
+    """transport_encryption='required' raises RuntimeError when kernelspec lacks curve support."""
+    km = _make_km_with_kernelspec(
+        tmp_path, supported_encryption=None, transport_encryption="required"
+    )
+    with pytest.raises(RuntimeError, match=r"metadata\.supported_encryption"):
+        km.pre_start_kernel()
+    km.context.term()
+
+
 def test_connect_shell_to_curve_server_with_curve_keys_succeeds():
     """Public API path: load_connection_info + connect_shell works with curve keys."""
     pub, sec = zmq.curve_keypair()

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -22,7 +22,7 @@ from jupyter_client.session import Session
     "transport_encryption",
     [
         "disabled",
-        "enabled",
+        "auto",
         "required",
     ],
 )
@@ -111,9 +111,9 @@ def test_iopub_plaintext_visibility_depends_on_curve(transport_encryption, tmp_p
         km.context.term()
 
 
-@pytest.mark.parametrize("value", ["enabled", "required"])
+@pytest.mark.parametrize("value", ["auto", "required"])
 def test_transport_encryption_raises_when_curve_unavailable(value):
-    """Setting transport_encryption to 'enabled' or 'required' raises TraitError when CurveZMQ is unavailable."""
+    """Setting transport_encryption to 'auto' or 'required' raises TraitError when CurveZMQ is unavailable."""
     with (
         patch("zmq.has", return_value=False),
         pytest.raises(TraitError, match=r"zmq\.has\('curve'\)"),
@@ -121,9 +121,9 @@ def test_transport_encryption_raises_when_curve_unavailable(value):
         KernelManager(transport_encryption=value)
 
 
-@pytest.mark.parametrize("value", ["enabled", "required"])
+@pytest.mark.parametrize("value", ["auto", "required"])
 def test_transport_encryption_accepted_when_curve_available(value):
-    """Setting transport_encryption to 'enabled' or 'required' is accepted when CurveZMQ is available."""
+    """Setting transport_encryption to 'auto' or 'required' is accepted when CurveZMQ is available."""
     with patch("zmq.has", return_value=True):
         km = KernelManager(transport_encryption=value)
         assert km.transport_encryption == value
@@ -155,8 +155,8 @@ def _make_km(tmp_path, *, supported_encryption, transport_encryption):
 
 
 def test_enabled_without_curve_kernelspec_skips_keys(tmp_path):
-    """transport_encryption='enabled' skips key provisioning when kernelspec lacks curve support."""
-    km = _make_km(tmp_path, supported_encryption=None, transport_encryption="enabled")
+    """transport_encryption='auto' skips key provisioning when kernelspec lacks curve support."""
+    km = _make_km(tmp_path, supported_encryption=None, transport_encryption="auto")
     km.pre_start_kernel()
     info = km.get_connection_info()
     assert "curve_publickey" not in info
@@ -166,8 +166,8 @@ def test_enabled_without_curve_kernelspec_skips_keys(tmp_path):
 
 
 def test_enabled_with_curve_kernelspec_provisions_keys(tmp_path):
-    """transport_encryption='enabled' provisions keys when kernelspec declares curve support."""
-    km = _make_km(tmp_path, supported_encryption="curve", transport_encryption="enabled")
+    """transport_encryption='auto' provisions keys when kernelspec declares curve support."""
+    km = _make_km(tmp_path, supported_encryption="curve", transport_encryption="auto")
     km.pre_start_kernel()
     info = km.get_connection_info()
     assert "curve_publickey" in info

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -4,9 +4,11 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+from unittest.mock import patch
 
 import pytest
 import zmq
+from traitlets import TraitError
 
 from jupyter_client import KernelManager
 from jupyter_client.channels import HBChannel
@@ -107,6 +109,31 @@ def test_iopub_plaintext_visibility_depends_on_curve(transport_encryption, tmp_p
         eavesdropper_sock.close(linger=0)
         km.cleanup_connection_file()
         km.context.term()
+
+
+@pytest.mark.parametrize("value", ["enabled", "required"])
+def test_transport_encryption_raises_when_curve_unavailable(value):
+    """Setting transport_encryption to 'enabled' or 'required' raises TraitError when CurveZMQ is unavailable."""
+    with (
+        patch("zmq.has", return_value=False),
+        pytest.raises(TraitError, match=r"zmq\.has\('curve'\)"),
+    ):
+        KernelManager(transport_encryption=value)
+
+
+@pytest.mark.parametrize("value", ["enabled", "required"])
+def test_transport_encryption_accepted_when_curve_available(value):
+    """Setting transport_encryption to 'enabled' or 'required' is accepted when CurveZMQ is available."""
+    with patch("zmq.has", return_value=True):
+        km = KernelManager(transport_encryption=value)
+        assert km.transport_encryption == value
+
+
+def test_transport_encryption_disabled_does_not_require_curve():
+    """Setting transport_encryption to 'disabled' never raises regardless of CurveZMQ availability."""
+    with patch("zmq.has", return_value=False):
+        km = KernelManager(transport_encryption="disabled")
+        assert km.transport_encryption == "disabled"
 
 
 def test_connect_shell_to_curve_server_with_curve_keys_succeeds():

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -14,7 +14,7 @@ from jupyter_client import KernelManager
 from jupyter_client.channels import HBChannel
 from jupyter_client.client import KernelClient
 from jupyter_client.connect import ConnectionFileMixin
-from jupyter_client.kernelspec import KernelSpecManager
+from jupyter_client.kernelspec import KernelSpec, KernelSpecManager
 from jupyter_client.session import Session
 
 
@@ -136,28 +136,18 @@ def test_transport_encryption_disabled_does_not_require_curve():
         assert km.transport_encryption == "disabled"
 
 
-def _make_km_with_kernelspec(tmp_path, *, supported_encryption, transport_encryption):
-    """Helper: build a KernelManager backed by a kernelspec with the given metadata."""
-    kernel_name = "test-kernel"
-    kernel_dir = tmp_path / "kernels" / kernel_name
-    kernel_dir.mkdir(parents=True)
-    metadata = {}
-    if supported_encryption is not None:
-        metadata["supported_encryption"] = supported_encryption
-    with (kernel_dir / "kernel.json").open("w") as f:
-        json.dump(
-            {
-                "argv": ["python", "-c", "pass"],
-                "display_name": kernel_name,
-                "language": "python",
-                "metadata": metadata,
-            },
-            f,
-        )
-    km = KernelManager(
-        connection_file=str(tmp_path / "kernel.json"),
-        kernel_name=kernel_name,
-        kernel_spec_manager=KernelSpecManager(kernel_dirs=[str(tmp_path / "kernels")]),
+def _make_km(tmp_path, *, supported_encryption, transport_encryption):
+    """Helper: build a KernelManager with a kernelspec whose metadata is set directly."""
+    metadata = (
+        {} if supported_encryption is None else {"supported_encryption": supported_encryption}
+    )
+    km = KernelManager(connection_file=str(tmp_path / "kernel.json"))
+    km._kernel_spec = KernelSpec(
+        resource_dir="test",
+        argv=["python", "-c", "pass"],
+        display_name="test_kernel",
+        language="python",
+        metadata=metadata,
     )
     km.cache_ports = False
     km.transport_encryption = transport_encryption
@@ -166,9 +156,7 @@ def _make_km_with_kernelspec(tmp_path, *, supported_encryption, transport_encryp
 
 def test_enabled_without_curve_kernelspec_skips_keys(tmp_path):
     """transport_encryption='enabled' skips key provisioning when kernelspec lacks curve support."""
-    km = _make_km_with_kernelspec(
-        tmp_path, supported_encryption=None, transport_encryption="enabled"
-    )
+    km = _make_km(tmp_path, supported_encryption=None, transport_encryption="enabled")
     km.pre_start_kernel()
     info = km.get_connection_info()
     assert "curve_publickey" not in info
@@ -179,9 +167,7 @@ def test_enabled_without_curve_kernelspec_skips_keys(tmp_path):
 
 def test_enabled_with_curve_kernelspec_provisions_keys(tmp_path):
     """transport_encryption='enabled' provisions keys when kernelspec declares curve support."""
-    km = _make_km_with_kernelspec(
-        tmp_path, supported_encryption="curve", transport_encryption="enabled"
-    )
+    km = _make_km(tmp_path, supported_encryption="curve", transport_encryption="enabled")
     km.pre_start_kernel()
     info = km.get_connection_info()
     assert "curve_publickey" in info
@@ -192,9 +178,7 @@ def test_enabled_with_curve_kernelspec_provisions_keys(tmp_path):
 
 def test_required_without_curve_kernelspec_raises(tmp_path):
     """transport_encryption='required' raises RuntimeError when kernelspec lacks curve support."""
-    km = _make_km_with_kernelspec(
-        tmp_path, supported_encryption=None, transport_encryption="required"
-    )
+    km = _make_km(tmp_path, supported_encryption=None, transport_encryption="required")
     with pytest.raises(RuntimeError, match=r"metadata\.supported_encryption"):
         km.pre_start_kernel()
     km.context.term()

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -6,6 +6,8 @@
 import pytest
 import zmq
 
+from jupyter_client.channels import HBChannel
+from jupyter_client.client import KernelClient
 from jupyter_client.connect import ConnectionFileMixin
 from jupyter_client.session import Session
 
@@ -120,6 +122,61 @@ def test_connect_shell_to_curve_server_with_curve_keys_succeeds():
     finally:
         server.close(linger=0)
         ctx.term()
+
+
+def test_hb_channel_class_without_curve_support_raises_when_curve_is_active():
+    """KernelClient.hb_channel raises RuntimeError when the hb_channel_class
+    does not accept curve_serverkey but CurveZMQ is active."""
+
+    class LegacyHBChannel(HBChannel):
+        """Simulates an old heartbeat channel class that predates curve support."""
+
+        def __init__(self, context, session, address):  # type: ignore[override]
+            super().__init__(context, session, address)
+
+    pub, _sec = zmq.curve_keypair()
+
+    client = KernelClient()
+    client.hb_channel_class = LegacyHBChannel  # type: ignore[assignment]
+    client.load_connection_info(
+        {
+            "ip": "127.0.0.1",
+            "transport": "tcp",
+            "hb_port": 5555,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+            "curve_publickey": pub.decode("ascii"),
+            "curve_secretkey": pub.decode("ascii"),
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="curve_serverkey"):
+        _ = client.hb_channel
+
+
+def test_hb_channel_class_without_curve_support_does_not_raise_when_curve_disabled():
+    """KernelClient.hb_channel remains usable with legacy hb_channel_class when Curve is off."""
+
+    class LegacyHBChannel(HBChannel):
+        """Simulates an old heartbeat channel class that predates curve support."""
+
+        def __init__(self, context, session, address):  # type: ignore[override]
+            super().__init__(context, session, address)
+
+    client = KernelClient()
+    client.hb_channel_class = LegacyHBChannel  # type: ignore[assignment]
+    client.load_connection_info(
+        {
+            "ip": "127.0.0.1",
+            "transport": "tcp",
+            "hb_port": 5555,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+        }
+    )
+
+    hb = client.hb_channel
+    assert isinstance(hb, LegacyHBChannel)
 
 
 def test_connect_shell_to_curve_server_without_curve_keys_is_rejected():

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -6,6 +6,7 @@
 import pytest
 import zmq
 
+from jupyter_client import KernelManager
 from jupyter_client.channels import HBChannel
 from jupyter_client.client import KernelClient
 from jupyter_client.connect import ConnectionFileMixin
@@ -13,34 +14,38 @@ from jupyter_client.session import Session
 
 
 @pytest.mark.parametrize(
-    "enable_curve",
+    "transport_encryption",
     [
         False,
         True,
     ],
 )
-def test_iopub_plaintext_visibility_depends_on_curve(enable_curve):
+def test_iopub_plaintext_visibility_depends_on_curve(transport_encryption, tmp_path):
     """An unauthenticated subscriber sees plaintext only when Curve is disabled."""
 
-    ctx = zmq.Context()
+    km = KernelManager(connection_file=str(tmp_path / "kernel.json"))
+    km.cache_ports = False
+    km.transport_encryption = transport_encryption
+    km.pre_start_kernel()
+
     session = Session(key=b"secret-hmac-key")
-    server = ctx.socket(zmq.XPUB)
-    eavesdropper = ctx.socket(zmq.SUB)
+    server = km.context.socket(zmq.XPUB)
+    eavesdropper_sock = km.context.socket(zmq.SUB)
+    eavesdropper_sock.setsockopt(zmq.SUBSCRIBE, b"")
 
-    expect_plaintext_visible = not enable_curve
+    expect_plaintext_visible = not transport_encryption
 
-    if enable_curve:
-        pub, sec = zmq.curve_keypair()
-        server.curve_secretkey = sec
-        server.curve_publickey = pub
+    server_info = km.get_connection_info()
+    if "curve_publickey" in server_info and "curve_secretkey" in server_info:
+        server.curve_secretkey = server_info["curve_secretkey"].encode()
+        server.curve_publickey = server_info["curve_publickey"].encode()
         server.curve_server = True
 
     try:
-        port = server.bind_to_random_port("tcp://127.0.0.1")
+        server.bind(f"tcp://{km.ip}:{km.iopub_port}")
 
-        # Eavesdropper connects with no authentication or curve keys at all.
-        eavesdropper.setsockopt(zmq.SUBSCRIBE, b"")
-        eavesdropper.connect(f"tcp://127.0.0.1:{port}")
+        # Eavesdropper connects with no authentication or curve keys.
+        eavesdropper_sock.connect(f"tcp://{km.ip}:{km.iopub_port}")
 
         # In non-Curve mode, XPUB receives the subscription and we drain it.
         # In Curve mode, unauthenticated peers are rejected so no event arrives.
@@ -58,16 +63,16 @@ def test_iopub_plaintext_visibility_depends_on_curve(enable_curve):
         # Check if an unauthenticated subscriber can read plaintext payload,
         # using the same event polling behavior in both modes.
         recv_poller = zmq.Poller()
-        recv_poller.register(eavesdropper, zmq.POLLIN)
+        recv_poller.register(eavesdropper_sock, zmq.POLLIN)
         events = dict(recv_poller.poll(timeout=1000))
 
-        did_receive = eavesdropper in events
+        did_receive = eavesdropper_sock in events
         assert did_receive is expect_plaintext_visible, (
             "Unexpected unauthenticated visibility result for IOPub payload"
         )
         if expect_plaintext_visible:
             # Demonstrates that the message content is visible in plaintext frames when Curve is disabled.
-            raw_frames = eavesdropper.recv_multipart()
+            raw_frames = eavesdropper_sock.recv_multipart()
             raw_bytes = b"".join(raw_frames)
             assert b"top_secret_output_12345" in raw_bytes, (
                 f"Expected plaintext content in raw frames.\nRaw bytes: {raw_bytes!r}"
@@ -76,8 +81,9 @@ def test_iopub_plaintext_visibility_depends_on_curve(enable_curve):
 
     finally:
         server.close(linger=0)
-        eavesdropper.close(linger=0)
-        ctx.term()
+        eavesdropper_sock.close(linger=0)
+        km.cleanup_connection_file()
+        km.context.term()
 
 
 def test_connect_shell_to_curve_server_with_curve_keys_succeeds():

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -152,7 +152,7 @@ def test_hb_channel_class_without_curve_support_raises_when_curve_is_active():
         }
     )
 
-    with pytest.raises(RuntimeError, match="curve_serverkey"):
+    with pytest.raises(RuntimeError, match=r"LegacyHBChannel.*curve_serverkey"):
         _ = client.hb_channel
 
 
@@ -179,6 +179,33 @@ def test_hb_channel_class_without_curve_support_does_not_raise_when_curve_disabl
 
     hb = client.hb_channel
     assert isinstance(hb, LegacyHBChannel)
+
+
+def test_hb_channel_class_unrelated_typeerror_propagates_unchanged():
+    """TypeError unrelated to curve_serverkey is not swallowed or re-wrapped."""
+
+    class BrokenHBChannel(HBChannel):
+        def __init__(self, context, session, address, **kwargs):  # type: ignore[override]
+            raise TypeError("totally unrelated constructor error")
+
+    pub, _sec = zmq.curve_keypair()
+
+    client = KernelClient()
+    client.hb_channel_class = BrokenHBChannel  # type: ignore[assignment]
+    client.load_connection_info(
+        {
+            "ip": "127.0.0.1",
+            "transport": "tcp",
+            "hb_port": 5555,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+            "curve_publickey": pub.decode("ascii"),
+            "curve_secretkey": pub.decode("ascii"),
+        }
+    )
+
+    with pytest.raises(TypeError, match="totally unrelated constructor error"):
+        _ = client.hb_channel
 
 
 def test_connect_shell_to_curve_server_without_curve_keys_is_rejected():

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -256,8 +256,11 @@ def test_hb_channel_class_without_curve_support_raises_when_curve_is_active():
         }
     )
 
-    with pytest.raises(RuntimeError, match=r"LegacyHBChannel.*curve_serverkey"):
-        _ = client.hb_channel
+    try:
+        with pytest.raises(RuntimeError, match=r"LegacyHBChannel.*curve_serverkey"):
+            _ = client.hb_channel
+    finally:
+        client.context.term()
 
 
 def test_hb_channel_class_without_curve_support_does_not_raise_when_curve_disabled():
@@ -281,8 +284,11 @@ def test_hb_channel_class_without_curve_support_does_not_raise_when_curve_disabl
         }
     )
 
-    hb = client.hb_channel
-    assert isinstance(hb, LegacyHBChannel)
+    try:
+        hb = client.hb_channel
+        assert isinstance(hb, LegacyHBChannel)
+    finally:
+        client.context.term()
 
 
 def test_hb_channel_class_unrelated_typeerror_propagates_unchanged():
@@ -308,8 +314,11 @@ def test_hb_channel_class_unrelated_typeerror_propagates_unchanged():
         }
     )
 
-    with pytest.raises(TypeError, match="totally unrelated constructor error"):
-        _ = client.hb_channel
+    try:
+        with pytest.raises(TypeError, match="totally unrelated constructor error"):
+            _ = client.hb_channel
+    finally:
+        client.context.term()
 
 
 def test_connect_shell_to_curve_server_without_curve_keys_is_rejected():

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -16,8 +16,9 @@ from jupyter_client.session import Session
 @pytest.mark.parametrize(
     "transport_encryption",
     [
-        False,
-        True,
+        "disabled",
+        "enabled",
+        "required",
     ],
 )
 def test_iopub_plaintext_visibility_depends_on_curve(transport_encryption, tmp_path):
@@ -33,7 +34,7 @@ def test_iopub_plaintext_visibility_depends_on_curve(transport_encryption, tmp_p
     eavesdropper_sock = km.context.socket(zmq.SUB)
     eavesdropper_sock.setsockopt(zmq.SUBSCRIBE, b"")
 
-    expect_plaintext_visible = not transport_encryption
+    expect_plaintext_visible = transport_encryption == "disabled"
 
     server_info = km.get_connection_info()
     if "curve_publickey" in server_info and "curve_secretkey" in server_info:

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -159,3 +159,45 @@ def test_connect_shell_to_curve_server_without_curve_keys_is_rejected():
     finally:
         server.close(linger=0)
         ctx.term()
+
+
+def test_connect_shell_to_curve_server_with_wrong_curve_keys_is_rejected():
+    """Public API path: mismatched curve keys - traffic to a Curve server is dropped."""
+    pub, sec = zmq.curve_keypair()
+    wrong_pub, wrong_sec = zmq.curve_keypair()
+
+    ctx = zmq.Context()
+    server = ctx.socket(zmq.ROUTER)
+    server.curve_secretkey = sec
+    server.curve_publickey = pub
+    server.curve_server = True
+    port = server.bind_to_random_port("tcp://127.0.0.1")
+
+    try:
+        info = {
+            "ip": "127.0.0.1",
+            "transport": "tcp",
+            "shell_port": port,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+            "curve_publickey": wrong_pub.decode("ascii"),
+            "curve_secretkey": wrong_sec.decode("ascii"),
+        }
+        mixin = ConnectionFileMixin()
+        mixin.context = ctx
+        mixin.load_connection_info(info)
+
+        client_sock = mixin.connect_shell()
+        try:
+            client_sock.send(b"probe", flags=zmq.NOBLOCK)
+            poller = zmq.Poller()
+            poller.register(server, zmq.POLLIN)
+            events = dict(poller.poll(timeout=300))
+            assert server not in events, (
+                "Message with wrong curve keys reached Curve server - expected drop"
+            )
+        finally:
+            client_sock.close(linger=0)
+    finally:
+        server.close(linger=0)
+        ctx.term()


### PR DESCRIPTION
This PR adds CurveZMQ transport encryption to jupyter_client, providing the foundational layer for encrypted kernel communication. It is the upstream dependency for ipykernel#1515 and jupyter-server#1638.

What's changed

- local_provisioner.py: Generates a CurveZMQ keypair and writes curve_publickey / curve_secretkey into the connection file. The client owns key generation.
- connect.py: Reads curve keys from connection files and applies them when setting up ZMQ sockets.
- manager.py: Introduces a transport_encryption traitlet with three modes:

  - 'disabled' (default) — no encryption, existing behavior unchanged
  - 'auto' — enables encryption only for kernelspecs that advertise metadata.supported_encryption: 'curve'
  - 'required' — encryption is mandatory; kernel startup fails if the kernelspec doesn't declare support
- channels.py / client.py: Heartbeat channel configured as a CurveZMQ client using the server's public key.
- Validation: Checks for libsodium support in pyzmq at startup and raises a clear error if missing.

Design notes

- Named `transport_encryption` (not a boolean) to leave room for future encryption backends beyond CurveZMQ.
- Fully backward-compatible: 'disabled' is the default, so nothing changes for existing kernels.
- Kernel capability discovery is via kernelspec metadata (supported_encryption: 'curve'), handled on the kernel side in ipykernel#1515.
- Guards against pyzmq builds without libsodium, with graceful degradation or a clear error depending on the configured mode.



### References

- Closes https://github.com/jupyter/jupyter_client/issues/808
- PoC for https://github.com/jupyter/enhancement-proposals/issues/75
- Sibling PR https://github.com/ipython/ipykernel/pull/1515
- Toggle on server-level: https://github.com/jupyter-server/jupyter_server/pull/1638

### Code changes

Follows ipyparallel approach (https://github.com/ipython/ipyparallel/pull/553)

- [x] Tests
- [x] Add `curve_serverkey` handling to heartbeat channel
- [x] Pass curve keys from connection file to the socket (implemented at mixing level)