### PR TITLE
DOC: document execute_result transient field

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -1698,11 +1698,12 @@ Message type: ``execute_result``::
         # (for prompt N).
         'execution_count' : int,
 
-        # data and metadata are identical to a display_data message.
+        # data, metadata, and transient are identical to a display_data message.
         # the object being displayed is that passed to the display hook,
         # i.e. the *result* of the execution.
         'data' : dict,
         'metadata' : dict,
+        'transient' : dict,
     }
 
 Execution errors


### PR DESCRIPTION
## Summary

- add the optional `transient` mapping to the `execute_result` message schema
- update the schema comment to reflect its parity with `display_data`

## Validation

CI is the source of truth per project guidance. A full local documentation environment was unavailable because task-owned dependency provisioning timed out; no local test-passing claim is made.

Closes #305.

## Disclosure

This change was prepared with AI-assisted automation under explicit human authorization. 🤖 🍆
