### PR TITLE
Temporarily pin Python to 3.14 in pre-releases test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,6 +164,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: pre
+          python_version: "3.14"
       - name: Run the tests
         run: |
           hatch run test:nowarn


### PR DESCRIPTION
Until maturin supports Python 3.15 pre-releases

I think some 3.15 adjacent work is tracked in https://github.com/PyO3/maturin/issues/3064, more context in https://github.com/pyca/cryptography/issues/13974