### PR TITLE
Fix kernel restart for curve encryption.

### DIFF
--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -546,6 +546,8 @@ class ConnectionFileMixin(LoggingConfigurable):
             control_port=self.control_port,
             signature_scheme=self.session.signature_scheme,
             kernel_name=self.kernel_name,
+            curve_publickey=self.curve_publickey,
+            curve_secretkey=self.curve_secretkey,
             **kwargs,
         )
         # write_connection_file also sets default ports:

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -16,6 +16,9 @@ from ..launcher import launch_kernel
 from ..localinterfaces import is_local_ip, local_ips
 from .provisioner_base import KernelProvisionerBase
 
+if TYPE_CHECKING:
+    from jupyter_client.manager import KernelManager
+
 
 class LocalProvisioner(KernelProvisionerBase):
     """
@@ -174,75 +177,64 @@ class LocalProvisioner(KernelProvisionerBase):
         """
 
         # This should be considered temporary until a better division of labor can be defined.
-        km = self.parent
+        km: KernelManager | None = self.parent
         if km:
-            transport_encryption = kwargs.pop(
-                "transport_encryption", getattr(km, "transport_encryption", "disabled")
-            )
-            transport_encryption_policy = (
-                km._transport_encryption_policy(transport_encryption)
-                if hasattr(km, "_transport_encryption_policy")
-                else ("auto" if bool(transport_encryption) else "disabled")
-            )
-            encryption_required = transport_encryption_policy == "required"
-            encryption_enabled = transport_encryption_policy in {"auto", "required"}
-            curve_publickey: bytes | None = None
-            curve_secretkey: bytes | None = None
-            if encryption_required and km.transport != "tcp":
-                msg = "transport_encryption='required' is only supported when transport='tcp'."
-                raise RuntimeError(msg)
-            if km.transport == "tcp" and not is_local_ip(km.ip):
-                msg = (
-                    "Can only launch a kernel on a local interface. "
-                    f"This one is not: {km.ip}."
-                    "Make sure that the '*_address' attributes are "
-                    "configured properly. "
-                    f"Currently valid addresses are: {local_ips()}"
-                )
-                raise RuntimeError(msg)
             # build the Popen cmd
-            extra_arguments = kwargs.pop("extra_arguments", [])
+            if not os.path.exists(km.connection_file):
+                transport_encryption = kwargs.pop(
+                    "transport_encryption", getattr(km, "transport_encryption", "disabled")
+                )
+                transport_encryption_policy = (
+                    km._transport_encryption_policy(transport_encryption)
+                    if hasattr(km, "_transport_encryption_policy")
+                    else ("auto" if bool(transport_encryption) else "disabled")
+                )
+                encryption_required = transport_encryption_policy == "required"
+                encryption_enabled = transport_encryption_policy in {"auto", "required"}
+                if encryption_required and km.transport != "tcp":
+                    msg = "transport_encryption='required' is only supported when transport='tcp'."
+                    raise RuntimeError(msg)
+                if km.transport == "tcp" and not is_local_ip(km.ip):
+                    msg = (
+                        "Can only launch a kernel on a local interface. "
+                        f"This one is not: {km.ip}."
+                        "Make sure that the '*_address' attributes are "
+                        "configured properly. "
+                        f"Currently valid addresses are: {local_ips()}"
+                    )
+                    raise RuntimeError(msg)
 
-            # write connection file / get default ports
-            # TODO - change when handshake pattern is adopted
-            if km.cache_ports and not self.ports_cached:
-                lpc = LocalPortCache.instance()
-                km.shell_port = lpc.find_available_port(km.ip)
-                km.iopub_port = lpc.find_available_port(km.ip)
-                km.stdin_port = lpc.find_available_port(km.ip)
-                km.hb_port = lpc.find_available_port(km.ip)
-                km.control_port = lpc.find_available_port(km.ip)
-                self.ports_cached = True
+                # write connection file / get default ports
+                # TODO - change when handshake pattern is adopted
+                if km.cache_ports and not self.ports_cached:
+                    lpc = LocalPortCache.instance()
+                    km.shell_port = lpc.find_available_port(km.ip)
+                    km.iopub_port = lpc.find_available_port(km.ip)
+                    km.stdin_port = lpc.find_available_port(km.ip)
+                    km.hb_port = lpc.find_available_port(km.ip)
+                    km.control_port = lpc.find_available_port(km.ip)
+                    self.ports_cached = True
 
-            if encryption_enabled and km.transport == "tcp":
-                kernel_curve_ok = encryption_required or (
-                    hasattr(km, "_kernel_supports_curve_encryption")
-                    and km._kernel_supports_curve_encryption()
-                )
-                if kernel_curve_ok:
-                    curve_publickey, curve_secretkey = zmq.curve_keypair()
-                    km.curve_publickey = curve_publickey
-                    km.curve_secretkey = curve_secretkey
-            if "env" in kwargs:
-                jupyter_session = kwargs["env"].get("JPY_SESSION_NAME", "")
-                km.write_connection_file(
-                    jupyter_session=jupyter_session,
-                    curve_publickey=curve_publickey,
-                    curve_secretkey=curve_secretkey,
-                )
-            else:
-                km.write_connection_file(
-                    curve_publickey=curve_publickey,
-                    curve_secretkey=curve_secretkey,
-                )
-            self.connection_info = km.get_connection_info()
+                if encryption_enabled and km.transport == "tcp":
+                    kernel_curve_ok = encryption_required or (
+                        hasattr(km, "_kernel_supports_curve_encryption")
+                        and km._kernel_supports_curve_encryption()
+                    )
+                    if kernel_curve_ok and not km.curve_publickey:
+                        km.curve_publickey, km.curve_secretkey = zmq.curve_keypair()
+                extra = {}
+                if (env := kwargs.get("env")) and (
+                    jupyter_session := env.get("JPY_SESSION_NAME", "")
+                ):
+                    extra["jupyter_session"] = jupyter_session
+                km.write_connection_file(**extra)
+                self.connection_info = km.get_connection_info()
 
             kernel_cmd = km.format_kernel_cmd(
-                extra_arguments=extra_arguments
+                extra_arguments=kwargs.pop("extra_arguments", [])
             )  # This needs to remain here for b/c
         else:
-            extra_arguments = kwargs.pop("extra_arguments", [])
-            kernel_cmd = self.kernel_spec.argv + extra_arguments
+            kernel_cmd = [*self.kernel_spec.argv, *kwargs.pop("extra_arguments", [])]
 
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)
 

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -180,7 +180,9 @@ class LocalProvisioner(KernelProvisionerBase):
         km: KernelManager | None = self.parent
         if km:
             # build the Popen cmd
-            if not os.path.exists(km.connection_file):
+            if os.path.exists(km.connection_file):
+                km.load_connection_file()
+            else:
                 transport_encryption = kwargs.pop(
                     "transport_encryption", getattr(km, "transport_encryption", "disabled")
                 )

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -17,7 +17,7 @@ from traitlets import Int, Unicode
 from jupyter_client.connect import KernelConnectionInfo
 from jupyter_client.kernelspec import KernelSpec, KernelSpecManager, NoSuchKernel
 from jupyter_client.launcher import launch_kernel
-from jupyter_client.manager import AsyncKernelManager
+from jupyter_client.manager import AsyncKernelManager, KernelManager
 from jupyter_client.provisioning import (
     KernelProvisionerBase,
     KernelProvisionerFactory,
@@ -95,7 +95,7 @@ class CustomTestProvisioner(KernelProvisionerBase):  # type:ignore
             self.process.terminate()
 
     async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
-        km = self.parent
+        km: KernelManager | None = self.parent
         if km:
             # save kwargs for use in restart
             km._launch_args = kwargs.copy()
@@ -118,10 +118,7 @@ class CustomTestProvisioner(KernelProvisionerBase):  # type:ignore
                 km.curve_publickey = curve_publickey
                 km.curve_secretkey = curve_secretkey
             # write connection file / get default ports
-            km.write_connection_file(
-                curve_publickey=curve_publickey,
-                curve_secretkey=curve_secretkey,
-            )
+            km.write_connection_file()
             self.connection_info = km.get_connection_info()
 
             kernel_cmd = km.format_kernel_cmd(
@@ -298,7 +295,7 @@ class TestRuntime:
             assert kernel_mgr.provisioner.has_process is False
 
     async def test_local_provisioner_pre_launch_generates_curve_keys_under_transport_encryption(
-        self, monkeypatch, tmp_path
+        self, tmp_path
     ):
         """When transport encryption is enabled, LocalProvisioner seeds curve keys before launch."""
         km = AsyncKernelManager(connection_file=str(tmp_path / "kernel.json"))
@@ -317,15 +314,10 @@ class TestRuntime:
         assert km.provisioner is not None
         assert isinstance(km.provisioner, LocalProvisioner)
 
-        monkeypatch.setattr(
-            "jupyter_client.provisioning.local_provisioner.zmq.curve_keypair",
-            lambda: (b"A" * 40, b"B" * 40),
-        )
-
         await km.provisioner.pre_launch()
 
-        assert km.provisioner.connection_info["curve_publickey"] == "A" * 40
-        assert km.provisioner.connection_info["curve_secretkey"] == "B" * 40
+        assert km.provisioner.connection_info["curve_publickey"] is not None
+        assert km.provisioner.connection_info["curve_secretkey"] is not None
 
     async def test_local_provisioner_pre_launch_requires_tcp_for_required_transport_encryption(
         self, tmp_path


### PR DESCRIPTION
Previously if a kernel was started with curve encryption it could not be restarted because the encryption settings were wrong for the restarted kernel.

This PR ensures the curve details are written to the connection file and also avoids changing settings on the kernel if the connection file still exists.