### PR TITLE
Support curve encryption over IPC too

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -31,9 +31,9 @@ silently dropped before any data is delivered.
 
 .. note::
 
-    ``transport_encryption`` applies to TCP transport only. IPC sockets
-    already rely on filesystem permissions for access control and do not
-    support CurveZMQ.
+    ``transport_encryption`` applies to both the ``tcp`` and ``ipc``
+    transports. IPC sockets also rely on filesystem permissions for access
+    control, but CurveZMQ can be layered on top for defense in depth.
 
 
 The ``transport_encryption`` setting

--- a/jupyter_client/provisioning/local_provisioner.py
+++ b/jupyter_client/provisioning/local_provisioner.py
@@ -186,10 +186,16 @@ class LocalProvisioner(KernelProvisionerBase):
             )
             encryption_required = transport_encryption_policy == "required"
             encryption_enabled = transport_encryption_policy in {"auto", "required"}
+            # CurveZMQ encryption is supported over the tcp and ipc transports.
+            # inproc is in-process (no wire handshake) and is never encrypted.
+            encryption_supported_transport = km.transport in {"tcp", "ipc"}
             curve_publickey: bytes | None = None
             curve_secretkey: bytes | None = None
-            if encryption_required and km.transport != "tcp":
-                msg = "transport_encryption='required' is only supported when transport='tcp'."
+            if encryption_required and not encryption_supported_transport:
+                msg = (
+                    "transport_encryption='required' is only supported when "
+                    "transport is 'tcp' or 'ipc'."
+                )
                 raise RuntimeError(msg)
             if km.transport == "tcp" and not is_local_ip(km.ip):
                 msg = (
@@ -214,7 +220,7 @@ class LocalProvisioner(KernelProvisionerBase):
                 km.control_port = lpc.find_available_port(km.ip)
                 self.ports_cached = True
 
-            if encryption_enabled and km.transport == "tcp":
+            if encryption_enabled and encryption_supported_transport:
                 kernel_curve_ok = encryption_required or (
                     hasattr(km, "_kernel_supports_curve_encryption")
                     and km._kernel_supports_curve_encryption()

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -317,10 +317,8 @@ class TestRuntime:
         assert km.provisioner.connection_info["curve_publickey"] is not None
         assert km.provisioner.connection_info["curve_secretkey"] is not None
 
-    async def test_local_provisioner_pre_launch_requires_tcp_for_required_transport_encryption(
-        self, tmp_path
-    ):
-        """Required transport encryption rejects non-TCP transports."""
+    async def test_local_provisioner_pre_launch_generates_curve_keys_over_ipc(self, tmp_path):
+        """Curve keys are provisioned over the ipc transport too (not just tcp)."""
         km = AsyncKernelManager(connection_file=str(tmp_path / "kernel.json"))
         km._kernel_spec = KernelSpec(
             resource_dir="test",
@@ -334,8 +332,14 @@ class TestRuntime:
         )
         km.transport = "ipc"
         km.transport_encryption = "required"
-        with pytest.raises(RuntimeError, match="transport='tcp'"):
-            await km._async_pre_start_kernel()
+        await km._async_pre_start_kernel()
+        assert isinstance(km.provisioner, LocalProvisioner)
+
+        await km.provisioner.pre_launch()
+
+        assert km.provisioner.connection_info["transport"] == "ipc"
+        assert km.provisioner.connection_info["curve_publickey"] is not None
+        assert km.provisioner.connection_info["curve_secretkey"] is not None
 
     async def test_existing(self, kpf, akm):
         await self.akm_test(akm)

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -4,6 +4,9 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+import os
+import shutil
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -16,6 +19,19 @@ from jupyter_client.client import KernelClient
 from jupyter_client.connect import ConnectionFileMixin
 from jupyter_client.kernelspec import KernelSpec, KernelSpecManager
 from jupyter_client.session import Session
+
+from .utils import skip_win32
+
+
+def _short_ipc_dir():
+    """A short directory for ipc sockets.
+
+    IPC socket paths must stay under the ``sun_path`` limit (~104 chars). The
+    platform temp dir is too long on macOS (``/var/folders/...``), so anchor
+    sockets under ``/tmp``, which is short on the POSIX platforms where the
+    ipc transport is supported.
+    """
+    return tempfile.mkdtemp(prefix="jc-ipc-", dir="/tmp")
 
 
 @pytest.mark.parametrize(
@@ -216,16 +232,18 @@ def test_required_without_curve_kernelspec_over_ipc_raises(tmp_path):
     km.context.term()
 
 
-def test_connect_shell_to_curve_server_over_ipc_succeeds(tmp_path):
+@skip_win32
+def test_connect_shell_to_curve_server_over_ipc_succeeds():
     """End-to-end: an authenticated client reaches a CurveZMQ server over the IPC transport."""
     pub, sec = zmq.curve_keypair()
 
+    ipc_dir = _short_ipc_dir()
     ctx = zmq.Context()
     server = ctx.socket(zmq.ROUTER)
     server.curve_secretkey = sec
     server.curve_publickey = pub
     server.curve_server = True
-    ip = str(tmp_path / "kernel")
+    ip = os.path.join(ipc_dir, "k")
     port = 1
     server.bind(f"ipc://{ip}-{port}")  # matches ConnectionFileMixin._make_url for ipc
 
@@ -258,18 +276,21 @@ def test_connect_shell_to_curve_server_over_ipc_succeeds(tmp_path):
     finally:
         server.close(linger=0)
         ctx.term()
+        shutil.rmtree(ipc_dir, ignore_errors=True)
 
 
-def test_connect_shell_to_curve_server_over_ipc_without_keys_is_rejected(tmp_path):
+@skip_win32
+def test_connect_shell_to_curve_server_over_ipc_without_keys_is_rejected():
     """End-to-end: over IPC, an unauthenticated client is dropped by the CurveZMQ server."""
     pub, sec = zmq.curve_keypair()
 
+    ipc_dir = _short_ipc_dir()
     ctx = zmq.Context()
     server = ctx.socket(zmq.ROUTER)
     server.curve_secretkey = sec
     server.curve_publickey = pub
     server.curve_server = True
-    ip = str(tmp_path / "kernel")
+    ip = os.path.join(ipc_dir, "k")
     port = 1
     server.bind(f"ipc://{ip}-{port}")
 
@@ -299,6 +320,7 @@ def test_connect_shell_to_curve_server_over_ipc_without_keys_is_rejected(tmp_pat
     finally:
         server.close(linger=0)
         ctx.term()
+        shutil.rmtree(ipc_dir, ignore_errors=True)
 
 
 def test_curve_keys_reused_across_restart(tmp_path):

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -136,7 +136,7 @@ def test_transport_encryption_disabled_does_not_require_curve():
         assert km.transport_encryption == "disabled"
 
 
-def _make_km(tmp_path, *, supported_encryption, transport_encryption):
+def _make_km(tmp_path, *, supported_encryption, transport_encryption, transport="tcp"):
     """Helper: build a KernelManager with a kernelspec whose metadata is set directly."""
     metadata = (
         {} if supported_encryption is None else {"supported_encryption": supported_encryption}
@@ -150,6 +150,7 @@ def _make_km(tmp_path, *, supported_encryption, transport_encryption):
         metadata=metadata,
     )
     km.cache_ports = False
+    km.transport = transport
     km.transport_encryption = transport_encryption
     return km
 
@@ -182,6 +183,122 @@ def test_required_without_curve_kernelspec_raises(tmp_path):
     with pytest.raises(RuntimeError, match=r"metadata\.supported_encryption"):
         km.pre_start_kernel()
     km.context.term()
+
+
+@pytest.mark.parametrize("transport_encryption", ["auto", "required"])
+def test_provisions_keys_over_ipc(transport_encryption, tmp_path):
+    """CurveZMQ keys are provisioned for the IPC transport too, not just TCP."""
+    km = _make_km(
+        tmp_path,
+        supported_encryption="curve",
+        transport_encryption=transport_encryption,
+        transport="ipc",
+    )
+    km.pre_start_kernel()  # must not raise for either policy over ipc
+    info = km.get_connection_info()
+    assert info["transport"] == "ipc"
+    assert "curve_publickey" in info
+    assert "curve_secretkey" in info
+    km.cleanup_connection_file()
+    km.context.term()
+
+
+def test_required_without_curve_kernelspec_over_ipc_raises(tmp_path):
+    """Over IPC, 'required' still refuses a kernelspec that does not declare curve support."""
+    km = _make_km(
+        tmp_path,
+        supported_encryption=None,
+        transport_encryption="required",
+        transport="ipc",
+    )
+    with pytest.raises(RuntimeError, match=r"metadata\.supported_encryption"):
+        km.pre_start_kernel()
+    km.context.term()
+
+
+def test_connect_shell_to_curve_server_over_ipc_succeeds(tmp_path):
+    """End-to-end: an authenticated client reaches a CurveZMQ server over the IPC transport."""
+    pub, sec = zmq.curve_keypair()
+
+    ctx = zmq.Context()
+    server = ctx.socket(zmq.ROUTER)
+    server.curve_secretkey = sec
+    server.curve_publickey = pub
+    server.curve_server = True
+    ip = str(tmp_path / "kernel")
+    port = 1
+    server.bind(f"ipc://{ip}-{port}")  # matches ConnectionFileMixin._make_url for ipc
+
+    try:
+        info = {
+            "ip": ip,
+            "transport": "ipc",
+            "shell_port": port,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+            "curve_publickey": pub.decode("ascii"),
+            "curve_secretkey": sec.decode("ascii"),
+        }
+        mixin = ConnectionFileMixin()
+        mixin.context = ctx
+        mixin.load_connection_info(info)
+
+        client_sock = mixin.connect_shell()
+        try:
+            client_sock.send(b"probe", flags=zmq.NOBLOCK)
+            poller = zmq.Poller()
+            poller.register(server, zmq.POLLIN)
+            events = dict(poller.poll(timeout=1000))
+            assert server in events, (
+                "Authenticated client over ipc was not received - "
+                "Curve encryption did not work over the ipc transport"
+            )
+        finally:
+            client_sock.close(linger=0)
+    finally:
+        server.close(linger=0)
+        ctx.term()
+
+
+def test_connect_shell_to_curve_server_over_ipc_without_keys_is_rejected(tmp_path):
+    """End-to-end: over IPC, an unauthenticated client is dropped by the CurveZMQ server."""
+    pub, sec = zmq.curve_keypair()
+
+    ctx = zmq.Context()
+    server = ctx.socket(zmq.ROUTER)
+    server.curve_secretkey = sec
+    server.curve_publickey = pub
+    server.curve_server = True
+    ip = str(tmp_path / "kernel")
+    port = 1
+    server.bind(f"ipc://{ip}-{port}")
+
+    try:
+        info = {
+            "ip": ip,
+            "transport": "ipc",
+            "shell_port": port,
+            "key": "abc123",
+            "signature_scheme": "hmac-sha256",
+        }
+        mixin = ConnectionFileMixin()
+        mixin.context = ctx
+        mixin.load_connection_info(info)
+
+        client_sock = mixin.connect_shell()
+        try:
+            client_sock.send(b"probe", flags=zmq.NOBLOCK)
+            poller = zmq.Poller()
+            poller.register(server, zmq.POLLIN)
+            events = dict(poller.poll(timeout=300))
+            assert server not in events, (
+                "Unauthenticated message reached Curve server over ipc - expected drop"
+            )
+        finally:
+            client_sock.close(linger=0)
+    finally:
+        server.close(linger=0)
+        ctx.term()
 
 
 def test_curve_keys_reused_across_restart(tmp_path):


### PR DESCRIPTION
Previously key generation was gated on transport == 'tcp' and transport_encryption='required' over IPC raised; IPC is now supported, aligning with the latest state of the JEP https://github.com/jupyter/enhancement-proposals/pull/145