### PR TITLE
CI: fix testing of nbconvert

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: nbconvert
-          package_spec: -e ".[test]"
+          package_spec: ".[test]"
 
   jupyter_server:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/jupyterlab/maintainer-tools/pull/275 introduce extra quoting of package-spec so `-e` does not worl anymore; fallback to non-editabel install