### PR TITLE
Add @default decorator to KernelClient and AsyncKernelClient

### DIFF
--- a/jupyter_client/asynchronous/client.py
+++ b/jupyter_client/asynchronous/client.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import typing as t
 
 import zmq.asyncio
-from traitlets import Instance, Type
+from traitlets import Instance, Type, default
 
 from ..channels import AsyncZMQSocketChannel, HBChannel
 from ..client import KernelClient, reqrep
@@ -36,6 +36,7 @@ class AsyncKernelClient(KernelClient):
 
     context = Instance(zmq.asyncio.Context)  # type:ignore[assignment]
 
+    @default("context")
     def _context_default(self) -> zmq.asyncio.Context:
         self._created_context = True
         return zmq.asyncio.Context()

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -13,7 +13,7 @@ from queue import Empty
 
 import zmq.asyncio
 from jupyter_core.utils import ensure_async
-from traitlets import Any, Bool, Instance, Type
+from traitlets import Any, Bool, Instance, Type, default
 
 from .channels import major_protocol_version
 from .channelsabc import ChannelABC, HBChannelABC
@@ -93,6 +93,7 @@ class KernelClient(ConnectionFileMixin):
 
     _created_context = Bool(False)
 
+    @default("context")
     def _context_default(self) -> zmq.Context:
         self._created_context = True
         return zmq.Context()


### PR DESCRIPTION
## Description

The `_context_default` methods on `KernelClient` and `AsyncKernelClient` still use the old-style magic method pattern for default trait values. This replaces them with the newer `@default` decorator pattern, consistent with `MultiKernelManager` and `KernelManager`.

The functional behavior is unchanged — the old magic method pattern remains fully supported — but using the decorator is the modern, recommended approach.

## Changes

- `jupyter_client/client.py`: Added `@default("context")` decorator and import
- `jupyter_client/asynchronous/client.py`: Added `@default("context")` decorator and import

Fixes #1065

---

Payment: PayPal n6085530@gmail.com