### PR TITLE
Align `supported_encryption` format with JEP in docs

### DIFF
--- a/docs/kernels.rst
+++ b/docs/kernels.rst
@@ -230,10 +230,11 @@ JSON serialised dictionary containing the following keys and values:
   here should be namespaced for the tool reading and writing that metadata.
   The following key is recognised by ``jupyter_client`` itself:
 
-  - **supported_encryption** (optional): Set to ``"curve"`` to declare that
-    this kernel can handle CurveZMQ keys in its connection file. Required
-    when ``KernelManager.transport_encryption`` is ``'required'``, and used
-    as a gate when it is ``'auto'``. See :ref:`security` for details.
+  - **supported_encryption** (optional): A list of the encryption schemes the
+    kernel can handle, e.g. ``["curve"]``, declaring that it can use CurveZMQ
+    keys from its connection file. Required when
+    ``KernelManager.transport_encryption`` is ``'required'``, and used as a
+    gate when it is ``'auto'``. See :ref:`security` for details.
 - **kernel_protocol_version** (optional): A string indicating which version of the
   kernel protocol the kernel supports.
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -47,13 +47,13 @@ Transport encryption is controlled by the
 
 ``'auto'``
     Keys are generated **only when the kernelspec declares support** via
-    ``metadata.supported_encryption: 'curve'``. Kernelspecs that do not
+    ``metadata.supported_encryption: ['curve']``. Kernelspecs that do not
     declare this field are started without encryption, so the setting is safe
     to enable globally without breaking existing kernels.
 
 ``'required'``
     Keys are always generated. Startup fails with a :exc:`RuntimeError` if
-    the kernelspec does not declare ``metadata.supported_encryption: 'curve'``,
+    the kernelspec does not declare ``metadata.supported_encryption: ['curve']``,
     so kernels that have not been updated to handle the connection-file keys
     are never started unencrypted.
 
@@ -84,7 +84,7 @@ A kernel must declare CurveZMQ support in its ``kernel.json`` before the
         "display_name": "Python 3",
         "language": "python",
         "metadata": {
-            "supported_encryption": "curve"
+            "supported_encryption": ["curve"]
         }
     }
 

--- a/jupyter_client/manager.py
+++ b/jupyter_client/manager.py
@@ -476,7 +476,7 @@ class KernelManager(ConnectionFileMixin):
         ):
             msg = (
                 "transport_encryption='required' but kernelspec does not declare "
-                "metadata.supported_encryption='curve'."
+                "'curve' in `metadata.supported_encryption`."
             )
             raise RuntimeError(msg)
         if self.provisioner is None:  # will not be None on restarts


### PR DESCRIPTION
Same as https://github.com/ipython/ipykernel/pull/1528 to align with the latest state in https://github.com/jupyter/enhancement-proposals/pull/145