### PR TITLE
Remove `3.14t` testing until `msgpack` supports it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,6 @@ jobs:
         python-version:
           - "3.10"
           - "3.14"
-          - "3.14t"
         include:
           - os: windows-latest
             python-version: "3.12"


### PR DESCRIPTION
Right now this is just CI noise.

See https://github.com/msgpack/msgpack-python/issues/613

I'll open a tracking issue to reenable it.