### PR TITLE
TRy to speedup test (and skip Python 3.15; orjson).

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,11 @@ jobs:
         run: |
           echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-} -W default" >> $GITHUB_ENV
 
+      - name: enable slow tests on the latest python for each platform
+        if: ${{ matrix.python-version == '3.14' }}
+        run: |
+          echo "PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-} --runslow" >> $GITHUB_ENV
+
       - name: disable coverage on pypy
         if: ${{ startsWith(matrix.python-version, 'pypy') }}
         run: |
@@ -164,6 +169,8 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: pre
+          # Pin to <=3.14: orjson does not yet build on 3.15-dev.
+          python_version: "3.14"
       - name: Run the tests
         run: |
           hatch run test:nowarn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ testpaths = [
 timeout = 100
 # Restore this setting to debug failures
 timeout_method = "thread"
+markers = [
+  "slow: marks tests as slow (deselected by default; pass --runslow to enable)",
+]
 filterwarnings= [
   # Fail on warnings
   "error",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,24 @@ os.environ["JUPYTER_PLATFORM_DIRS"] = "1"
 pytest_plugins = ["pytest_jupyter", "pytest_jupyter.jupyter_client"]
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow",
+        action="store_true",
+        default=False,
+        help="run tests marked as slow",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
 @pytest.fixture(autouse=True)
 def setup_environ(jp_environ):
     pass

--- a/tests/problemkernel.py
+++ b/tests/problemkernel.py
@@ -34,7 +34,7 @@ class ProblemTestApp(IPKernelApp):
 
 if __name__ == "__main__":
     # make startup artificially slow,
-    # so that we exercise client logic for slow-starting kernels
-    startup_delay = int(os.environ.get("STARTUP_DELAY", "2"))
+    # so that we exercise client logic for slow-starting kernels.
+    startup_delay = float(os.environ.get("STARTUP_DELAY", "2"))
     time.sleep(startup_delay)
     ProblemTestApp.launch_instance()

--- a/tests/test_localinterfaces.py
+++ b/tests/test_localinterfaces.py
@@ -6,9 +6,12 @@
 # -----------------------------------------------------------------------------
 import sys
 
+import pytest
+
 from jupyter_client import localinterfaces
 
 
+@pytest.mark.slow
 def test_load_ips():
     # Override the machinery that skips it if it was called before
     localinterfaces._load_ips.called = False  # type:ignore[attr-defined]

--- a/tests/test_restarter.py
+++ b/tests/test_restarter.py
@@ -55,7 +55,7 @@ def install_fail_kernel():
 @pytest.fixture
 def install_slow_fail_kernel():
     return _install_kernel(
-        "problemtest-slow", extra_env={"STARTUP_DELAY": "5", "FAIL_ON_START": "1"}
+        "problemtest-slow", extra_env={"STARTUP_DELAY": "0.5", "FAIL_ON_START": "1"}
     )
 
 
@@ -93,6 +93,9 @@ async def test_restart_check(config, install_kernel, debug_logging):
     N_restarts = 1
     config.KernelRestarter.restart_limit = N_restarts
     config.KernelRestarter.debug = True
+    # Tighten the heartbeat poll interval (default 3.0s) so death is detected
+    # quickly. Localhost ZMQ heartbeats round-trip in <1ms even on slow CI.
+    config.KernelRestarter.time_to_dead = 0.5
     km = IOLoopKernelManager(kernel_name=install_kernel, config=config)
 
     cbs = 0
@@ -124,7 +127,7 @@ async def test_restart_check(config, install_kernel, debug_logging):
                 assert km.provisioner is not None
                 await km.provisioner.kill()
                 restarts[i].result()
-                # Wait for kill + restart
+                # Wait for kill + restart.
                 max_wait = 10.0
                 waited = 0.0
                 while waited < max_wait and km.is_alive():
@@ -149,6 +152,7 @@ async def test_restarter_gives_up(config, install_fail_kernel, debug_logging):
     N_restarts = 1
     config.KernelRestarter.restart_limit = N_restarts
     config.KernelRestarter.debug = True
+    config.KernelRestarter.time_to_dead = 0.5
     km = IOLoopKernelManager(kernel_name=install_fail_kernel, config=config)
 
     cbs = 0
@@ -193,6 +197,7 @@ async def test_async_restart_check(config, install_kernel, debug_logging):
     N_restarts = 1
     config.KernelRestarter.restart_limit = N_restarts
     config.KernelRestarter.debug = True
+    config.KernelRestarter.time_to_dead = 0.5
     km = AsyncIOLoopKernelManager(kernel_name=install_kernel, config=config)
 
     cbs = 0
@@ -224,8 +229,10 @@ async def test_async_restart_check(config, install_kernel, debug_logging):
                 assert km.provisioner is not None
                 await km.provisioner.kill()
                 await restarts[i]
-                # Wait for kill + restart
-                max_wait = 10.0
+                # Wait for kill + restart. Generous timeout for slow CI; the
+                # loop exits as soon as the state flips, so fast machines
+                # finish quickly.
+                max_wait = 30.0
                 waited = 0.0
                 while waited < max_wait and await km.is_alive():
                     await asyncio.sleep(0.1)
@@ -249,6 +256,7 @@ async def test_async_restarter_gives_up(config, install_slow_fail_kernel, debug_
     config.KernelRestarter.restart_limit = N_restarts
     config.KernelRestarter.debug = True
     config.KernelRestarter.stable_start_time = 30.0
+    config.KernelRestarter.time_to_dead = 0.5
     km = AsyncIOLoopKernelManager(kernel_name=install_slow_fail_kernel, config=config)
 
     cbs = 0


### PR DESCRIPTION
jupyterlab/maintainer-tools#275 introduce extra
quoting of package-spec so `-e` does not worl anymore; fallback to
non-editabel install