### PR TITLE
Fix ConnectionFileMixin.write_connection_file and restart for curve encryption.

### DIFF
--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -128,12 +128,7 @@ class KernelClient(ConnectionFileMixin):
                 if self.log:
                     self.log.debug("Destroying zmq context for %s", self)
                 self.context.destroy(linger=100)
-        try:
-            super_del = super().__del__  # type:ignore[misc]
-        except AttributeError:
-            pass
-        else:
-            super_del()
+        super().__del__()
 
     # --------------------------------------------------------------------------
     # Channel proxy methods

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -542,6 +542,8 @@ class ConnectionFileMixin(LoggingConfigurable):
     def write_connection_file(self, **kwargs: Any) -> None:
         """Write connection info to JSON dict in self.connection_file."""
         cfg_: Any = self.get_connection_info()
+        assert not set(cfg_).intersection(kwargs), "Overwriting connection info is not allowed!"
+
         if os.path.exists(self.connection_file):
             with contextlib.suppress(Exception), open(self.connection_file, "rb") as f:
                 cfg_ = json.load(f) | cfg_

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -383,6 +383,7 @@ class ConnectionFileMixin(LoggingConfigurable):
     )
 
     def __del__(self) -> None:
+        """Handle garbage collection.  Remove connection file if written."""
         if self._connection_file_written:
             self.cleanup_connection_file()
 

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -61,7 +61,7 @@ def write_connection_file(
     hb_port: int = 0,
     control_port: int = 0,
     ip: str = "",
-    key: bytes = b"",
+    key: str | bytes = b"",
     transport: str = "tcp",
     signature_scheme: str = "hmac-sha256",
     kernel_name: str = "",
@@ -95,7 +95,7 @@ def write_connection_file(
     ip  : str, optional
         The ip address the kernel will bind to.
 
-    key : bytes, optional
+    key : str, bytes, optional
         The Session key used for message authentication.
 
     signature_scheme : str, optional
@@ -170,7 +170,7 @@ def write_connection_file(
         "hb_port": hb_port,
     }
     cfg["ip"] = ip
-    cfg["key"] = key.decode()
+    cfg["key"] = key.decode() if isinstance(key, bytes) else key
     cfg["transport"] = transport
     cfg["signature_scheme"] = signature_scheme
     cfg["kernel_name"] = kernel_name
@@ -540,7 +540,7 @@ class ConnectionFileMixin(LoggingConfigurable):
 
     def write_connection_file(self, **kwargs: Any) -> None:
         """Write connection info to JSON dict in self.connection_file."""
-        cfg_ = self.get_connection_info()
+        cfg_: Any = self.get_connection_info()
         if os.path.exists(self.connection_file):
             with contextlib.suppress(Exception), open(self.connection_file, "rb") as f:
                 cfg_ = json.load(f) | cfg_

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -547,7 +547,7 @@ class ConnectionFileMixin(LoggingConfigurable):
                 cfg_ = json.load(f) | cfg_
         else:
             self._connection_file_written = True
-        self.connection_file, cfg = write_connection_file(self.connection_file, **kwargs | cfg_)
+        self.connection_file, cfg = write_connection_file(self.connection_file, **cfg_ | kwargs)
         # write_connection_file also sets default ports:
         self._record_random_port_names()
         for name in port_names:

--- a/jupyter_client/connect.py
+++ b/jupyter_client/connect.py
@@ -8,6 +8,7 @@ related to writing and reading connections files.
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
 
+import contextlib
 import errno
 import glob
 import json
@@ -64,8 +65,8 @@ def write_connection_file(
     transport: str = "tcp",
     signature_scheme: str = "hmac-sha256",
     kernel_name: str = "",
-    curve_publickey: bytes | None = None,
-    curve_secretkey: bytes | None = None,
+    curve_publickey: str | bytes | None = None,
+    curve_secretkey: str | bytes | None = None,
     **kwargs: Any,
 ) -> tuple[str, KernelConnectionInfo]:
     """Generates a JSON config file, including the selection of random ports.
@@ -174,9 +175,13 @@ def write_connection_file(
     cfg["signature_scheme"] = signature_scheme
     cfg["kernel_name"] = kernel_name
     if curve_publickey is not None:
-        cfg["curve_publickey"] = curve_publickey.decode("ascii")
+        if isinstance(curve_publickey, bytes):
+            curve_publickey = curve_publickey.decode("ascii")
+        cfg["curve_publickey"] = curve_publickey
     if curve_secretkey is not None:
-        cfg["curve_secretkey"] = curve_secretkey.decode("ascii")
+        if isinstance(curve_secretkey, bytes):
+            curve_secretkey = curve_secretkey.decode("ascii")
+        cfg["curve_secretkey"] = curve_secretkey
     cfg.update(kwargs)  # type: ignore[typeddict-item]
 
     # Only ever write this file as user read/writeable
@@ -377,6 +382,10 @@ class ConnectionFileMixin(LoggingConfigurable):
         to the Kernel, so be careful!""",
     )
 
+    def __del__(self) -> None:
+        if self._connection_file_written:
+            self.cleanup_connection_file()
+
     def _ip_default(self) -> str:
         if self.transport == "ipc":
             if self.connection_file:
@@ -531,29 +540,17 @@ class ConnectionFileMixin(LoggingConfigurable):
 
     def write_connection_file(self, **kwargs: Any) -> None:
         """Write connection info to JSON dict in self.connection_file."""
-        if self._connection_file_written and os.path.exists(self.connection_file):
-            return
-
-        self.connection_file, cfg = write_connection_file(
-            self.connection_file,
-            transport=self.transport,
-            ip=self.ip,
-            key=self.session.key,
-            stdin_port=self.stdin_port,
-            iopub_port=self.iopub_port,
-            shell_port=self.shell_port,
-            hb_port=self.hb_port,
-            control_port=self.control_port,
-            signature_scheme=self.session.signature_scheme,
-            kernel_name=self.kernel_name,
-            **kwargs,
-        )
+        cfg_ = self.get_connection_info()
+        if os.path.exists(self.connection_file):
+            with contextlib.suppress(Exception), open(self.connection_file, "rb") as f:
+                cfg_ = json.load(f) | cfg_
+        else:
+            self._connection_file_written = True
+        self.connection_file, cfg = write_connection_file(self.connection_file, **kwargs | cfg_)
         # write_connection_file also sets default ports:
         self._record_random_port_names()
         for name in port_names:
             setattr(self, name, cast(int, cfg.get(name)))
-
-        self._connection_file_written = True
 
     def load_connection_file(self, connection_file: str | None = None) -> None:
         """Load connection info from JSON dict in self.connection_file.

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -16,6 +16,9 @@ from ..launcher import launch_kernel
 from ..localinterfaces import is_local_ip, local_ips
 from .provisioner_base import KernelProvisionerBase
 
+if TYPE_CHECKING:
+    from jupyter_client.manager import KernelManager
+
 
 class LocalProvisioner(KernelProvisionerBase):
     """
@@ -174,8 +177,12 @@ class LocalProvisioner(KernelProvisionerBase):
         """
 
         # This should be considered temporary until a better division of labor can be defined.
-        km = self.parent
+        km: KernelManager | None = self.parent
+        extra_arguments: list[str] = kwargs.pop("extra_arguments", [])
         if km:
+            # build the Popen cmd
+            if os.path.exists(km.connection_file):
+                km.load_connection_file()
             transport_encryption = kwargs.pop(
                 "transport_encryption", getattr(km, "transport_encryption", "disabled")
             )
@@ -186,8 +193,6 @@ class LocalProvisioner(KernelProvisionerBase):
             )
             encryption_required = transport_encryption_policy == "required"
             encryption_enabled = transport_encryption_policy in {"auto", "required"}
-            curve_publickey: bytes | None = None
-            curve_secretkey: bytes | None = None
             if encryption_required and km.transport != "tcp":
                 msg = "transport_encryption='required' is only supported when transport='tcp'."
                 raise RuntimeError(msg)
@@ -200,8 +205,6 @@ class LocalProvisioner(KernelProvisionerBase):
                     f"Currently valid addresses are: {local_ips()}"
                 )
                 raise RuntimeError(msg)
-            # build the Popen cmd
-            extra_arguments = kwargs.pop("extra_arguments", [])
 
             # write connection file / get default ports
             # TODO - change when handshake pattern is adopted
@@ -219,30 +222,17 @@ class LocalProvisioner(KernelProvisionerBase):
                     hasattr(km, "_kernel_supports_curve_encryption")
                     and km._kernel_supports_curve_encryption()
                 )
-                if kernel_curve_ok:
-                    curve_publickey, curve_secretkey = zmq.curve_keypair()
-                    km.curve_publickey = curve_publickey
-                    km.curve_secretkey = curve_secretkey
-            if "env" in kwargs:
-                jupyter_session = kwargs["env"].get("JPY_SESSION_NAME", "")
-                km.write_connection_file(
-                    jupyter_session=jupyter_session,
-                    curve_publickey=curve_publickey,
-                    curve_secretkey=curve_secretkey,
-                )
-            else:
-                km.write_connection_file(
-                    curve_publickey=curve_publickey,
-                    curve_secretkey=curve_secretkey,
-                )
+                if kernel_curve_ok and not km.curve_publickey:
+                    km.curve_publickey, km.curve_secretkey = zmq.curve_keypair()
+            extra = {}
+            if (env := kwargs.get("env")) and (jupyter_session := env.get("JPY_SESSION_NAME", "")):
+                extra["jupyter_session"] = jupyter_session
+            km.write_connection_file(**extra)
             self.connection_info = km.get_connection_info()
 
-            kernel_cmd = km.format_kernel_cmd(
-                extra_arguments=extra_arguments
-            )  # This needs to remain here for b/c
+            kernel_cmd = km.format_kernel_cmd(extra_arguments)  # This needs to remain here for b/c
         else:
-            extra_arguments = kwargs.pop("extra_arguments", [])
-            kernel_cmd = self.kernel_spec.argv + extra_arguments
+            kernel_cmd = [*self.kernel_spec.argv, *extra_arguments]
 
         return await super().pre_launch(cmd=kernel_cmd, **kwargs)
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -236,7 +236,7 @@ def test_find_connection_file_abspath():
 def test_mixin_record_random_ports():
     with TemporaryDirectory() as d:
         dc = DummyConfigurable(data_dir=d, kernel_name="via-tcp", transport="tcp")
-        dc.write_connection_file()
+        dc.write_connection_file(extra=111)
 
         assert dc._connection_file_written
         assert os.path.exists(dc.connection_file)
@@ -245,7 +245,8 @@ def test_mixin_record_random_ports():
         # Check we can write extra info to the config file
         dc.write_connection_file(extra=123)
         info2 = json.loads(pathlib.Path(dc.connection_file).read_bytes())
-        assert info2.pop("extra", None) == 123
+        assert info2.pop("extra") == 123
+        info.pop("extra")
         assert info2 == info
 
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -236,6 +236,8 @@ def test_find_connection_file_abspath():
 def test_mixin_record_random_ports():
     with TemporaryDirectory() as d:
         dc = DummyConfigurable(data_dir=d, kernel_name="via-tcp", transport="tcp")
+        with pytest.raises(AssertionError, match="Overwriting connection info is not allowed!"):
+            dc.write_connection_file(transport="tcp")
         dc.write_connection_file(extra=111)
 
         assert dc._connection_file_written

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -2,8 +2,10 @@
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import gc
 import json
 import os
+import pathlib
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -239,18 +241,30 @@ def test_mixin_record_random_ports():
         assert dc._connection_file_written
         assert os.path.exists(dc.connection_file)
         assert dc._random_port_names == connect.port_names
+        info = json.loads(pathlib.Path(dc.connection_file).read_bytes())
+        # Check we can write extra info to the config file
+        dc.write_connection_file(extra=123)
+        info2 = json.loads(pathlib.Path(dc.connection_file).read_bytes())
+        assert info2.pop("extra", None) == 123
+        assert info2 == info
 
 
-def test_mixin_cleanup_random_ports():
+@pytest.mark.parametrize("mode", ["direct", "deleted"])
+def test_mixin_cleanup_random_ports(mode: str):
     with TemporaryDirectory() as d:
         dc = DummyConfigurable(data_dir=d, kernel_name="via-tcp", transport="tcp")
         dc.write_connection_file()
         filename = dc.connection_file
-        dc.cleanup_random_ports()
+        if mode == "direct":
+            dc.cleanup_random_ports()
 
-        assert not os.path.exists(filename)
-        for name in dc._random_port_names:  # type:ignore
-            assert getattr(dc, name) == 0
+            assert not os.path.exists(filename)
+            for name in dc._random_port_names:  # type:ignore
+                assert getattr(dc, name) == 0
+        else:
+            del dc
+            gc.collect()
+            assert not os.path.exists(filename)
 
 
 param_values = [

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -238,17 +238,18 @@ def test_mixin_record_random_ports():
         dc = DummyConfigurable(data_dir=d, kernel_name="via-tcp", transport="tcp")
         with pytest.raises(AssertionError, match="Overwriting connection info is not allowed!"):
             dc.write_connection_file(transport="tcp")
-        dc.write_connection_file(extra=111)
+        dc.write_connection_file(extra=111, existing=True)
 
         assert dc._connection_file_written
         assert os.path.exists(dc.connection_file)
         assert dc._random_port_names == connect.port_names
         info = json.loads(pathlib.Path(dc.connection_file).read_bytes())
-        # Check we can write extra info to the config file
+        assert "existing" in info
+        assert info.pop("extra") == 111
+        # Check we can overwrite extra info stored in the config file
         dc.write_connection_file(extra=123)
         info2 = json.loads(pathlib.Path(dc.connection_file).read_bytes())
         assert info2.pop("extra") == 123
-        info.pop("extra")
         assert info2 == info
 
 

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -17,7 +17,7 @@ from traitlets import Int, Unicode
 from jupyter_client.connect import KernelConnectionInfo
 from jupyter_client.kernelspec import KernelSpec, KernelSpecManager, NoSuchKernel
 from jupyter_client.launcher import launch_kernel
-from jupyter_client.manager import AsyncKernelManager
+from jupyter_client.manager import AsyncKernelManager, KernelManager
 from jupyter_client.provisioning import (
     KernelProvisionerBase,
     KernelProvisionerFactory,
@@ -95,7 +95,7 @@ class CustomTestProvisioner(KernelProvisionerBase):  # type:ignore
             self.process.terminate()
 
     async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
-        km = self.parent
+        km: KernelManager | None = self.parent
         if km:
             # save kwargs for use in restart
             km._launch_args = kwargs.copy()
@@ -118,10 +118,7 @@ class CustomTestProvisioner(KernelProvisionerBase):  # type:ignore
                 km.curve_publickey = curve_publickey
                 km.curve_secretkey = curve_secretkey
             # write connection file / get default ports
-            km.write_connection_file(
-                curve_publickey=curve_publickey,
-                curve_secretkey=curve_secretkey,
-            )
+            km.write_connection_file()
             self.connection_info = km.get_connection_info()
 
             kernel_cmd = km.format_kernel_cmd(
@@ -298,7 +295,7 @@ class TestRuntime:
             assert kernel_mgr.provisioner.has_process is False
 
     async def test_local_provisioner_pre_launch_generates_curve_keys_under_transport_encryption(
-        self, monkeypatch, tmp_path
+        self, tmp_path
     ):
         """When transport encryption is enabled, LocalProvisioner seeds curve keys before launch."""
         km = AsyncKernelManager(connection_file=str(tmp_path / "kernel.json"))
@@ -317,15 +314,10 @@ class TestRuntime:
         assert km.provisioner is not None
         assert isinstance(km.provisioner, LocalProvisioner)
 
-        monkeypatch.setattr(
-            "jupyter_client.provisioning.local_provisioner.zmq.curve_keypair",
-            lambda: (b"A" * 40, b"B" * 40),
-        )
-
         await km.provisioner.pre_launch()
 
-        assert km.provisioner.connection_info["curve_publickey"] == "A" * 40
-        assert km.provisioner.connection_info["curve_secretkey"] == "B" * 40
+        assert km.provisioner.connection_info["curve_publickey"] is not None
+        assert km.provisioner.connection_info["curve_secretkey"] is not None
 
     async def test_local_provisioner_pre_launch_requires_tcp_for_required_transport_encryption(
         self, tmp_path


### PR DESCRIPTION
 `ConnectionFileMixin.write_connection_file` will now update an existing file with the current settings. The method can be called multiple times with extra settings to add. Previously the behavior was ambiguous, possibly with nothing written, possibly resulting in settings mismatch. This became more apparent with the recent addition of curve encryption support.

Replaces #1123

This also adds `__del__` to delete the connection file if it was written by the ConnectionFileMixin.
