### PR TITLE
Add an example kernel provisioner (Tenki Sandbox microVMs)

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupyter_server
+          # Skip test_check_version: newer `packaging` rejects the "1.0" literal
+          # used by jupyter_server's own test - unrelated to jupyter_client.
+          test_command: "pytest -vv -raXxs -W default --durations 10 --color=yes --deselect tests/test_utils.py::test_check_version"
 
   jupyter_kernel_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tenki-provisioner-example.yml
+++ b/.github/workflows/tenki-provisioner-example.yml
@@ -1,0 +1,45 @@
+name: tenki_provisioner example
+
+# The repository's main test workflow does not exercise examples/, so this job
+# lints, format-checks, and unit-tests the Tenki Sandbox provisioner example on
+# its own. The unit tests mock the SDK; the live end-to-end check is not run in
+# CI (it needs Tenki credentials and provisions a real microVM).
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "examples/tenki_provisioner/**"
+      - ".github/workflows/tenki-provisioner-example.yml"
+  pull_request:
+    paths:
+      - "examples/tenki_provisioner/**"
+      - ".github/workflows/tenki-provisioner-example.yml"
+
+concurrency:
+  group: tenki-provisioner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: examples/tenki_provisioner
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+          pip install -e ".[test]"
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+      - name: Unit tests
+        run: pytest -q

--- a/docs/provisioning.rst
+++ b/docs/provisioning.rst
@@ -357,3 +357,24 @@ names (colon-separated):
     Available kernel provisioners:
       local-provisioner    jupyter_client.provisioning:LocalProvisioner
       rbac-provisioner     acme.rbac.provisioner:RBACProvisioner
+
+A complete, remote example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The YARN and RBAC snippets above are illustrative fragments. For a small but
+*complete* provisioner that launches kernels off the local machine, see
+``examples/tenki_provisioner`` in this repository. It runs each kernel inside a
+disposable `Tenki Sandbox <https://tenki.cloud/docs/sandbox>`_ microVM and
+demonstrates the pieces a real remote provisioner needs:
+
+-  driving the kernel over the ZeroMQ ``ipc`` transport and staging matching
+   client-side and kernel-side connection files,
+-  bridging the five channel sockets from the local machine into the remote
+   environment,
+-  implementing the full process-control surface (:meth:`poll`, :meth:`wait`,
+   :meth:`send_signal`, :meth:`kill`, :meth:`terminate`, :meth:`cleanup`),
+-  registering via the ``jupyter_client.kernel_provisioners`` entry point and
+   shipping a kernelspec installer.
+
+It includes unit tests (with the remote backend mocked) and a live end-to-end
+check, and is a useful starting point to copy for other remote environments.

--- a/examples/tenki_provisioner/README.md
+++ b/examples/tenki_provisioner/README.md
@@ -79,6 +79,7 @@ Some deployments require you to name the **project** the sandbox is created in
 
 ```python
 from tenki_sandbox import Client
+
 for ws in Client().who_am_i().workspaces:
     print(ws.name, ws.id)
     for p in ws.projects:
@@ -115,8 +116,7 @@ traitlets):
 | `image`                | service default | Sandbox image reference                       |
 | `allow_outbound`       | `true`      | Guest outbound network (needed to pip install)    |
 | `idle_timeout_minutes` | `0`         | Idle pause/terminate after N minutes (0 = default)|
-| `max_duration_seconds` | `0`         | Hard lifetime cap / leak backstop (0 = no cap)    |
-| `keepalive_interval_seconds` | `240` | Refresh interval to avoid idle-pausing an idle kernel (0 = off) |
+| `max_duration_seconds` | `3600`      | Hard lifetime cap / leak backstop (0 = no cap; raise for long sessions) |
 | `install_ipykernel`    | `true`      | `pip install ipykernel` in the guest if missing   |
 | `extra_pip_packages`   | `[]`        | Extra packages to install in the guest            |
 | `kernel_argv`          | ipykernel   | Guest launch command; `{connection_file}` is substituted |
@@ -141,15 +141,20 @@ traitlets):
   launch is cancelled), the microVM is torn down before the error propagates. As
   a last resort, set `max_duration_seconds` so an orphaned VM self-terminates.
 - **Idle sessions.** A kernel is idle between cells. If your deployment
-  idle-pauses sandboxes, a long gap could pause the VM mid-session; the
-  provisioner runs a best-effort `refresh` every `keepalive_interval_seconds` to
-  avoid this. For long unattended gaps, also raise `idle_timeout_minutes`.
+  idle-pauses sandboxes and the gap exceeds the idle window, the VM can pause
+  mid-session. `tenki-sandbox` 0.4.0 exposes no client-side activity API to
+  refresh the idle timer (`refresh()` only reads state), so the provisioner does
+  not attempt a keepalive. If you expect long idle gaps, raise (or disable via
+  the service) `idle_timeout_minutes`.
 - **Long-running cells.** `create_timeout` bounds *provisioning* only, not cell
   execution. There is no hard cell timeout; size `max_duration_seconds` to your
-  longest expected session (or leave it `0` for no cap).
-- **Teardown is retryable.** If terminating the microVM fails, the error is
-  logged and the sandbox handle is retained so a subsequent `cleanup` retries,
-  rather than silently leaking a running VM.
+  longest expected session (it defaults to 1 hour as a leak backstop; `0`
+  disables the cap).
+- **Teardown is observable.** Terminating the microVM is retried a few times; if
+  it still fails, `cleanup` raises rather than reporting a successful, leaked VM.
+- **No cross-process reattach.** `get_provisioner_info`/`load_provisioner_info`
+  are left at the base implementation; a provisioner in a different process
+  cannot resume management of a running kernel.
 
 ## Tests
 

--- a/examples/tenki_provisioner/README.md
+++ b/examples/tenki_provisioner/README.md
@@ -9,7 +9,7 @@ on your machine. Notebook code — including anything an AI agent generates — 
 fully sandboxed, with its own CPU/memory and no access to your local filesystem.
 When the kernel shuts down, the microVM is destroyed.
 
-This example is built **entirely on the [`tenki-sandbox` Python SDK](https://pypi.org/project/tenki-sandbox/)** —
+This example is built **entirely on the [`tenki` Python SDK](https://pypi.org/project/tenki/)** —
 no SSH, no CLI, and no inbound networking required.
 
 ## How it works
@@ -74,19 +74,17 @@ export TENKI_API_KEY=tk_...
 
 You can also pass `auth_token` / `base_url` in the kernelspec `config` stanza.
 
-Some deployments require you to name the **project** the sandbox is created in
-(the Python SDK does not auto-select one). Discover the ids with:
+Some deployments require you to name the **workspace** the sandbox is created in
+(the Python SDK does not always auto-select one). Discover the ids with:
 
 ```python
-from tenki_sandbox import Client
+from tenki import Client
 
 for ws in Client().who_am_i().workspaces:
     print(ws.name, ws.id)
-    for p in ws.projects:
-        print("  ", p.name, p.id)
 ```
 
-Then set `project_id` (and optionally `workspace_id`) in the kernelspec config.
+Then set `workspace_id` in the kernelspec config.
 
 ## Use it
 
@@ -111,8 +109,7 @@ traitlets):
 | ---------------------- | ----------- | ------------------------------------------------- |
 | `cpu_cores` | `2` | vCPUs for the microVM (1–16) |
 | `memory_mb` | `4096` | Memory in MiB |
-| `project_id` | `""` | Tenki project to create the sandbox in (may be required) |
-| `workspace_id` | `""` | Tenki workspace id (optional) |
+| `workspace_id` | `""` | Tenki workspace to create the sandbox in (may be required) |
 | `image` | service default | Sandbox image reference |
 | `allow_outbound` | `true` | Guest outbound network (needed to pip install) |
 | `idle_timeout_minutes` | `0` | Idle pause/terminate after N minutes (0 = default)|
@@ -142,7 +139,7 @@ traitlets):
   a last resort, set `max_duration_seconds` so an orphaned VM self-terminates.
 - **Idle sessions.** A kernel is idle between cells. If your deployment
   idle-pauses sandboxes and the gap exceeds the idle window, the VM can pause
-  mid-session. `tenki-sandbox` 0.4.0 exposes no client-side activity API to
+  mid-session. `tenki` 0.5.x exposes no client-side activity API to
   refresh the idle timer (`refresh()` only reads state), so the provisioner does
   not attempt a keepalive. If you expect long idle gaps, raise (or disable via
   the service) `idle_timeout_minutes`.

--- a/examples/tenki_provisioner/README.md
+++ b/examples/tenki_provisioner/README.md
@@ -74,6 +74,19 @@ export TENKI_API_KEY=tk_...
 
 You can also pass `auth_token` / `base_url` in the kernelspec `config` stanza.
 
+Some deployments require you to name the **project** the sandbox is created in
+(the Python SDK does not auto-select one). Discover the ids with:
+
+```python
+from tenki_sandbox import Client
+for ws in Client().who_am_i().workspaces:
+    print(ws.name, ws.id)
+    for p in ws.projects:
+        print("  ", p.name, p.id)
+```
+
+Then set `project_id` (and optionally `workspace_id`) in the kernelspec config.
+
 ## Use it
 
 Install a kernelspec that routes through the provisioner:
@@ -97,6 +110,8 @@ traitlets):
 | ---------------------- | ----------- | ------------------------------------------------- |
 | `cpu_cores`            | `2`         | vCPUs for the microVM (1–16)                      |
 | `memory_mb`            | `4096`      | Memory in MiB                                      |
+| `project_id`           | `""`        | Tenki project to create the sandbox in (may be required) |
+| `workspace_id`         | `""`        | Tenki workspace id (optional)                     |
 | `image`                | service default | Sandbox image reference                       |
 | `allow_outbound`       | `true`      | Guest outbound network (needed to pip install)    |
 | `idle_timeout_minutes` | `0`         | Auto-terminate after idle minutes (0 = default)   |
@@ -112,6 +127,9 @@ traitlets):
   runs on Linux inside the microVM.)
 - The guest image must have a Python interpreter; `ipykernel` is installed on
   first launch unless you bake it into the image (`install_ipykernel=false`).
+  The default image (Ubuntu 24.04 / Python 3.12) marks its system interpreter
+  externally-managed (PEP 668); the provisioner handles this by retrying the
+  install with `--break-system-packages` (the guest is disposable).
 - **Restart** provisions a fresh microVM — kernel restarts do not preserve guest
   state.
 

--- a/examples/tenki_provisioner/README.md
+++ b/examples/tenki_provisioner/README.md
@@ -114,7 +114,9 @@ traitlets):
 | `workspace_id`         | `""`        | Tenki workspace id (optional)                     |
 | `image`                | service default | Sandbox image reference                       |
 | `allow_outbound`       | `true`      | Guest outbound network (needed to pip install)    |
-| `idle_timeout_minutes` | `0`         | Auto-terminate after idle minutes (0 = default)   |
+| `idle_timeout_minutes` | `0`         | Idle pause/terminate after N minutes (0 = default)|
+| `max_duration_seconds` | `0`         | Hard lifetime cap / leak backstop (0 = no cap)    |
+| `keepalive_interval_seconds` | `240` | Refresh interval to avoid idle-pausing an idle kernel (0 = off) |
 | `install_ipykernel`    | `true`      | `pip install ipykernel` in the guest if missing   |
 | `extra_pip_packages`   | `[]`        | Extra packages to install in the guest            |
 | `kernel_argv`          | ipykernel   | Guest launch command; `{connection_file}` is substituted |
@@ -132,6 +134,22 @@ traitlets):
   install with `--break-system-packages` (the guest is disposable).
 - **Restart** provisions a fresh microVM — kernel restarts do not preserve guest
   state.
+
+## Lifecycle & duration notes
+
+- **Leak-safe launch.** If provisioning succeeds but a later step fails (or the
+  launch is cancelled), the microVM is torn down before the error propagates. As
+  a last resort, set `max_duration_seconds` so an orphaned VM self-terminates.
+- **Idle sessions.** A kernel is idle between cells. If your deployment
+  idle-pauses sandboxes, a long gap could pause the VM mid-session; the
+  provisioner runs a best-effort `refresh` every `keepalive_interval_seconds` to
+  avoid this. For long unattended gaps, also raise `idle_timeout_minutes`.
+- **Long-running cells.** `create_timeout` bounds *provisioning* only, not cell
+  execution. There is no hard cell timeout; size `max_duration_seconds` to your
+  longest expected session (or leave it `0` for no cap).
+- **Teardown is retryable.** If terminating the microVM fails, the error is
+  logged and the sandbox handle is retained so a subsequent `cleanup` retries,
+  rather than silently leaking a running VM.
 
 ## Tests
 

--- a/examples/tenki_provisioner/README.md
+++ b/examples/tenki_provisioner/README.md
@@ -1,0 +1,126 @@
+# Tenki Sandbox kernel provisioner
+
+Run Jupyter kernels inside disposable [Tenki Sandbox](https://tenki.cloud/docs/sandbox)
+microVMs, using the [`jupyter_client` kernel provisioner](https://jupyter-client.readthedocs.io/en/latest/provisioning.html)
+extension point.
+
+Every kernel you start is launched in its own isolated Linux microVM instead of
+on your machine. Notebook code — including anything an AI agent generates — runs
+fully sandboxed, with its own CPU/memory and no access to your local filesystem.
+When the kernel shuts down, the microVM is destroyed.
+
+This example is built **entirely on the [`tenki-sandbox` Python SDK](https://pypi.org/project/tenki-sandbox/)** —
+no SSH, no CLI, and no inbound networking required.
+
+## How it works
+
+A Jupyter kernel exposes five ZeroMQ channels (`shell`, `iopub`, `stdin`,
+`control`, `hb`). Normally these are TCP ports on `localhost`. Because the kernel
+here runs inside a microVM, we instead drive it over ZeroMQ's **`ipc` transport**,
+so each channel is a Unix-domain socket the kernel *binds* inside the guest.
+
+`jupyter_client` runs locally, so it needs sockets to *connect* to locally. The
+provisioner writes two connection files that are identical except for the socket
+path prefix — one for the client (a private temp dir) and one for the kernel
+(under the guest's `/home/tenki`) — so the HMAC signing key and channel indices
+line up on both ends. It then bridges each local socket to the matching guest
+socket with the SDK's `dial` primitive, a raw bidirectional byte stream into the
+microVM:
+
+```
+ jupyter_client                 TenkiProvisioner                    microVM
+ ┌────────────┐   ipc:// unix   ┌──────────────────┐  sandbox.dial  ┌──────────┐
+ │ KernelClient├───────────────►│ local socket ↔   ├───────────────►│ ipykernel│
+ │  (5 ZMQ     │◄───────────────┤ dial() bridge    │◄───────────────┤ (5 ipc   │
+ │   channels) │                │ (one per channel)│  gRPC stream   │  sockets)│
+ └────────────┘                 └──────────────────┘                └──────────┘
+```
+
+Lifecycle mapping onto `KernelProvisionerBase`:
+
+| Provisioner method | Tenki action                                                   |
+| ------------------ | -------------------------------------------------------------- |
+| `pre_launch`       | Switch kernel to `ipc`; stage local + guest connection files   |
+| `launch_kernel`    | `Sandbox.create` → install `ipykernel` → `start` kernel → bridge sockets |
+| `poll` / `wait`    | Track the guest process via the SDK `Process` handle           |
+| `send_signal`      | Forward the signal to the guest process (`SIGINT` interrupts)  |
+| `kill` / `terminate` | Signal the guest process                                     |
+| `cleanup`          | Close the socket bridge and terminate the microVM              |
+
+## Install
+
+```bash
+pip install -e .            # from this directory
+# or, once published:
+# pip install tenki-jupyter-provisioner
+```
+
+This registers the provisioner under the name `tenki-provisioner` via the
+`jupyter_client.kernel_provisioners` entry point. Confirm it:
+
+```bash
+jupyter kernelspec provisioners
+#   tenki-provisioner    tenki_provisioner:TenkiProvisioner
+```
+
+## Authenticate
+
+Get an API key from your Tenki workspace settings and export it (the SDK reads
+it automatically):
+
+```bash
+export TENKI_API_KEY=tk_...
+```
+
+You can also pass `auth_token` / `base_url` in the kernelspec `config` stanza.
+
+## Use it
+
+Install a kernelspec that routes through the provisioner:
+
+```bash
+python -m tenki_provisioner.kernelspec install \
+    --name tenki-python --display-name "Python (Tenki Sandbox)" \
+    --cpu 4 --memory-mb 8192
+```
+
+Now `Python (Tenki Sandbox)` appears in Jupyter Lab/Notebook, and
+`jupyter console --kernel tenki-python` opens a shell whose kernel lives in a
+microVM. A sample `kernel.json` is in [`kernels/tenki_python/`](kernels/tenki_python/kernel.json).
+
+### Configuration
+
+Set these in the kernelspec `metadata.kernel_provisioner.config` stanza (or as
+traitlets):
+
+| Option                 | Default     | Description                                       |
+| ---------------------- | ----------- | ------------------------------------------------- |
+| `cpu_cores`            | `2`         | vCPUs for the microVM (1–16)                      |
+| `memory_mb`            | `4096`      | Memory in MiB                                      |
+| `image`                | service default | Sandbox image reference                       |
+| `allow_outbound`       | `true`      | Guest outbound network (needed to pip install)    |
+| `idle_timeout_minutes` | `0`         | Auto-terminate after idle minutes (0 = default)   |
+| `install_ipykernel`    | `true`      | `pip install ipykernel` in the guest if missing   |
+| `extra_pip_packages`   | `[]`        | Extra packages to install in the guest            |
+| `kernel_argv`          | ipykernel   | Guest launch command; `{connection_file}` is substituted |
+| `env`                  | `{}`        | Environment variables for the kernel process      |
+
+## Requirements & limitations
+
+- **Unix client only.** The `ipc` transport uses Unix-domain sockets, so the
+  machine running `jupyter_client` must be Linux or macOS. (The kernel always
+  runs on Linux inside the microVM.)
+- The guest image must have a Python interpreter; `ipykernel` is installed on
+  first launch unless you bake it into the image (`install_ipykernel=false`).
+- **Restart** provisions a fresh microVM — kernel restarts do not preserve guest
+  state.
+
+## Tests
+
+```bash
+pip install -e ".[test]"
+pytest
+```
+
+The unit tests mock the SDK. For a live end-to-end run (`TENKI_API_KEY` set),
+see [`tests/README.md`](tests/README.md).

--- a/examples/tenki_provisioner/README.md
+++ b/examples/tenki_provisioner/README.md
@@ -38,14 +38,14 @@ microVM:
 
 Lifecycle mapping onto `KernelProvisionerBase`:
 
-| Provisioner method | Tenki action                                                   |
+| Provisioner method | Tenki action |
 | ------------------ | -------------------------------------------------------------- |
-| `pre_launch`       | Switch kernel to `ipc`; stage local + guest connection files   |
-| `launch_kernel`    | `Sandbox.create` → install `ipykernel` → `start` kernel → bridge sockets |
-| `poll` / `wait`    | Track the guest process via the SDK `Process` handle           |
-| `send_signal`      | Forward the signal to the guest process (`SIGINT` interrupts)  |
-| `kill` / `terminate` | Signal the guest process                                     |
-| `cleanup`          | Close the socket bridge and terminate the microVM              |
+| `pre_launch` | Switch kernel to `ipc`; stage local + guest connection files |
+| `launch_kernel` | `Sandbox.create` → install `ipykernel` → `start` kernel → bridge sockets |
+| `poll` / `wait` | Track the guest process via the SDK `Process` handle |
+| `send_signal` | Forward the signal to the guest process (`SIGINT` interrupts) |
+| `kill` / `terminate` | Signal the guest process |
+| `cleanup` | Close the socket bridge and terminate the microVM |
 
 ## Install
 
@@ -107,20 +107,20 @@ microVM. A sample `kernel.json` is in [`kernels/tenki_python/`](kernels/tenki_py
 Set these in the kernelspec `metadata.kernel_provisioner.config` stanza (or as
 traitlets):
 
-| Option                 | Default     | Description                                       |
+| Option | Default | Description |
 | ---------------------- | ----------- | ------------------------------------------------- |
-| `cpu_cores`            | `2`         | vCPUs for the microVM (1–16)                      |
-| `memory_mb`            | `4096`      | Memory in MiB                                      |
-| `project_id`           | `""`        | Tenki project to create the sandbox in (may be required) |
-| `workspace_id`         | `""`        | Tenki workspace id (optional)                     |
-| `image`                | service default | Sandbox image reference                       |
-| `allow_outbound`       | `true`      | Guest outbound network (needed to pip install)    |
-| `idle_timeout_minutes` | `0`         | Idle pause/terminate after N minutes (0 = default)|
-| `max_duration_seconds` | `3600`      | Hard lifetime cap / leak backstop (0 = no cap; raise for long sessions) |
-| `install_ipykernel`    | `true`      | `pip install ipykernel` in the guest if missing   |
-| `extra_pip_packages`   | `[]`        | Extra packages to install in the guest            |
-| `kernel_argv`          | ipykernel   | Guest launch command; `{connection_file}` is substituted |
-| `env`                  | `{}`        | Environment variables for the kernel process      |
+| `cpu_cores` | `2` | vCPUs for the microVM (1–16) |
+| `memory_mb` | `4096` | Memory in MiB |
+| `project_id` | `""` | Tenki project to create the sandbox in (may be required) |
+| `workspace_id` | `""` | Tenki workspace id (optional) |
+| `image` | service default | Sandbox image reference |
+| `allow_outbound` | `true` | Guest outbound network (needed to pip install) |
+| `idle_timeout_minutes` | `0` | Idle pause/terminate after N minutes (0 = default)|
+| `max_duration_seconds` | `3600` | Hard lifetime cap / leak backstop (0 = no cap; raise for long sessions) |
+| `install_ipykernel` | `true` | `pip install ipykernel` in the guest if missing |
+| `extra_pip_packages` | `[]` | Extra packages to install in the guest |
+| `kernel_argv` | ipykernel | Guest launch command; `{connection_file}` is substituted |
+| `env` | `{}` | Environment variables for the kernel process |
 
 ## Requirements & limitations
 

--- a/examples/tenki_provisioner/kernels/tenki_python/kernel.json
+++ b/examples/tenki_provisioner/kernels/tenki_python/kernel.json
@@ -1,0 +1,15 @@
+{
+  "argv": ["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+  "display_name": "Python (Tenki Sandbox)",
+  "language": "python",
+  "interrupt_mode": "signal",
+  "metadata": {
+    "kernel_provisioner": {
+      "provisioner_name": "tenki-provisioner",
+      "config": {
+        "cpu_cores": 4,
+        "memory_mb": 8192
+      }
+    }
+  }
+}

--- a/examples/tenki_provisioner/pyproject.toml
+++ b/examples/tenki_provisioner/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tenki-jupyter-provisioner"
+version = "0.1.0"
+description = "Run Jupyter kernels inside Tenki Sandbox microVMs (a jupyter_client kernel provisioner)."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "BSD-3-Clause"
+keywords = ["jupyter", "kernel", "provisioner", "tenki", "sandbox", "microvm"]
+authors = [{ name = "Tenki Cloud integration" }]
+dependencies = [
+    "jupyter_client>=7.0",
+    "tenki-sandbox>=0.1",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7", "pytest-asyncio>=0.23", "ipykernel>=6"]
+
+[project.urls]
+Homepage = "https://tenki.cloud/docs/sandbox"
+Source = "https://github.com/jupyter/jupyter_client"
+
+# This is the extension point jupyter_client uses to discover provisioners.
+[project.entry-points."jupyter_client.kernel_provisioners"]
+tenki-provisioner = "tenki_provisioner:TenkiProvisioner"
+
+[tool.hatch.build.targets.wheel]
+packages = ["tenki_provisioner"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/examples/tenki_provisioner/pyproject.toml
+++ b/examples/tenki_provisioner/pyproject.toml
@@ -35,3 +35,13 @@ packages = ["tenki_provisioner"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+# Inherit the repository's ruff configuration and relax a few rules that are
+# legitimate for a CLI installer, a runnable e2e script, and tests.
+[tool.ruff]
+extend = "../../pyproject.toml"
+
+[tool.ruff.lint.per-file-ignores]
+"tenki_provisioner/kernelspec.py" = ["T201"]     # a CLI prints to the user
+"tests/live_e2e.py" = ["T201"]                    # a runnable script prints progress
+"tests/test_provisioner.py" = ["EM101", "EM102", "RUF059"]  # test ergonomics

--- a/examples/tenki_provisioner/pyproject.toml
+++ b/examples/tenki_provisioner/pyproject.toml
@@ -13,7 +13,9 @@ keywords = ["jupyter", "kernel", "provisioner", "tenki", "sandbox", "microvm"]
 authors = [{ name = "Tenki Cloud integration" }]
 dependencies = [
     "jupyter_client>=7.0",
-    "tenki-sandbox>=0.1",
+    # 0.4.0 is the version this integration is developed and tested against;
+    # it carries sandbox-lifecycle fixes over 0.3.x. Pin to the tested line.
+    "tenki-sandbox>=0.4.0,<0.5",
 ]
 
 [project.optional-dependencies]

--- a/examples/tenki_provisioner/pyproject.toml
+++ b/examples/tenki_provisioner/pyproject.toml
@@ -13,9 +13,9 @@ keywords = ["jupyter", "kernel", "provisioner", "tenki", "sandbox", "microvm"]
 authors = [{ name = "Tenki Cloud integration" }]
 dependencies = [
     "jupyter_client>=7.0",
-    # 0.4.0 is the version this integration is developed and tested against;
-    # it carries sandbox-lifecycle fixes over 0.3.x. Pin to the tested line.
-    "tenki-sandbox>=0.4.0,<0.5",
+    # `tenki` is the current SDK (successor to `tenki-sandbox`). Pin to the
+    # 0.5.x line this integration is developed and tested against.
+    "tenki>=0.5.4,<0.6",
 ]
 
 [project.optional-dependencies]

--- a/examples/tenki_provisioner/tenki_provisioner/__init__.py
+++ b/examples/tenki_provisioner/tenki_provisioner/__init__.py
@@ -1,0 +1,11 @@
+"""Tenki Sandbox kernel provisioner for jupyter_client.
+
+Launch Jupyter kernels inside disposable `Tenki Sandbox <https://tenki.cloud>`_
+microVMs. Register the provisioner in a kernelspec's ``kernel_provisioner``
+metadata under the name ``tenki-provisioner``.
+"""
+
+from .provisioner import REMOTE_HOME, TenkiProvisioner
+
+__all__ = ["REMOTE_HOME", "TenkiProvisioner"]
+__version__ = "0.1.0"

--- a/examples/tenki_provisioner/tenki_provisioner/_proxy.py
+++ b/examples/tenki_provisioner/tenki_provisioner/_proxy.py
@@ -21,7 +21,7 @@ import threading
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from tenki_sandbox import Sandbox
+    from tenki import Sandbox
 
 _BUFSIZE = 65536
 
@@ -39,7 +39,7 @@ class IpcSocketProxy:
     Parameters
     ----------
     sandbox:
-        A live :class:`tenki_sandbox.Sandbox` whose ``dial`` method opens a raw
+        A live :class:`tenki.Sandbox` whose ``dial`` method opens a raw
         stream to a Unix socket inside the guest.
     mappings:
         Pairs of ``(local_socket_path, remote_socket_path)`` -- one per Jupyter

--- a/examples/tenki_provisioner/tenki_provisioner/_proxy.py
+++ b/examples/tenki_provisioner/tenki_provisioner/_proxy.py
@@ -1,0 +1,150 @@
+"""A tiny loopback proxy that bridges local Unix-domain sockets to Unix sockets
+inside a Tenki Sandbox using the SDK's ``dial`` primitive.
+
+A Jupyter kernel speaks over five ZeroMQ channels.  When the kernel runs inside
+a Tenki Sandbox microVM we run it over the ZeroMQ ``ipc`` transport, so each
+channel is a Unix-domain socket the kernel *binds* inside the guest.  The client
+(``jupyter_client``) is local, so it needs something to *connect* to locally.
+
+For every channel we bind a local Unix socket and, whenever the local ZeroMQ
+client connects, we open a ``dial`` stream to the matching guest socket and pump
+bytes in both directions.  ``dial`` is a bidirectional, raw byte stream provided
+by the Tenki Sandbox SDK -- no external tooling (ssh, CLI) is required.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tenki_sandbox import Sandbox
+
+_BUFSIZE = 65536
+
+
+def _safe(fn) -> None:
+    try:
+        fn()
+    except Exception:  # noqa: BLE001 - best-effort teardown
+        pass
+
+
+class IpcSocketProxy:
+    """Bridge ``local_path`` <-> ``remote_path`` for a set of channel sockets.
+
+    Parameters
+    ----------
+    sandbox:
+        A live :class:`tenki_sandbox.Sandbox` whose ``dial`` method opens a raw
+        stream to a Unix socket inside the guest.
+    mappings:
+        Pairs of ``(local_socket_path, remote_socket_path)`` -- one per Jupyter
+        channel.
+    """
+
+    def __init__(
+        self,
+        sandbox: "Sandbox",
+        mappings: list[tuple[str, str]],
+        log: logging.Logger | None = None,
+    ) -> None:
+        self._sandbox = sandbox
+        self._mappings = mappings
+        self._log = log or logging.getLogger(__name__)
+        self._servers: list[socket.socket] = []
+        self._threads: list[threading.Thread] = []
+        self._conns: list[tuple[socket.socket, object]] = []
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def start(self) -> None:
+        """Bind every local socket and begin accepting connections."""
+        for local_path, remote_path in self._mappings:
+            _safe(lambda p=local_path: os.unlink(p) if os.path.exists(p) else None)
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server.bind(local_path)
+            server.listen(16)
+            self._servers.append(server)
+            t = threading.Thread(
+                target=self._accept_loop,
+                args=(server, remote_path),
+                name=f"tenki-ipc-accept:{os.path.basename(local_path)}",
+                daemon=True,
+            )
+            t.start()
+            self._threads.append(t)
+        self._log.debug("IPC proxy started with %d channel(s)", len(self._mappings))
+
+    def _accept_loop(self, server: socket.socket, remote_path: str) -> None:
+        while not self._closed:
+            try:
+                conn, _ = server.accept()
+            except OSError:
+                return  # server socket closed during shutdown
+            t = threading.Thread(
+                target=self._handle, args=(conn, remote_path), daemon=True
+            )
+            t.start()
+
+    def _handle(self, conn: socket.socket, remote_path: str) -> None:
+        try:
+            dial = self._sandbox.dial(remote_path)
+        except Exception as exc:  # noqa: BLE001 - kernel socket may not be up yet
+            self._log.debug("dial(%s) failed: %s", remote_path, exc)
+            _safe(conn.close)
+            return
+
+        with self._lock:
+            if self._closed:
+                _safe(conn.close)
+                _safe(dial.close)
+                return
+            self._conns.append((conn, dial))
+
+        def sock_to_dial() -> None:
+            try:
+                while True:
+                    data = conn.recv(_BUFSIZE)
+                    if not data:
+                        break
+                    dial.write(data)
+            except Exception:  # noqa: BLE001
+                pass
+            finally:
+                _safe(dial.close)  # half-close write side toward the guest
+
+        def dial_to_sock() -> None:
+            try:
+                while True:
+                    data = dial.read(_BUFSIZE)
+                    if not data:
+                        break
+                    conn.sendall(data)
+            except Exception:  # noqa: BLE001
+                pass
+            finally:
+                _safe(lambda: conn.shutdown(socket.SHUT_WR))
+
+        threading.Thread(target=sock_to_dial, daemon=True).start()
+        threading.Thread(target=dial_to_sock, daemon=True).start()
+
+    def close(self) -> None:
+        """Stop accepting and tear down every open connection."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            conns = list(self._conns)
+            self._conns.clear()
+        for server in self._servers:
+            _safe(server.close)
+        for conn, dial in conns:
+            _safe(conn.close)
+            _safe(dial.close)
+        for local_path, _ in self._mappings:
+            _safe(lambda p=local_path: os.unlink(p) if os.path.exists(p) else None)
+        self._log.debug("IPC proxy closed")

--- a/examples/tenki_provisioner/tenki_provisioner/_proxy.py
+++ b/examples/tenki_provisioner/tenki_provisioner/_proxy.py
@@ -29,7 +29,7 @@ _BUFSIZE = 65536
 def _safe(fn) -> None:
     try:
         fn()
-    except Exception:  # noqa: BLE001 - best-effort teardown
+    except Exception:  # best-effort teardown
         pass
 
 
@@ -48,7 +48,7 @@ class IpcSocketProxy:
 
     def __init__(
         self,
-        sandbox: "Sandbox",
+        sandbox: Sandbox,
         mappings: list[tuple[str, str]],
         log: logging.Logger | None = None,
     ) -> None:
@@ -85,15 +85,13 @@ class IpcSocketProxy:
                 conn, _ = server.accept()
             except OSError:
                 return  # server socket closed during shutdown
-            t = threading.Thread(
-                target=self._handle, args=(conn, remote_path), daemon=True
-            )
+            t = threading.Thread(target=self._handle, args=(conn, remote_path), daemon=True)
             t.start()
 
     def _handle(self, conn: socket.socket, remote_path: str) -> None:
         try:
             dial = self._sandbox.dial(remote_path)
-        except Exception as exc:  # noqa: BLE001 - kernel socket may not be up yet
+        except Exception as exc:  # kernel socket may not be up yet
             self._log.debug("dial(%s) failed: %s", remote_path, exc)
             _safe(conn.close)
             return
@@ -112,7 +110,7 @@ class IpcSocketProxy:
                     if not data:
                         break
                     dial.write(data)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
             finally:
                 _safe(dial.close)  # half-close write side toward the guest
@@ -124,7 +122,7 @@ class IpcSocketProxy:
                     if not data:
                         break
                     conn.sendall(data)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
             finally:
                 _safe(lambda: conn.shutdown(socket.SHUT_WR))

--- a/examples/tenki_provisioner/tenki_provisioner/kernelspec.py
+++ b/examples/tenki_provisioner/tenki_provisioner/kernelspec.py
@@ -1,0 +1,83 @@
+"""Install a kernelspec that launches kernels via :class:`TenkiProvisioner`.
+
+Usage::
+
+    python -m tenki_provisioner.kernelspec install --name tenki-python \
+        --display-name "Python (Tenki Sandbox)" --cpu 4 --memory-mb 8192
+
+This writes a ``kernel.json`` with a ``kernel_provisioner`` metadata stanza so
+Jupyter routes the kernel through the Tenki provisioner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from jupyter_client.kernelspec import KernelSpecManager
+
+
+def build_kernel_json(display_name: str, config: dict) -> dict:
+    return {
+        "argv": ["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+        "display_name": display_name,
+        "language": "python",
+        # ipykernel supports message-based interrupt; the provisioner also
+        # forwards real signals, so "signal" works too.
+        "interrupt_mode": "signal",
+        "metadata": {
+            "kernel_provisioner": {
+                "provisioner_name": "tenki-provisioner",
+                "config": config,
+            }
+        },
+    }
+
+
+def install(args: argparse.Namespace) -> int:
+    config: dict = {"cpu_cores": args.cpu, "memory_mb": args.memory_mb}
+    if args.image:
+        config["image"] = args.image
+    if args.idle_timeout_minutes:
+        config["idle_timeout_minutes"] = args.idle_timeout_minutes
+
+    kernel_json = build_kernel_json(args.display_name, config)
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "kernel.json").write_text(json.dumps(kernel_json, indent=2))
+        dest = KernelSpecManager().install_kernel_spec(
+            tmp, kernel_name=args.name, user=args.user, prefix=args.prefix
+        )
+    print(f"Installed kernelspec '{args.name}' -> {dest}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("install", help="Install the Tenki kernelspec.")
+    p.add_argument("--name", default="tenki-python", help="Kernelspec name.")
+    p.add_argument(
+        "--display-name", default="Python (Tenki Sandbox)", help="UI display name."
+    )
+    p.add_argument("--cpu", type=int, default=2, help="vCPUs for the sandbox.")
+    p.add_argument("--memory-mb", type=int, default=4096, help="Memory (MiB).")
+    p.add_argument("--image", default="", help="Sandbox image (optional).")
+    p.add_argument(
+        "--idle-timeout-minutes", type=int, default=0, help="Idle auto-terminate."
+    )
+    p.add_argument("--user", action="store_true", help="Install into the user dir.")
+    p.add_argument("--prefix", default=None, help="Install prefix (e.g. sys.prefix).")
+    p.set_defaults(func=install)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/tenki_provisioner/tenki_provisioner/kernelspec.py
+++ b/examples/tenki_provisioner/tenki_provisioner/kernelspec.py
@@ -62,15 +62,11 @@ def main(argv: list[str] | None = None) -> int:
 
     p = sub.add_parser("install", help="Install the Tenki kernelspec.")
     p.add_argument("--name", default="tenki-python", help="Kernelspec name.")
-    p.add_argument(
-        "--display-name", default="Python (Tenki Sandbox)", help="UI display name."
-    )
+    p.add_argument("--display-name", default="Python (Tenki Sandbox)", help="UI display name.")
     p.add_argument("--cpu", type=int, default=2, help="vCPUs for the sandbox.")
     p.add_argument("--memory-mb", type=int, default=4096, help="Memory (MiB).")
     p.add_argument("--image", default="", help="Sandbox image (optional).")
-    p.add_argument(
-        "--idle-timeout-minutes", type=int, default=0, help="Idle auto-terminate."
-    )
+    p.add_argument("--idle-timeout-minutes", type=int, default=0, help="Idle auto-terminate.")
     p.add_argument("--user", action="store_true", help="Install into the user dir.")
     p.add_argument("--prefix", default=None, help="Install prefix (e.g. sys.prefix).")
     p.set_defaults(func=install)

--- a/examples/tenki_provisioner/tenki_provisioner/provisioner.py
+++ b/examples/tenki_provisioner/tenki_provisioner/provisioner.py
@@ -18,6 +18,7 @@ import shutil
 import signal
 import tempfile
 import threading
+import time
 from typing import Any
 
 from jupyter_client.connect import KernelConnectionInfo
@@ -55,9 +56,9 @@ class TenkiProvisioner(KernelProvisionerBase):
     # --- Sandbox sizing / creation -----------------------------------------
     cpu_cores = Int(2, help="vCPUs for the sandbox microVM (1-16).").tag(config=True)
     memory_mb = Int(4096, help="Memory for the sandbox microVM in MiB.").tag(config=True)
-    image = Unicode(
-        "", help="Sandbox image reference. Empty uses the service default."
-    ).tag(config=True)
+    image = Unicode("", help="Sandbox image reference. Empty uses the service default.").tag(
+        config=True
+    )
     allow_outbound = Bool(
         True,
         help="Allow the guest outbound network access (needed to pip install ipykernel).",
@@ -66,15 +67,11 @@ class TenkiProvisioner(KernelProvisionerBase):
         0, help="Pause/terminate the sandbox after this many idle minutes (0 = service default)."
     ).tag(config=True)
     max_duration_seconds = Int(
-        0,
-        help="Hard cap on sandbox lifetime, as a leak backstop: if the provisioner "
-        "dies without cleaning up, the microVM self-terminates. 0 = no cap. Set "
-        "this comfortably longer than your longest expected kernel session.",
-    ).tag(config=True)
-    keepalive_interval_seconds = Int(
-        240,
-        help="Best-effort: refresh the sandbox this often so an idle kernel (no cell "
-        "running) isn't idle-paused mid-session. 0 = disabled.",
+        3600,
+        help="Hard cap on sandbox lifetime (seconds): the final leak backstop. If "
+        "the provisioner process dies or a launch is cancelled without cleanup, the "
+        "microVM self-terminates after this long. Raise it for sessions longer than "
+        "an hour; 0 disables the cap (not recommended for ephemeral kernels).",
     ).tag(config=True)
 
     # --- Kernel launch -----------------------------------------------------
@@ -110,9 +107,7 @@ class TenkiProvisioner(KernelProvisionerBase):
     create_timeout = Int(180, help="Seconds to wait for the sandbox to become ready.").tag(
         config=True
     )
-    install_timeout = Int(240, help="Seconds allowed for installing ipykernel.").tag(
-        config=True
-    )
+    install_timeout = Int(240, help="Seconds allowed for installing ipykernel.").tag(config=True)
     kernel_ready_timeout = Int(
         60, help="Seconds to wait for the kernel's channel sockets to appear."
     ).tag(config=True)
@@ -127,8 +122,7 @@ class TenkiProvisioner(KernelProvisionerBase):
         self._local_prefix: str | None = None
         self._remote_prefix: str | None = None
         self._remote_conn_path: str | None = None
-        self._keepalive_stop: threading.Event | None = None
-        self._keepalive_thread: threading.Thread | None = None
+        self._create_future: Any = None
 
     # ------------------------------------------------------------------ utils
     @staticmethod
@@ -158,32 +152,39 @@ class TenkiProvisioner(KernelProvisionerBase):
             msg = "TenkiProvisioner must be owned by a KernelManager."
             raise RuntimeError(msg)
 
-        # Unix-domain socket paths are length-limited (~104 chars on macOS), so
-        # root them under a short directory rather than the (long) system temp
-        # dir. The channel sockets live here as "<tmpdir>/k-<N>".
-        short_base = "/tmp" if os.path.isdir("/tmp") else tempfile.gettempdir()
-        self._tmpdir = tempfile.mkdtemp(prefix="tk-", dir=short_base)
-        os.chmod(self._tmpdir, 0o700)
-        self._local_prefix = os.path.join(self._tmpdir, "k")
+        # On restart, jupyter_client preserves the connection file (and thus the
+        # ports); the same provisioner instance is reused, so its prefix/ports/
+        # connection_info survive. Only set up the transport on the first launch
+        # — reallocating a new local prefix would strand already-connected
+        # clients, and zeroing the ports would make write_connection_file() (which
+        # returns early when the file already exists) leave the kernel with no
+        # ports to bind, timing out the restart.
+        if self._local_prefix is None:
+            # Unix-domain socket paths are length-limited (~104 chars on macOS),
+            # so root them under a short directory rather than the (long) system
+            # temp dir. The channel sockets live here as "<tmpdir>/k-<N>".
+            short_base = "/tmp" if os.path.isdir("/tmp") else tempfile.gettempdir()  # noqa: S108 - short path required for AF_UNIX length limit; the dir itself is mkdtemp'd 0700
+            self._tmpdir = tempfile.mkdtemp(prefix="tk-", dir=short_base)
+            os.chmod(self._tmpdir, 0o700)
+            self._local_prefix = os.path.join(self._tmpdir, "k")
 
-        # Drive the kernel over ipc with locally-controlled socket paths.
-        km.transport = "ipc"
-        km.ip = self._local_prefix
-        km.cache_ports = False
-        for name in _CHANNELS:
-            setattr(km, f"{name}_port", 0)
+            # Drive the kernel over ipc with locally-controlled socket paths.
+            km.transport = "ipc"
+            km.ip = self._local_prefix
+            km.cache_ports = False
+            for name in _CHANNELS:
+                setattr(km, f"{name}_port", 0)
 
-        env = kwargs.get("env", {})
-        km.write_connection_file(jupyter_session=env.get("JPY_SESSION_NAME", ""))
-        self.connection_info = km.get_connection_info()
+            env = kwargs.get("env", {})
+            km.write_connection_file(jupyter_session=env.get("JPY_SESSION_NAME", ""))
+            self.connection_info = km.get_connection_info()
 
-        ident = self._identifier()
-        self._remote_prefix = f"{REMOTE_HOME}/{ident}-k"
-        self._remote_conn_path = f"{REMOTE_HOME}/{ident}-connection.json"
+            ident = self._identifier()
+            self._remote_prefix = f"{REMOTE_HOME}/{ident}-k"
+            self._remote_conn_path = f"{REMOTE_HOME}/{ident}-connection.json"
 
         argv = [
-            arg.replace("{connection_file}", self._remote_conn_path)
-            for arg in self.kernel_argv
+            arg.replace("{connection_file}", self._remote_conn_path) for arg in self.kernel_argv
         ]
         return await super().pre_launch(cmd=argv, **kwargs)
 
@@ -199,23 +200,59 @@ class TenkiProvisioner(KernelProvisionerBase):
         # A relaunch (e.g. restart) must not orphan a sandbox from a prior launch.
         if self._sandbox is not None:
             await self.cleanup(restart=True)
+        self._returncode = None  # fresh process for this (re)launch
+        env = kwargs.get("env") or {}
         try:
-            await self._run(self._provision_sandbox)
+            await self._provision_sandbox_cancellation_safe()
             await self._run(self._ensure_ipykernel)
             await self._run(self._write_remote_connection_file)
-            await self._run(self._start_kernel_process, cmd)
+            await self._run(self._start_kernel_process, cmd, env)
             await self._run(self._await_kernel_sockets)
             await self._run(self._preflight_dial)
             self._start_proxy()
-            self._start_keepalive()
         except BaseException as exc:  # includes CancelledError
             self.log.warning("launch failed (%s); tearing down sandbox", exc)
-            await self.cleanup(restart=True)
+            try:
+                await self.cleanup(restart=False)
+            except Exception:  # don't mask the original failure
+                self.log.exception("cleanup after failed launch also failed")
             raise
         return self.connection_info
 
     # ------------------------------------------------------------ blocking bits
-    def _provision_sandbox(self) -> None:
+    async def _provision_sandbox_cancellation_safe(self) -> None:
+        """Create the sandbox such that cancellation can't leak a late VM.
+
+        ``run_in_executor`` cannot cancel the worker thread running
+        ``Sandbox.create()``. If the await is cancelled, the create may still
+        succeed afterwards. We keep the future and, on cancellation, arrange for
+        any sandbox it eventually produces to be terminated rather than orphaned.
+        """
+        loop = asyncio.get_running_loop()
+        fut = loop.run_in_executor(None, self._provision_sandbox)
+        self._create_future = fut
+        try:
+            self._sandbox = await fut
+        except BaseException:
+            self._reap_late_creation(fut)
+            raise
+
+    def _reap_late_creation(self, fut: Any) -> None:
+        def _cb(f: Any) -> None:
+            try:
+                sb = f.result()
+            except BaseException:  # create failed; nothing to reap
+                return
+            if sb is not None and self._sandbox is not sb:
+                self.log.warning("terminating sandbox created after cancellation")
+                try:
+                    _terminate_sandbox(sb)
+                except Exception as exc:
+                    self.log.error("failed to terminate late sandbox: %s", exc)
+
+        fut.add_done_callback(_cb)
+
+    def _provision_sandbox(self) -> Any:
         from tenki_sandbox import Sandbox
 
         opts: dict[str, Any] = {
@@ -243,8 +280,9 @@ class TenkiProvisioner(KernelProvisionerBase):
         if self.base_url:
             opts["base_url"] = self.base_url
         self.log.info("Creating Tenki Sandbox for kernel %s", self.kernel_id)
-        self._sandbox = Sandbox.create(**opts)
-        self.log.info("Sandbox %s ready", getattr(self._sandbox, "id", "?"))
+        sandbox = Sandbox.create(**opts)
+        self.log.info("Sandbox %s ready", getattr(sandbox, "id", "?"))
+        return sandbox
 
     def _ensure_ipykernel(self) -> None:
         sb = self._sandbox
@@ -263,9 +301,7 @@ class TenkiProvisioner(KernelProvisionerBase):
             # managed (PEP 668). The guest is disposable, so a system-wide
             # install is fine — retry allowing it.
             self.log.info("Retrying install with --break-system-packages (PEP 668)")
-            result = sb.exec(
-                *base, "--break-system-packages", *need, timeout=self.install_timeout
-            )
+            result = sb.exec(*base, "--break-system-packages", *need, timeout=self.install_timeout)
         if not result.ok:
             detail = (result.stdout_text + "\n" + result.stderr_text).strip()
             msg = f"Failed to install {' '.join(need)} in sandbox (exit {result.exit_code}):\n{detail}"
@@ -280,10 +316,14 @@ class TenkiProvisioner(KernelProvisionerBase):
         )
         self._sandbox.fs.write_text(self._remote_conn_path, payload)
 
-    def _start_kernel_process(self, cmd: list[str]) -> None:
-        guest_env = {}
-        if self.kernel_spec is not None and self.kernel_spec.env:
-            guest_env.update(self.kernel_spec.env)
+    def _start_kernel_process(self, cmd: list[str], env: dict[str, str]) -> None:
+        # Forward the finalized launch environment computed by the base
+        # pre_launch(): kernelspec `env` (with substitutions), explicit
+        # start_kernel(env=...) values, and JPY_* connection vars. We forward
+        # only entries that differ from this process's own environment, so the
+        # guest gets the caller's intent without inheriting the full local env
+        # (PATH, HOME, secrets, ...). Configured `env` always wins.
+        guest_env = {k: v for k, v in (env or {}).items() if os.environ.get(k) != v}
         guest_env.update(self.env)
         self.log.info("Launching kernel in sandbox: %s", " ".join(cmd))
         self._process = self._sandbox.start(*cmd, cwd=REMOTE_HOME, env=guest_env or None)
@@ -299,7 +339,7 @@ class TenkiProvisioner(KernelProvisionerBase):
                 if not rc and sig:
                     rc = 128 + int(sig)
                 self._returncode = rc
-            except Exception:  # noqa: BLE001
+            except Exception:
                 self._returncode = 1
 
         threading.Thread(target=_reap, name="tenki-kernel-reap", daemon=True).start()
@@ -339,12 +379,12 @@ class TenkiProvisioner(KernelProvisionerBase):
                 f"({exc})"
             )
             raise RuntimeError(msg) from exc
-        except Exception as exc:  # noqa: BLE001 - transient; proxy will retry
+        except Exception as exc:  # transient; proxy will retry
             self.log.warning("dial preflight to %s failed: %s", probe, exc)
             return
         try:
             conn.close()
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
 
     def _start_proxy(self) -> None:
@@ -357,38 +397,6 @@ class TenkiProvisioner(KernelProvisionerBase):
         ]
         self._proxy = IpcSocketProxy(self._sandbox, mappings, log=self.log)
         self._proxy.start()
-
-    def _start_keepalive(self) -> None:
-        """Periodically refresh the sandbox so an idle kernel isn't idle-paused.
-
-        A Jupyter kernel is idle between cells, and data-plane traffic may not
-        reset the idle timer. This best-effort control-plane refresh keeps a
-        long-lived but bursty session alive. Disabled when the interval is 0.
-        """
-        interval = self.keepalive_interval_seconds
-        if not interval or self._sandbox is None:
-            return
-        sandbox = self._sandbox
-        stop = threading.Event()
-        self._keepalive_stop = stop
-
-        def _loop() -> None:
-            while not stop.wait(interval):
-                try:
-                    sandbox.refresh()
-                except Exception as exc:  # noqa: BLE001 - keepalive is best-effort
-                    self.log.debug("keepalive refresh failed: %s", exc)
-
-        self._keepalive_thread = threading.Thread(
-            target=_loop, name="tenki-kernel-keepalive", daemon=True
-        )
-        self._keepalive_thread.start()
-
-    def _stop_keepalive(self) -> None:
-        if self._keepalive_stop is not None:
-            self._keepalive_stop.set()
-            self._keepalive_stop = None
-            self._keepalive_thread = None
 
     # ------------------------------------------------------------- process ctl
     async def poll(self) -> int | None:
@@ -421,65 +429,68 @@ class TenkiProvisioner(KernelProvisionerBase):
         if self._process is not None:
             try:
                 await self._run(self._process.signal, "SIGTERM")
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
 
     async def cleanup(self, restart: bool = False) -> None:
         """Tear down the proxy and terminate the sandbox microVM.
 
-        The sandbox handle is only cleared once teardown actually succeeds. If
-        termination fails the handle is retained and the error is logged (not
-        swallowed) so a later ``cleanup`` call can retry rather than silently
-        leaking a running microVM.
+        Termination is retried a few times; if it still fails the error is
+        raised (not swallowed) so teardown failure is observable to the caller
+        rather than being silently reported as a successful, leaked VM. The
+        sandbox handle is cleared only once teardown is confirmed. On ``restart``
+        the local socket prefix is preserved so the replacement kernel reuses the
+        same connection info and already-connected clients are not stranded.
         """
-        self._stop_keepalive()
         if self._proxy is not None:
             self._proxy.close()
             self._proxy = None
         sandbox = self._sandbox
         if sandbox is not None:
             self.log.info("Terminating sandbox for kernel %s", self.kernel_id)
-            try:
-                await self._run(_terminate_sandbox, sandbox)
-                self._sandbox = None  # only clear on confirmed teardown
-                self._process = None
-            except Exception as exc:  # noqa: BLE001
-                # Keep the handle so cleanup can be retried; do not report success.
-                self.log.error(
-                    "Failed to terminate sandbox for kernel %s (handle retained "
-                    "for retry): %s",
-                    self.kernel_id,
-                    exc,
-                )
-                return
-        else:
-            self._process = None
-        if self._tmpdir is not None:
-            shutil.rmtree(self._tmpdir, ignore_errors=True)
-            self._tmpdir = None
+            await self._run(_terminate_sandbox, sandbox)  # retries, then raises
+            self._sandbox = None  # only clear on confirmed teardown
+        self._process = None
+        if not restart:
+            if self._tmpdir is not None:
+                shutil.rmtree(self._tmpdir, ignore_errors=True)
+                self._tmpdir = None
+            self._local_prefix = None
+            self._remote_prefix = None
+            self._remote_conn_path = None
 
-    async def get_provisioner_info(self) -> dict[str, Any]:
-        info = await super().get_provisioner_info()
-        info["sandbox_id"] = getattr(self._sandbox, "id", None)
-        return info
+    @property
+    def sandbox_id(self) -> str | None:
+        """Id of the current sandbox, or ``None``.
+
+        Cross-process reattach is intentionally not supported:
+        ``get_provisioner_info`` / ``load_provisioner_info`` are left at the base
+        implementation (which persists only ``connection_info`` and
+        ``kernel_id``). Reconstructing the guest process handle and channel
+        bridge in another process is out of scope for this example, so persisting
+        a sandbox id we cannot reattach to would be misleading.
+        """
+        return getattr(self._sandbox, "id", None)
 
 
-def _terminate_sandbox(sandbox: Any) -> None:
-    """Terminate the microVM, raising if it cannot be confirmed torn down.
+def _terminate_sandbox(sandbox: Any, attempts: int = 3, delay: float = 1.0) -> None:
+    """Terminate the microVM, retrying, and raise if it cannot be torn down.
 
     Tries ``close()`` (which terminates and releases the client) and falls back
-    to ``terminate()``. Raises the last error if neither succeeds so the caller
-    can decide whether to retain the handle and retry.
+    to ``terminate()``, up to ``attempts`` times. Raises the last error if none
+    succeed so the caller can surface an observable teardown failure.
     """
     last_error: Exception | None = None
-    for method in ("close", "terminate"):
-        fn = getattr(sandbox, method, None)
-        if callable(fn):
-            try:
-                fn()
-                return
-            except Exception as exc:  # noqa: BLE001
-                last_error = exc
-                continue
+    for attempt in range(attempts):
+        for method in ("close", "terminate"):
+            fn = getattr(sandbox, method, None)
+            if callable(fn):
+                try:
+                    fn()
+                    return
+                except Exception as exc:
+                    last_error = exc
+        if attempt + 1 < attempts:
+            time.sleep(delay)
     if last_error is not None:
         raise last_error

--- a/examples/tenki_provisioner/tenki_provisioner/provisioner.py
+++ b/examples/tenki_provisioner/tenki_provisioner/provisioner.py
@@ -138,6 +138,41 @@ class TenkiProvisioner(KernelProvisionerBase):
     def _identifier(self) -> str:
         return (self.kernel_id or "kernel").replace("/", "_")
 
+    def _apply_transport_encryption(self, km: Any) -> None:
+        """Set up CurveZMQ keys when transport_encryption is enabled.
+
+        Mirrors ``LocalProvisioner``: Curve is supported over the ipc transport
+        we use, so honour the kernel manager's ``transport_encryption`` policy
+        instead of silently ignoring it. Keys are generated on the manager
+        before the connection file is written and are picked up by both the
+        client and the guest-side connection file. Guarded with ``getattr`` so a
+        manager without the (8.x) encryption API is simply treated as disabled.
+        """
+        policy_fn = getattr(km, "_transport_encryption_policy", None)
+        raw = getattr(km, "transport_encryption", "disabled")
+        if callable(policy_fn):
+            policy = policy_fn(raw)
+        elif isinstance(raw, str) and raw in {"disabled", "auto", "required"}:
+            policy = raw
+        else:
+            policy = "auto" if raw else "disabled"
+        required = policy == "required"
+        enabled = policy in {"auto", "required"}
+        supported = getattr(km, "transport", "tcp") in {"tcp", "ipc"}
+        if required and not supported:
+            msg = "transport_encryption='required' needs the tcp or ipc transport."
+            raise RuntimeError(msg)
+        if not (enabled and supported):
+            return
+        kernel_curve_ok = required or (
+            hasattr(km, "_kernel_supports_curve_encryption")
+            and km._kernel_supports_curve_encryption()
+        )
+        if kernel_curve_ok and getattr(km, "curve_publickey", None) is None:
+            import zmq
+
+            km.curve_publickey, km.curve_secretkey = zmq.curve_keypair()
+
     # -------------------------------------------------------------- lifecycle
     async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
         """Switch the kernel to the ``ipc`` transport and stage connection files.
@@ -174,6 +209,11 @@ class TenkiProvisioner(KernelProvisionerBase):
             km.cache_ports = False
             for name in _CHANNELS:
                 setattr(km, f"{name}_port", 0)
+
+            # CurveZMQ is supported over ipc; mirror LocalProvisioner so
+            # transport_encryption is honoured (keys must be set before the
+            # connection file is written).
+            self._apply_transport_encryption(km)
 
             env = kwargs.get("env", {})
             km.write_connection_file(jupyter_session=env.get("JPY_SESSION_NAME", ""))
@@ -232,7 +272,13 @@ class TenkiProvisioner(KernelProvisionerBase):
         fut = loop.run_in_executor(None, self._provision_sandbox)
         self._create_future = fut
         try:
-            self._sandbox = await fut
+            # Shield the executor future: cancelling the awaiting task must not
+            # cancel the underlying create() (the worker thread can't be
+            # cancelled anyway). Without the shield, cancellation would cancel
+            # `fut` and the reap callback would only ever see CancelledError,
+            # while the thread completes and leaks the sandbox. With the shield,
+            # `fut` runs to completion and its eventual result is reaped below.
+            self._sandbox = await asyncio.shield(fut)
         except BaseException:
             self._reap_late_creation(fut)
             raise
@@ -317,13 +363,20 @@ class TenkiProvisioner(KernelProvisionerBase):
         self._sandbox.fs.write_text(self._remote_conn_path, payload)
 
     def _start_kernel_process(self, cmd: list[str], env: dict[str, str]) -> None:
-        # Forward the finalized launch environment computed by the base
-        # pre_launch(): kernelspec `env` (with substitutions), explicit
-        # start_kernel(env=...) values, and JPY_* connection vars. We forward
-        # only entries that differ from this process's own environment, so the
-        # guest gets the caller's intent without inheriting the full local env
-        # (PATH, HOME, secrets, ...). Configured `env` always wins.
-        guest_env = {k: v for k, v in (env or {}).items() if os.environ.get(k) != v}
+        # Forward the caller's intent to the guest without inheriting this
+        # process's full environment (PATH, HOME, secrets, ...). We forward a key
+        # when it was *explicitly* provided — a kernelspec `env` key or a
+        # start_kernel(env=...) key — regardless of its value, plus any key not
+        # present in this process's environment (e.g. JPY_* connection vars).
+        # Tracking explicit keys (not value comparison) means an explicit value
+        # that happens to match the parent environment is still forwarded.
+        explicit_keys: set[str] = set(self.kernel_spec.env or {}) if self.kernel_spec else set()
+        km = self.parent
+        if km is not None:
+            explicit_keys |= set(getattr(km, "_launch_args", {}).get("env", {}) or {})
+        guest_env = {
+            k: v for k, v in (env or {}).items() if k in explicit_keys or os.environ.get(k) != v
+        }
         guest_env.update(self.env)
         self.log.info("Launching kernel in sandbox: %s", " ".join(cmd))
         self._process = self._sandbox.start(*cmd, cwd=REMOTE_HOME, env=guest_env or None)

--- a/examples/tenki_provisioner/tenki_provisioner/provisioner.py
+++ b/examples/tenki_provisioner/tenki_provisioner/provisioner.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import signal
 import tempfile
+import threading
 from typing import Any
 
 from jupyter_client.connect import KernelConnectionInfo
@@ -62,7 +63,18 @@ class TenkiProvisioner(KernelProvisionerBase):
         help="Allow the guest outbound network access (needed to pip install ipykernel).",
     ).tag(config=True)
     idle_timeout_minutes = Int(
-        0, help="Terminate the sandbox after this many idle minutes (0 = service default)."
+        0, help="Pause/terminate the sandbox after this many idle minutes (0 = service default)."
+    ).tag(config=True)
+    max_duration_seconds = Int(
+        0,
+        help="Hard cap on sandbox lifetime, as a leak backstop: if the provisioner "
+        "dies without cleaning up, the microVM self-terminates. 0 = no cap. Set "
+        "this comfortably longer than your longest expected kernel session.",
+    ).tag(config=True)
+    keepalive_interval_seconds = Int(
+        240,
+        help="Best-effort: refresh the sandbox this often so an idle kernel (no cell "
+        "running) isn't idle-paused mid-session. 0 = disabled.",
     ).tag(config=True)
 
     # --- Kernel launch -----------------------------------------------------
@@ -115,6 +127,8 @@ class TenkiProvisioner(KernelProvisionerBase):
         self._local_prefix: str | None = None
         self._remote_prefix: str | None = None
         self._remote_conn_path: str | None = None
+        self._keepalive_stop: threading.Event | None = None
+        self._keepalive_thread: threading.Thread | None = None
 
     # ------------------------------------------------------------------ utils
     @staticmethod
@@ -174,14 +188,30 @@ class TenkiProvisioner(KernelProvisionerBase):
         return await super().pre_launch(cmd=argv, **kwargs)
 
     async def launch_kernel(self, cmd: list[str], **kwargs: Any) -> KernelConnectionInfo:
-        """Create the sandbox, launch the kernel, and start the socket proxy."""
-        await self._run(self._provision_sandbox)
-        await self._run(self._ensure_ipykernel)
-        await self._run(self._write_remote_connection_file)
-        await self._run(self._start_kernel_process, cmd)
-        await self._run(self._await_kernel_sockets)
-        await self._run(self._preflight_dial)
-        self._start_proxy()
+        """Create the sandbox, launch the kernel, and start the socket proxy.
+
+        Failure-atomic: if anything after provisioning fails (or the launch is
+        cancelled), the sandbox is torn down before the error propagates, so a
+        failed launch never leaks a running microVM. A `max_duration` backstop
+        (see ``max_duration_seconds``) is the last line of defence if the
+        process dies before cleanup can run.
+        """
+        # A relaunch (e.g. restart) must not orphan a sandbox from a prior launch.
+        if self._sandbox is not None:
+            await self.cleanup(restart=True)
+        try:
+            await self._run(self._provision_sandbox)
+            await self._run(self._ensure_ipykernel)
+            await self._run(self._write_remote_connection_file)
+            await self._run(self._start_kernel_process, cmd)
+            await self._run(self._await_kernel_sockets)
+            await self._run(self._preflight_dial)
+            self._start_proxy()
+            self._start_keepalive()
+        except BaseException as exc:  # includes CancelledError
+            self.log.warning("launch failed (%s); tearing down sandbox", exc)
+            await self.cleanup(restart=True)
+            raise
         return self.connection_info
 
     # ------------------------------------------------------------ blocking bits
@@ -206,6 +236,8 @@ class TenkiProvisioner(KernelProvisionerBase):
             opts["image"] = self.image
         if self.idle_timeout_minutes:
             opts["idle_timeout_minutes"] = self.idle_timeout_minutes
+        if self.max_duration_seconds:
+            opts["max_duration"] = self.max_duration_seconds
         if self.auth_token:
             opts["auth_token"] = self.auth_token
         if self.base_url:
@@ -259,11 +291,16 @@ class TenkiProvisioner(KernelProvisionerBase):
         def _reap() -> None:
             try:
                 result = self._process.wait()
-                self._returncode = result.exit_code
+                rc = result.exit_code
+                # A process killed by a signal can report exit_code 0; surface
+                # that as a non-zero code (shell convention) so callers don't
+                # read a SIGKILL/SIGTERM as a clean exit.
+                sig = getattr(result, "signal", None)
+                if not rc and sig:
+                    rc = 128 + int(sig)
+                self._returncode = rc
             except Exception:  # noqa: BLE001
                 self._returncode = 1
-
-        import threading
 
         threading.Thread(target=_reap, name="tenki-kernel-reap", daemon=True).start()
 
@@ -321,6 +358,38 @@ class TenkiProvisioner(KernelProvisionerBase):
         self._proxy = IpcSocketProxy(self._sandbox, mappings, log=self.log)
         self._proxy.start()
 
+    def _start_keepalive(self) -> None:
+        """Periodically refresh the sandbox so an idle kernel isn't idle-paused.
+
+        A Jupyter kernel is idle between cells, and data-plane traffic may not
+        reset the idle timer. This best-effort control-plane refresh keeps a
+        long-lived but bursty session alive. Disabled when the interval is 0.
+        """
+        interval = self.keepalive_interval_seconds
+        if not interval or self._sandbox is None:
+            return
+        sandbox = self._sandbox
+        stop = threading.Event()
+        self._keepalive_stop = stop
+
+        def _loop() -> None:
+            while not stop.wait(interval):
+                try:
+                    sandbox.refresh()
+                except Exception as exc:  # noqa: BLE001 - keepalive is best-effort
+                    self.log.debug("keepalive refresh failed: %s", exc)
+
+        self._keepalive_thread = threading.Thread(
+            target=_loop, name="tenki-kernel-keepalive", daemon=True
+        )
+        self._keepalive_thread.start()
+
+    def _stop_keepalive(self) -> None:
+        if self._keepalive_stop is not None:
+            self._keepalive_stop.set()
+            self._keepalive_stop = None
+            self._keepalive_thread = None
+
     # ------------------------------------------------------------- process ctl
     async def poll(self) -> int | None:
         if self._process is None:
@@ -356,15 +425,35 @@ class TenkiProvisioner(KernelProvisionerBase):
                 pass
 
     async def cleanup(self, restart: bool = False) -> None:
-        """Tear down the proxy and terminate the sandbox microVM."""
+        """Tear down the proxy and terminate the sandbox microVM.
+
+        The sandbox handle is only cleared once teardown actually succeeds. If
+        termination fails the handle is retained and the error is logged (not
+        swallowed) so a later ``cleanup`` call can retry rather than silently
+        leaking a running microVM.
+        """
+        self._stop_keepalive()
         if self._proxy is not None:
             self._proxy.close()
             self._proxy = None
-        sandbox, self._sandbox = self._sandbox, None
+        sandbox = self._sandbox
         if sandbox is not None:
             self.log.info("Terminating sandbox for kernel %s", self.kernel_id)
-            await self._run(lambda: _safe_close(sandbox))
-        self._process = None
+            try:
+                await self._run(_terminate_sandbox, sandbox)
+                self._sandbox = None  # only clear on confirmed teardown
+                self._process = None
+            except Exception as exc:  # noqa: BLE001
+                # Keep the handle so cleanup can be retried; do not report success.
+                self.log.error(
+                    "Failed to terminate sandbox for kernel %s (handle retained "
+                    "for retry): %s",
+                    self.kernel_id,
+                    exc,
+                )
+                return
+        else:
+            self._process = None
         if self._tmpdir is not None:
             shutil.rmtree(self._tmpdir, ignore_errors=True)
             self._tmpdir = None
@@ -375,12 +464,22 @@ class TenkiProvisioner(KernelProvisionerBase):
         return info
 
 
-def _safe_close(sandbox: Any) -> None:
+def _terminate_sandbox(sandbox: Any) -> None:
+    """Terminate the microVM, raising if it cannot be confirmed torn down.
+
+    Tries ``close()`` (which terminates and releases the client) and falls back
+    to ``terminate()``. Raises the last error if neither succeeds so the caller
+    can decide whether to retain the handle and retry.
+    """
+    last_error: Exception | None = None
     for method in ("close", "terminate"):
         fn = getattr(sandbox, method, None)
         if callable(fn):
             try:
                 fn()
                 return
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
                 continue
+    if last_error is not None:
+        raise last_error

--- a/examples/tenki_provisioner/tenki_provisioner/provisioner.py
+++ b/examples/tenki_provisioner/tenki_provisioner/provisioner.py
@@ -1,0 +1,344 @@
+"""A :class:`~jupyter_client.provisioning.KernelProvisionerBase` that launches
+Jupyter kernels inside `Tenki Sandbox <https://tenki.cloud>`_ microVMs.
+
+Each kernel gets its own disposable, isolated Linux microVM.  The kernel talks
+to ``jupyter_client`` over the ZeroMQ ``ipc`` transport; the five channel
+sockets are bridged from the local machine into the guest with the Tenki
+Sandbox SDK's ``dial`` primitive (see :mod:`tenki_provisioner._proxy`).  The
+integration therefore depends only on the ``tenki-sandbox`` SDK -- no ssh, no
+CLI, no inbound networking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import signal
+import tempfile
+from typing import Any
+
+from jupyter_client.connect import KernelConnectionInfo
+from jupyter_client.provisioning.provisioner_base import KernelProvisionerBase
+from traitlets import Bool, Dict, Int, List, Unicode
+
+from ._proxy import IpcSocketProxy
+
+#: Working directory inside a Tenki Sandbox guest.  File operations are rooted
+#: here and absolute paths outside it are rejected by the service.
+REMOTE_HOME = "/home/tenki"
+
+#: Jupyter's five ZeroMQ channels, in the order the connection info names them.
+_CHANNELS = ("shell", "iopub", "stdin", "control", "hb")
+
+
+class TenkiProvisioner(KernelProvisionerBase):
+    """Provision a Jupyter kernel inside a Tenki Sandbox microVM.
+
+    The provisioner is configured through the ``config`` stanza of a kernelspec's
+    ``kernel_provisioner`` metadata, or programmatically via traitlets, e.g.::
+
+        {
+          "argv": ["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+          "language": "python",
+          "metadata": {
+            "kernel_provisioner": {
+              "provisioner_name": "tenki-provisioner",
+              "config": {"cpu_cores": 4, "memory_mb": 8192}
+            }
+          }
+        }
+    """
+
+    # --- Sandbox sizing / creation -----------------------------------------
+    cpu_cores = Int(2, help="vCPUs for the sandbox microVM (1-16).").tag(config=True)
+    memory_mb = Int(4096, help="Memory for the sandbox microVM in MiB.").tag(config=True)
+    image = Unicode(
+        "", help="Sandbox image reference. Empty uses the service default."
+    ).tag(config=True)
+    allow_outbound = Bool(
+        True,
+        help="Allow the guest outbound network access (needed to pip install ipykernel).",
+    ).tag(config=True)
+    idle_timeout_minutes = Int(
+        0, help="Terminate the sandbox after this many idle minutes (0 = service default)."
+    ).tag(config=True)
+
+    # --- Kernel launch -----------------------------------------------------
+    kernel_argv = List(
+        Unicode(),
+        default_value=["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+        help="Command run inside the guest. '{connection_file}' is substituted.",
+    ).tag(config=True)
+    python_executable = Unicode(
+        "python3", help="Interpreter used inside the guest for dependency checks."
+    ).tag(config=True)
+    install_ipykernel = Bool(
+        True, help="pip install ipykernel in the guest if it is not importable."
+    ).tag(config=True)
+    extra_pip_packages = List(
+        Unicode(), default_value=[], help="Extra packages to pip install in the guest."
+    ).tag(config=True)
+    env = Dict(
+        value_trait=Unicode(), help="Environment variables to set for the kernel process."
+    ).tag(config=True)
+
+    # --- Auth (falls back to TENKI_API_KEY / TENKI_API_ENDPOINT envs) ------
+    auth_token = Unicode(None, allow_none=True).tag(config=True)
+    base_url = Unicode(None, allow_none=True).tag(config=True)
+
+    # --- Timeouts ----------------------------------------------------------
+    create_timeout = Int(180, help="Seconds to wait for the sandbox to become ready.").tag(
+        config=True
+    )
+    install_timeout = Int(240, help="Seconds allowed for installing ipykernel.").tag(
+        config=True
+    )
+    kernel_ready_timeout = Int(
+        60, help="Seconds to wait for the kernel's channel sockets to appear."
+    ).tag(config=True)
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._sandbox: Any = None
+        self._process: Any = None
+        self._proxy: IpcSocketProxy | None = None
+        self._returncode: int | None = None
+        self._tmpdir: str | None = None
+        self._local_prefix: str | None = None
+        self._remote_prefix: str | None = None
+        self._remote_conn_path: str | None = None
+
+    # ------------------------------------------------------------------ utils
+    @staticmethod
+    async def _run(fn, *args, **kwargs):
+        """Run a blocking SDK call off the event loop."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, lambda: fn(*args, **kwargs))
+
+    @property
+    def has_process(self) -> bool:
+        return self._process is not None
+
+    def _identifier(self) -> str:
+        return (self.kernel_id or "kernel").replace("/", "_")
+
+    # -------------------------------------------------------------- lifecycle
+    async def pre_launch(self, **kwargs: Any) -> dict[str, Any]:
+        """Switch the kernel to the ``ipc`` transport and stage connection files.
+
+        We point the local (client-side) connection info at a private temp
+        directory and record a parallel guest-side prefix under ``REMOTE_HOME``.
+        The two connection files are identical except for that path prefix, so
+        the HMAC key and channel indices line up on both ends.
+        """
+        km = self.parent
+        if km is None:
+            msg = "TenkiProvisioner must be owned by a KernelManager."
+            raise RuntimeError(msg)
+
+        # Unix-domain socket paths are length-limited (~104 chars on macOS), so
+        # root them under a short directory rather than the (long) system temp
+        # dir. The channel sockets live here as "<tmpdir>/k-<N>".
+        short_base = "/tmp" if os.path.isdir("/tmp") else tempfile.gettempdir()
+        self._tmpdir = tempfile.mkdtemp(prefix="tk-", dir=short_base)
+        os.chmod(self._tmpdir, 0o700)
+        self._local_prefix = os.path.join(self._tmpdir, "k")
+
+        # Drive the kernel over ipc with locally-controlled socket paths.
+        km.transport = "ipc"
+        km.ip = self._local_prefix
+        km.cache_ports = False
+        for name in _CHANNELS:
+            setattr(km, f"{name}_port", 0)
+
+        env = kwargs.get("env", {})
+        km.write_connection_file(jupyter_session=env.get("JPY_SESSION_NAME", ""))
+        self.connection_info = km.get_connection_info()
+
+        ident = self._identifier()
+        self._remote_prefix = f"{REMOTE_HOME}/{ident}-k"
+        self._remote_conn_path = f"{REMOTE_HOME}/{ident}-connection.json"
+
+        argv = [
+            arg.replace("{connection_file}", self._remote_conn_path)
+            for arg in self.kernel_argv
+        ]
+        return await super().pre_launch(cmd=argv, **kwargs)
+
+    async def launch_kernel(self, cmd: list[str], **kwargs: Any) -> KernelConnectionInfo:
+        """Create the sandbox, launch the kernel, and start the socket proxy."""
+        await self._run(self._provision_sandbox)
+        await self._run(self._ensure_ipykernel)
+        await self._run(self._write_remote_connection_file)
+        await self._run(self._start_kernel_process, cmd)
+        await self._run(self._await_kernel_sockets)
+        self._start_proxy()
+        return self.connection_info
+
+    # ------------------------------------------------------------ blocking bits
+    def _provision_sandbox(self) -> None:
+        from tenki_sandbox import Sandbox
+
+        opts: dict[str, Any] = {
+            "name": f"jupyter-{self._identifier()}"[:63],
+            "cpu_cores": self.cpu_cores,
+            "memory_mb": self.memory_mb,
+            "allow_outbound": self.allow_outbound,
+            "allow_inbound": False,
+            "wait": True,
+            "timeout": self.create_timeout,
+            "metadata": {"purpose": "jupyter-kernel", "kernel_id": self.kernel_id or ""},
+        }
+        if self.image:
+            opts["image"] = self.image
+        if self.idle_timeout_minutes:
+            opts["idle_timeout_minutes"] = self.idle_timeout_minutes
+        if self.auth_token:
+            opts["auth_token"] = self.auth_token
+        if self.base_url:
+            opts["base_url"] = self.base_url
+        self.log.info("Creating Tenki Sandbox for kernel %s", self.kernel_id)
+        self._sandbox = Sandbox.create(**opts)
+        self.log.info("Sandbox %s ready", getattr(self._sandbox, "id", "?"))
+
+    def _ensure_ipykernel(self) -> None:
+        sb = self._sandbox
+        need = list(self.extra_pip_packages)
+        if self.install_ipykernel:
+            probe = sb.exec(self.python_executable, "-c", "import ipykernel", timeout=30)
+            if not probe.ok:
+                need.append("ipykernel")
+        if not need:
+            return
+        self.log.info("Installing in sandbox: %s", " ".join(need))
+        result = sb.exec(
+            self.python_executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            *need,
+            timeout=self.install_timeout,
+        )
+        result.check()
+
+    def _write_remote_connection_file(self) -> None:
+        remote_info = dict(self.connection_info)
+        remote_info["ip"] = self._remote_prefix
+        # bytes -> str for JSON (curve keys, if present, are already str here).
+        payload = json.dumps(
+            {k: (v.decode() if isinstance(v, bytes) else v) for k, v in remote_info.items()}
+        )
+        self._sandbox.fs.write_text(self._remote_conn_path, payload)
+
+    def _start_kernel_process(self, cmd: list[str]) -> None:
+        guest_env = {}
+        if self.kernel_spec is not None and self.kernel_spec.env:
+            guest_env.update(self.kernel_spec.env)
+        guest_env.update(self.env)
+        self.log.info("Launching kernel in sandbox: %s", " ".join(cmd))
+        self._process = self._sandbox.start(*cmd, cwd=REMOTE_HOME, env=guest_env or None)
+
+        def _reap() -> None:
+            try:
+                result = self._process.wait()
+                self._returncode = result.exit_code
+            except Exception:  # noqa: BLE001
+                self._returncode = 1
+
+        import threading
+
+        threading.Thread(target=_reap, name="tenki-kernel-reap", daemon=True).start()
+
+    def _await_kernel_sockets(self) -> None:
+        """Block until the kernel has bound all five ipc sockets in the guest."""
+        paths = [f"{self._remote_prefix}-{self.connection_info[f'{c}_port']}" for c in _CHANNELS]
+        test = " && ".join(f'test -S "{p}"' for p in paths)
+        script = (
+            f"for i in $(seq {self.kernel_ready_timeout}); do "
+            f"if {test}; then exit 0; fi; sleep 1; done; exit 1"
+        )
+        result = self._sandbox.exec("sh", "-c", script, timeout=self.kernel_ready_timeout + 10)
+        if not result.ok:
+            msg = (
+                "Kernel did not bind its channel sockets within "
+                f"{self.kernel_ready_timeout}s. stderr: {result.stderr_text}"
+            )
+            raise RuntimeError(msg)
+
+    def _start_proxy(self) -> None:
+        mappings = [
+            (
+                f"{self._local_prefix}-{self.connection_info[f'{c}_port']}",
+                f"{self._remote_prefix}-{self.connection_info[f'{c}_port']}",
+            )
+            for c in _CHANNELS
+        ]
+        self._proxy = IpcSocketProxy(self._sandbox, mappings, log=self.log)
+        self._proxy.start()
+
+    # ------------------------------------------------------------- process ctl
+    async def poll(self) -> int | None:
+        if self._process is None:
+            return 0
+        return self._returncode
+
+    async def wait(self) -> int | None:
+        if self._process is not None:
+            await self._run(self._process.wait)
+        return self._returncode
+
+    async def send_signal(self, signum: int) -> None:
+        if self._process is None:
+            return
+        if signum == signal.SIGKILL:
+            await self.kill()
+            return
+        try:
+            name = signal.Signals(signum).name  # e.g. "SIGINT"
+        except ValueError:
+            return
+        await self._run(self._process.signal, name)
+
+    async def kill(self, restart: bool = False) -> None:
+        if self._process is not None:
+            await self._run(self._process.kill)
+
+    async def terminate(self, restart: bool = False) -> None:
+        if self._process is not None:
+            try:
+                await self._run(self._process.signal, "SIGTERM")
+            except Exception:  # noqa: BLE001
+                pass
+
+    async def cleanup(self, restart: bool = False) -> None:
+        """Tear down the proxy and terminate the sandbox microVM."""
+        if self._proxy is not None:
+            self._proxy.close()
+            self._proxy = None
+        sandbox, self._sandbox = self._sandbox, None
+        if sandbox is not None:
+            self.log.info("Terminating sandbox for kernel %s", self.kernel_id)
+            await self._run(lambda: _safe_close(sandbox))
+        self._process = None
+        if self._tmpdir is not None:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+            self._tmpdir = None
+
+    async def get_provisioner_info(self) -> dict[str, Any]:
+        info = await super().get_provisioner_info()
+        info["sandbox_id"] = getattr(self._sandbox, "id", None)
+        return info
+
+
+def _safe_close(sandbox: Any) -> None:
+    for method in ("close", "terminate"):
+        fn = getattr(sandbox, method, None)
+        if callable(fn):
+            try:
+                fn()
+                return
+            except Exception:  # noqa: BLE001
+                continue

--- a/examples/tenki_provisioner/tenki_provisioner/provisioner.py
+++ b/examples/tenki_provisioner/tenki_provisioner/provisioner.py
@@ -5,8 +5,8 @@ Each kernel gets its own disposable, isolated Linux microVM.  The kernel talks
 to ``jupyter_client`` over the ZeroMQ ``ipc`` transport; the five channel
 sockets are bridged from the local machine into the guest with the Tenki
 Sandbox SDK's ``dial`` primitive (see :mod:`tenki_provisioner._proxy`).  The
-integration therefore depends only on the ``tenki-sandbox`` SDK -- no ssh, no
-CLI, no inbound networking.
+integration therefore depends only on the ``tenki`` SDK -- no ssh, no CLI, no
+inbound networking.
 """
 
 from __future__ import annotations
@@ -94,12 +94,11 @@ class TenkiProvisioner(KernelProvisionerBase):
     ).tag(config=True)
 
     # --- Placement / auth (auth falls back to TENKI_API_KEY / TENKI_API_ENDPOINT) ---
-    project_id = Unicode(
+    workspace_id = Unicode(
         "",
-        help="Tenki project to create the sandbox in. Required unless the "
+        help="Tenki workspace to create the sandbox in. Required unless the "
         "deployment auto-selects one. Discover via Client().who_am_i().",
     ).tag(config=True)
-    workspace_id = Unicode("", help="Tenki workspace id (optional).").tag(config=True)
     auth_token = Unicode(None, allow_none=True).tag(config=True)
     base_url = Unicode(None, allow_none=True).tag(config=True)
 
@@ -299,7 +298,7 @@ class TenkiProvisioner(KernelProvisionerBase):
         fut.add_done_callback(_cb)
 
     def _provision_sandbox(self) -> Any:
-        from tenki_sandbox import Sandbox
+        from tenki import Sandbox
 
         opts: dict[str, Any] = {
             "name": f"jupyter-{self._identifier()}"[:63],
@@ -311,8 +310,6 @@ class TenkiProvisioner(KernelProvisionerBase):
             "timeout": self.create_timeout,
             "metadata": {"purpose": "jupyter-kernel", "kernel_id": self.kernel_id or ""},
         }
-        if self.project_id:
-            opts["project_id"] = self.project_id
         if self.workspace_id:
             opts["workspace_id"] = self.workspace_id
         if self.image:
@@ -420,7 +417,7 @@ class TenkiProvisioner(KernelProvisionerBase):
         deployment hasn't enabled it, surface a clear error here rather than
         letting the kernel hang waiting for channels that never connect.
         """
-        from tenki_sandbox import CapabilityUnavailableError
+        from tenki import CapabilityUnavailableError
 
         probe = f"{self._remote_prefix}-{self.connection_info['hb_port']}"
         try:

--- a/examples/tenki_provisioner/tenki_provisioner/provisioner.py
+++ b/examples/tenki_provisioner/tenki_provisioner/provisioner.py
@@ -84,7 +84,13 @@ class TenkiProvisioner(KernelProvisionerBase):
         value_trait=Unicode(), help="Environment variables to set for the kernel process."
     ).tag(config=True)
 
-    # --- Auth (falls back to TENKI_API_KEY / TENKI_API_ENDPOINT envs) ------
+    # --- Placement / auth (auth falls back to TENKI_API_KEY / TENKI_API_ENDPOINT) ---
+    project_id = Unicode(
+        "",
+        help="Tenki project to create the sandbox in. Required unless the "
+        "deployment auto-selects one. Discover via Client().who_am_i().",
+    ).tag(config=True)
+    workspace_id = Unicode("", help="Tenki workspace id (optional).").tag(config=True)
     auth_token = Unicode(None, allow_none=True).tag(config=True)
     base_url = Unicode(None, allow_none=True).tag(config=True)
 
@@ -192,6 +198,10 @@ class TenkiProvisioner(KernelProvisionerBase):
             "timeout": self.create_timeout,
             "metadata": {"purpose": "jupyter-kernel", "kernel_id": self.kernel_id or ""},
         }
+        if self.project_id:
+            opts["project_id"] = self.project_id
+        if self.workspace_id:
+            opts["workspace_id"] = self.workspace_id
         if self.image:
             opts["image"] = self.image
         if self.idle_timeout_minutes:
@@ -214,16 +224,20 @@ class TenkiProvisioner(KernelProvisionerBase):
         if not need:
             return
         self.log.info("Installing in sandbox: %s", " ".join(need))
-        result = sb.exec(
-            self.python_executable,
-            "-m",
-            "pip",
-            "install",
-            "--quiet",
-            *need,
-            timeout=self.install_timeout,
-        )
-        result.check()
+        base = [self.python_executable, "-m", "pip", "install", "--quiet"]
+        result = sb.exec(*base, *need, timeout=self.install_timeout)
+        if not result.ok and "externally-managed" in (result.stdout_text + result.stderr_text):
+            # Debian/Ubuntu images mark the system interpreter externally
+            # managed (PEP 668). The guest is disposable, so a system-wide
+            # install is fine — retry allowing it.
+            self.log.info("Retrying install with --break-system-packages (PEP 668)")
+            result = sb.exec(
+                *base, "--break-system-packages", *need, timeout=self.install_timeout
+            )
+        if not result.ok:
+            detail = (result.stdout_text + "\n" + result.stderr_text).strip()
+            msg = f"Failed to install {' '.join(need)} in sandbox (exit {result.exit_code}):\n{detail}"
+            raise RuntimeError(msg)
 
     def _write_remote_connection_file(self) -> None:
         remote_info = dict(self.connection_info)

--- a/examples/tenki_provisioner/tenki_provisioner/provisioner.py
+++ b/examples/tenki_provisioner/tenki_provisioner/provisioner.py
@@ -174,6 +174,7 @@ class TenkiProvisioner(KernelProvisionerBase):
         await self._run(self._write_remote_connection_file)
         await self._run(self._start_kernel_process, cmd)
         await self._run(self._await_kernel_sockets)
+        await self._run(self._preflight_dial)
         self._start_proxy()
         return self.connection_info
 
@@ -267,6 +268,33 @@ class TenkiProvisioner(KernelProvisionerBase):
                 f"{self.kernel_ready_timeout}s. stderr: {result.stderr_text}"
             )
             raise RuntimeError(msg)
+
+    def _preflight_dial(self) -> None:
+        """Fail early, and legibly, if the guest is unreachable over ``dial``.
+
+        The channel bridge relies on the SDK's ``dial`` primitive. If a
+        deployment hasn't enabled it, surface a clear error here rather than
+        letting the kernel hang waiting for channels that never connect.
+        """
+        from tenki_sandbox import CapabilityUnavailableError
+
+        probe = f"{self._remote_prefix}-{self.connection_info['hb_port']}"
+        try:
+            conn = self._sandbox.dial(probe)
+        except CapabilityUnavailableError as exc:
+            msg = (
+                "Tenki Sandbox 'dial' is required to reach the kernel but is "
+                "unavailable in this deployment. Contact Tenki to enable it. "
+                f"({exc})"
+            )
+            raise RuntimeError(msg) from exc
+        except Exception as exc:  # noqa: BLE001 - transient; proxy will retry
+            self.log.warning("dial preflight to %s failed: %s", probe, exc)
+            return
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001
+            pass
 
     def _start_proxy(self) -> None:
         mappings = [

--- a/examples/tenki_provisioner/tests/README.md
+++ b/examples/tenki_provisioner/tests/README.md
@@ -1,0 +1,28 @@
+# Tests
+
+## Unit tests (no credentials)
+
+The SDK is fully mocked; these run anywhere and never bill.
+
+```bash
+pip install -e ".[test]"
+pytest
+```
+
+## Live end-to-end check (needs a Tenki API key)
+
+`live_e2e.py` starts a real kernel inside a Tenki Sandbox microVM, executes code
+in it, and asserts the kernel ran remotely (its hostname differs from the local
+machine). It provisions and then terminates a microVM, so it incurs a small
+amount of metered usage.
+
+```bash
+export TENKI_API_KEY=tk_...
+python tests/live_e2e.py
+```
+
+Expected tail:
+
+```
+PASS: kernel ran remotely on 'sandbox-xxxxxxx' (local is 'your-laptop').
+```

--- a/examples/tenki_provisioner/tests/README.md
+++ b/examples/tenki_provisioner/tests/README.md
@@ -18,11 +18,17 @@ amount of metered usage.
 
 ```bash
 export TENKI_API_KEY=tk_...
+# Some deployments require naming the project (see the top-level README):
+export TENKI_PROJECT_ID=<project-uuid>
 python tests/live_e2e.py
 ```
 
 Expected tail:
 
 ```
-PASS: kernel ran remotely on 'sandbox-xxxxxxx' (local is 'your-laptop').
+PASS: kernel ran remotely on '019f84cb-9a1a-...' (local is 'your-laptop').
 ```
+
+This has been verified end to end against live Tenki (Ubuntu 24.04 guest,
+Python 3.12): kernel started in a microVM, `6 * 7` computed remotely, microVM
+terminated on shutdown.

--- a/examples/tenki_provisioner/tests/README.md
+++ b/examples/tenki_provisioner/tests/README.md
@@ -19,7 +19,7 @@ amount of metered usage.
 ```bash
 export TENKI_API_KEY=tk_...
 # Some deployments require naming the project (see the top-level README):
-export TENKI_PROJECT_ID=<project-uuid>
+export TENKI_WORKSPACE_ID=<workspace-uuid>
 python tests/live_e2e.py
 ```
 

--- a/examples/tenki_provisioner/tests/live_e2e.py
+++ b/examples/tenki_provisioner/tests/live_e2e.py
@@ -39,8 +39,8 @@ def main() -> None:
     # Route this kernel through the Tenki provisioner regardless of the
     # installed kernelspec, so the check is self-contained.
     config = {"cpu_cores": 2, "memory_mb": 4096}
-    if os.environ.get("TENKI_PROJECT_ID"):
-        config["project_id"] = os.environ["TENKI_PROJECT_ID"]
+    if os.environ.get("TENKI_WORKSPACE_ID"):
+        config["workspace_id"] = os.environ["TENKI_WORKSPACE_ID"]
     km.kernel_spec.metadata["kernel_provisioner"] = {
         "provisioner_name": "tenki-provisioner",
         "config": config,
@@ -116,7 +116,7 @@ def main() -> None:
 
 def _verify_terminated(sandbox_id: str, timeout: float = 60.0) -> None:
     """Poll until the sandbox reaches a terminal state, enforcing no leak."""
-    from tenki_sandbox import Client, SessionNotFoundError, SessionTerminatedError
+    from tenki import Client, SessionNotFoundError, SessionTerminatedError
 
     print(f"Verifying sandbox {sandbox_id} reached TERMINATED ...")
     client = Client()

--- a/examples/tenki_provisioner/tests/live_e2e.py
+++ b/examples/tenki_provisioner/tests/live_e2e.py
@@ -16,6 +16,7 @@ import os
 import queue
 import socket
 import sys
+import time
 import uuid
 
 from jupyter_client.manager import KernelManager
@@ -46,7 +47,9 @@ def main() -> None:
     }
 
     print(f"Starting kernel {kid} in a Tenki Sandbox microVM (local host: {local_host}) ...")
-    km.start_kernel()
+    km.start_kernel(env={"TENKI_E2E_SENTINEL": "sentinel-42"})
+    sandbox_id = km.provisioner.sandbox_id
+    print(f"Sandbox id: {sandbox_id}")
     kc = km.client()
     kc.start_channels()
     try:
@@ -54,10 +57,11 @@ def main() -> None:
         print("Kernel is ready. Executing remote code ...")
 
         code = (
-            "import socket, sys, platform\n"
+            "import socket, sys, platform, os\n"
             "print('HOST=' + socket.gethostname())\n"
             "print('PLATFORM=' + sys.platform)\n"
             "print('UNAME=' + platform.uname().release)\n"
+            "print('SENTINEL=' + os.environ.get('TENKI_E2E_SENTINEL', 'MISSING'))\n"
             "print('SUM=' + str(6 * 7))\n"
         )
         msg_id = kc.execute(code)
@@ -89,10 +93,12 @@ def main() -> None:
 
         if "SUM=42" not in text:
             _fail("did not observe expected computation result (SUM=42)")
+        if "SENTINEL=sentinel-42" not in text:
+            _fail("start_kernel(env=...) did not reach the guest (env not propagated)")
         remote_host = ""
         for line in text.splitlines():
             if line.startswith("HOST="):
-                remote_host = line[len("HOST="):].strip()
+                remote_host = line[len("HOST=") :].strip()
         if not remote_host:
             _fail("could not read remote hostname")
         if remote_host == local_host:
@@ -103,6 +109,33 @@ def main() -> None:
         print("Shutting down kernel and terminating microVM ...")
         kc.stop_channels()
         km.shutdown_kernel(now=True)
+
+    if sandbox_id:
+        _verify_terminated(sandbox_id)
+
+
+def _verify_terminated(sandbox_id: str, timeout: float = 60.0) -> None:
+    """Poll until the sandbox reaches a terminal state, enforcing no leak."""
+    from tenki_sandbox import Client, SandboxError
+
+    print(f"Verifying sandbox {sandbox_id} reached TERMINATED ...")
+    client = Client()
+    deadline = time.monotonic() + timeout
+    last_state = "?"
+    while time.monotonic() < deadline:
+        try:
+            sb = client.get(sandbox_id)
+            sb.refresh()
+            last_state = sb.state
+        except SandboxError as exc:
+            # A gone/not-found/terminated session is a terminal outcome.
+            print(f"PASS: sandbox is gone ({type(exc).__name__}).")
+            return
+        if last_state == "TERMINATED":
+            print("PASS: sandbox reached TERMINATED.")
+            return
+        time.sleep(2)
+    _fail(f"sandbox {sandbox_id} did not terminate within {timeout}s (last state {last_state})")
 
 
 if __name__ == "__main__":

--- a/examples/tenki_provisioner/tests/live_e2e.py
+++ b/examples/tenki_provisioner/tests/live_e2e.py
@@ -116,7 +116,7 @@ def main() -> None:
 
 def _verify_terminated(sandbox_id: str, timeout: float = 60.0) -> None:
     """Poll until the sandbox reaches a terminal state, enforcing no leak."""
-    from tenki_sandbox import Client, SandboxError
+    from tenki_sandbox import Client, SessionNotFoundError, SessionTerminatedError
 
     print(f"Verifying sandbox {sandbox_id} reached TERMINATED ...")
     client = Client()
@@ -127,8 +127,9 @@ def _verify_terminated(sandbox_id: str, timeout: float = 60.0) -> None:
             sb = client.get(sandbox_id)
             sb.refresh()
             last_state = sb.state
-        except SandboxError as exc:
-            # A gone/not-found/terminated session is a terminal outcome.
+        except (SessionNotFoundError, SessionTerminatedError) as exc:
+            # Only a gone/terminated session counts as success; auth/service
+            # errors must propagate rather than masquerade as termination.
             print(f"PASS: sandbox is gone ({type(exc).__name__}).")
             return
         if last_state == "TERMINATED":

--- a/examples/tenki_provisioner/tests/live_e2e.py
+++ b/examples/tenki_provisioner/tests/live_e2e.py
@@ -37,9 +37,12 @@ def main() -> None:
     km.kernel_id = kid
     # Route this kernel through the Tenki provisioner regardless of the
     # installed kernelspec, so the check is self-contained.
+    config = {"cpu_cores": 2, "memory_mb": 4096}
+    if os.environ.get("TENKI_PROJECT_ID"):
+        config["project_id"] = os.environ["TENKI_PROJECT_ID"]
     km.kernel_spec.metadata["kernel_provisioner"] = {
         "provisioner_name": "tenki-provisioner",
-        "config": {"cpu_cores": 2, "memory_mb": 4096},
+        "config": config,
     }
 
     print(f"Starting kernel {kid} in a Tenki Sandbox microVM (local host: {local_host}) ...")

--- a/examples/tenki_provisioner/tests/live_e2e.py
+++ b/examples/tenki_provisioner/tests/live_e2e.py
@@ -1,0 +1,106 @@
+"""Live end-to-end check: start a real kernel inside a Tenki Sandbox microVM,
+execute code in it, and prove it ran remotely.
+
+Requires a Tenki API key in the environment::
+
+    export TENKI_API_KEY=tk_...
+    python tests/live_e2e.py
+
+Exits non-zero on any failure. This is intentionally a script (not a pytest
+test) so it never runs — or bills — during ordinary `pytest` runs.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import socket
+import sys
+import uuid
+
+from jupyter_client.manager import KernelManager
+
+
+def _fail(msg: str) -> None:
+    print(f"FAIL: {msg}")
+    sys.exit(1)
+
+
+def main() -> None:
+    if not (os.environ.get("TENKI_API_KEY") or os.environ.get("TENKI_AUTH_TOKEN")):
+        _fail("set TENKI_API_KEY (or TENKI_AUTH_TOKEN) first")
+
+    local_host = socket.gethostname()
+    kid = f"live-{uuid.uuid4().hex[:8]}"
+
+    km = KernelManager(kernel_name="python3")
+    km.kernel_id = kid
+    # Route this kernel through the Tenki provisioner regardless of the
+    # installed kernelspec, so the check is self-contained.
+    km.kernel_spec.metadata["kernel_provisioner"] = {
+        "provisioner_name": "tenki-provisioner",
+        "config": {"cpu_cores": 2, "memory_mb": 4096},
+    }
+
+    print(f"Starting kernel {kid} in a Tenki Sandbox microVM (local host: {local_host}) ...")
+    km.start_kernel()
+    kc = km.client()
+    kc.start_channels()
+    try:
+        kc.wait_for_ready(timeout=180)
+        print("Kernel is ready. Executing remote code ...")
+
+        code = (
+            "import socket, sys, platform\n"
+            "print('HOST=' + socket.gethostname())\n"
+            "print('PLATFORM=' + sys.platform)\n"
+            "print('UNAME=' + platform.uname().release)\n"
+            "print('SUM=' + str(6 * 7))\n"
+        )
+        msg_id = kc.execute(code)
+
+        outputs: list[str] = []
+        got_reply = False
+        while True:
+            try:
+                msg = kc.get_iopub_msg(timeout=60)
+            except queue.Empty:
+                break
+            if msg["parent_header"].get("msg_id") != msg_id:
+                continue
+            mtype = msg["msg_type"]
+            content = msg["content"]
+            if mtype == "stream":
+                outputs.append(content["text"])
+            elif mtype == "error":
+                _fail("remote execution error:\n" + "\n".join(content["traceback"]))
+            elif mtype == "status" and content["execution_state"] == "idle" and got_reply:
+                break
+            elif mtype == "execute_input":
+                got_reply = True
+
+        text = "".join(outputs)
+        print("--- remote stdout ---")
+        print(text.rstrip())
+        print("---------------------")
+
+        if "SUM=42" not in text:
+            _fail("did not observe expected computation result (SUM=42)")
+        remote_host = ""
+        for line in text.splitlines():
+            if line.startswith("HOST="):
+                remote_host = line[len("HOST="):].strip()
+        if not remote_host:
+            _fail("could not read remote hostname")
+        if remote_host == local_host:
+            _fail(f"kernel appears to be local (host {remote_host} == {local_host})")
+
+        print(f"PASS: kernel ran remotely on {remote_host!r} (local is {local_host!r}).")
+    finally:
+        print("Shutting down kernel and terminating microVM ...")
+        kc.stop_channels()
+        km.shutdown_kernel(now=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tenki_provisioner/tests/test_provisioner.py
+++ b/examples/tenki_provisioner/tests/test_provisioner.py
@@ -1,0 +1,278 @@
+"""Unit tests for the Tenki kernel provisioner (SDK fully mocked).
+
+The live, end-to-end path (a real kernel in a real microVM) is exercised
+separately; these tests pin down the provisioner's control logic and the
+loopback socket proxy without needing Tenki credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import threading
+
+import pytest
+from jupyter_client.kernelspec import KernelSpec
+from traitlets.config import LoggingConfigurable
+
+from tenki_provisioner import TenkiProvisioner
+from tenki_provisioner._proxy import IpcSocketProxy
+
+# --------------------------------------------------------------------------- fakes
+
+
+class FakeKernelManager(LoggingConfigurable):
+    """Minimal stand-in for a ConnectionFileMixin/KernelManager."""
+
+    def __init__(self, conn_path: str, **kw):
+        super().__init__(**kw)
+        self.transport = "tcp"
+        self.ip = "127.0.0.1"
+        self.cache_ports = True
+        self.key = "0000-secret"
+        self._conn_path = conn_path
+        for name in ("shell", "iopub", "stdin", "control", "hb"):
+            setattr(self, f"{name}_port", 0)
+
+    def write_connection_file(self, jupyter_session=""):
+        # Emulate ipc channel-index assignment (1..5).
+        self.shell_port, self.iopub_port, self.stdin_port = 1, 2, 3
+        self.control_port, self.hb_port = 4, 5
+        with open(self._conn_path, "w") as fh:
+            json.dump(self.get_connection_info(), fh)
+
+    def get_connection_info(self):
+        return {
+            "transport": self.transport,
+            "ip": self.ip,
+            "key": self.key,
+            "signature_scheme": "hmac-sha256",
+            "kernel_name": "python3",
+            "shell_port": self.shell_port,
+            "iopub_port": self.iopub_port,
+            "stdin_port": self.stdin_port,
+            "control_port": self.control_port,
+            "hb_port": self.hb_port,
+        }
+
+
+class FakeResult:
+    def __init__(self, ok=True, exit_code=0, stderr=""):
+        self.ok = ok
+        self.exit_code = exit_code
+        self.stderr_text = stderr
+
+    def check(self):
+        if not self.ok:
+            raise RuntimeError(f"command failed: {self.stderr_text}")
+
+
+class FakeProcess:
+    def __init__(self):
+        self._done = threading.Event()
+        self.exit_code = None
+        self.signals: list[str] = []
+
+    def wait(self, timeout=None):
+        self._done.wait(timeout)
+        return FakeResult(exit_code=self.exit_code or 0)
+
+    def signal(self, name):
+        self.signals.append(name)
+
+    def kill(self):
+        self.signals.append("SIGKILL")
+        self.exit_code = -9
+        self._done.set()
+
+
+class FakeFS:
+    def __init__(self):
+        self.files: dict[str, str] = {}
+
+    def write_text(self, path, data):
+        self.files[path] = data
+
+
+class FakeSandbox:
+    """Records interactions; ipykernel is 'already installed', sockets 'ready'."""
+
+    id = "sbx-unit-test"
+
+    def __init__(self, dial_factory=None):
+        self.fs = FakeFS()
+        self.exec_calls: list[tuple] = []
+        self.start_calls: list[tuple] = []
+        self.process = FakeProcess()
+        self.closed = False
+        self._dial_factory = dial_factory
+
+    def exec(self, *argv, **kw):
+        self.exec_calls.append(argv)
+        return FakeResult(ok=True)
+
+    def start(self, *argv, **kw):
+        self.start_calls.append((argv, kw))
+        return self.process
+
+    def dial(self, path):
+        assert self._dial_factory is not None, "dial not expected in this test"
+        return self._dial_factory(path)
+
+    def close(self):
+        self.closed = True
+
+
+def make_provisioner(tmp_path, sandbox, **config):
+    import tenki_sandbox
+
+    # from tenki_sandbox import Sandbox; Sandbox.create(**opts) -> our fake
+    def _create(**opts):
+        sandbox.create_opts = opts
+        return sandbox
+
+    tenki_sandbox.Sandbox.create = staticmethod(_create)
+
+    ks = KernelSpec(
+        argv=["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+        language="python",
+        env={},
+        display_name="test",
+    )
+    km = FakeKernelManager(str(tmp_path / "local-conn.json"))
+    return TenkiProvisioner(parent=km, kernel_id="k1", kernel_spec=ks, **config), km
+
+
+# --------------------------------------------------------------------------- tests
+
+
+async def test_pre_launch_switches_to_ipc(tmp_path):
+    prov, km = make_provisioner(tmp_path, FakeSandbox())
+    kw = await prov.pre_launch(env={})
+
+    assert km.transport == "ipc"
+    assert km.cache_ports is False
+    assert km.ip == prov._local_prefix
+    # connection command targets the guest-side connection file
+    assert kw["cmd"] == [
+        "python3",
+        "-m",
+        "ipykernel_launcher",
+        "-f",
+        "/home/tenki/k1-connection.json",
+    ]
+    assert prov.connection_info["transport"] == "ipc"
+    assert prov.connection_info["shell_port"] == 1
+
+
+async def test_launch_provisions_and_bridges(tmp_path):
+    sandbox = FakeSandbox()
+    prov, km = make_provisioner(tmp_path, sandbox, cpu_cores=4, memory_mb=8192)
+
+    kw = await prov.pre_launch(env={})
+    cmd = kw.pop("cmd")
+    info = await prov.launch_kernel(cmd, **kw)
+
+    # sandbox sized from config
+    assert sandbox.create_opts["cpu_cores"] == 4
+    assert sandbox.create_opts["memory_mb"] == 8192
+    assert sandbox.create_opts["allow_inbound"] is False
+
+    # guest-side connection file written, differing only in the ip prefix
+    remote = json.loads(sandbox.fs.files["/home/tenki/k1-connection.json"])
+    assert remote["ip"] == "/home/tenki/k1-k"
+    assert remote["key"] == info["key"]
+    assert remote["shell_port"] == info["shell_port"]
+
+    # kernel launched with the substituted argv in the guest home
+    (argv, start_kw), = [(a, k) for a, k in sandbox.start_calls]
+    assert argv[:3] == ("python3", "-m", "ipykernel_launcher")
+    assert start_kw["cwd"] == "/home/tenki"
+
+    # local channel sockets are bound by the proxy
+    for ch in ("shell", "iopub", "stdin", "control", "hb"):
+        port = info[f"{ch}_port"]
+        assert os.path.exists(f"{prov._local_prefix}-{port}")
+
+    assert await prov.poll() is None  # still running
+
+    await prov.cleanup()
+    assert sandbox.closed is True
+    assert prov.has_process is False
+    assert not os.path.exists(f"{prov._local_prefix}-1")  # sockets cleaned up
+
+
+async def test_signals_forwarded(tmp_path):
+    sandbox = FakeSandbox()
+    prov, km = make_provisioner(tmp_path, sandbox)
+    kw = await prov.pre_launch(env={})
+    await prov.launch_kernel(kw.pop("cmd"), **kw)
+
+    await prov.send_signal(signal.SIGINT)
+    assert "SIGINT" in sandbox.process.signals
+
+    await prov.kill()
+    assert "SIGKILL" in sandbox.process.signals
+    assert await prov.wait() == -9
+
+    await prov.cleanup()
+
+
+def test_ipc_proxy_bridges_bytes(tmp_path):
+    """A local unix-socket client reaches a guest 'echo' socket via dial()."""
+
+    def dial_factory(remote_path):
+        near, far = socket.socketpair()
+
+        def echo():
+            try:
+                while True:
+                    data = far.recv(4096)
+                    if not data:
+                        break
+                    far.sendall(data)  # echo back
+            finally:
+                far.close()
+
+        threading.Thread(target=echo, daemon=True).start()
+        return _SocketDial(near)
+
+    sandbox = FakeSandbox(dial_factory=dial_factory)
+    # Unix-domain socket paths are length-limited; use a short dir, not tmp_path.
+    import tempfile
+
+    sock_dir = tempfile.mkdtemp(prefix="tk-", dir="/tmp")
+    local_path = os.path.join(sock_dir, "chan-1")
+    proxy = IpcSocketProxy(sandbox, [(local_path, "/home/tenki/remote-1")])
+    proxy.start()
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(5)
+        client.connect(local_path)
+        client.sendall(b"ping-through-tenki")
+        assert client.recv(4096) == b"ping-through-tenki"
+        client.close()
+    finally:
+        proxy.close()
+
+
+class _SocketDial:
+    """Adapts a socket to the DialConn read/write/close surface used by the proxy."""
+
+    def __init__(self, sock):
+        self._sock = sock
+
+    def write(self, data):
+        self._sock.sendall(data)
+
+    def read(self, n):
+        return self._sock.recv(n)
+
+    def close(self):
+        try:
+            self._sock.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        self._sock.close()

--- a/examples/tenki_provisioner/tests/test_provisioner.py
+++ b/examples/tenki_provisioner/tests/test_provisioner.py
@@ -33,10 +33,12 @@ class FakeKernelManager(LoggingConfigurable):
         self.cache_ports = True
         self.key = "0000-secret"
         self._conn_path = conn_path
+        self.write_connection_file_calls = 0
         for name in ("shell", "iopub", "stdin", "control", "hb"):
             setattr(self, f"{name}_port", 0)
 
     def write_connection_file(self, jupyter_session=""):
+        self.write_connection_file_calls += 1
         # Emulate ipc channel-index assignment (1..5).
         self.shell_port, self.iopub_port, self.stdin_port = 1, 2, 3
         self.control_port, self.hb_port = 4, 5
@@ -193,10 +195,11 @@ async def test_launch_provisions_and_bridges(tmp_path):
     cmd = kw.pop("cmd")
     info = await prov.launch_kernel(cmd, **kw)
 
-    # sandbox sized from config
+    # sandbox sized from config, with a finite max_duration backstop
     assert sandbox.create_opts["cpu_cores"] == 4
     assert sandbox.create_opts["memory_mb"] == 8192
     assert sandbox.create_opts["allow_inbound"] is False
+    assert sandbox.create_opts["max_duration"] == 3600
 
     # guest-side connection file written, differing only in the ip prefix
     remote = json.loads(sandbox.fs.files["/home/tenki/k1-connection.json"])
@@ -205,7 +208,7 @@ async def test_launch_provisions_and_bridges(tmp_path):
     assert remote["shell_port"] == info["shell_port"]
 
     # kernel launched with the substituted argv in the guest home
-    (argv, start_kw), = [(a, k) for a, k in sandbox.start_calls]
+    ((argv, start_kw),) = [(a, k) for a, k in sandbox.start_calls]
     assert argv[:3] == ("python3", "-m", "ipykernel_launcher")
     assert start_kw["cwd"] == "/home/tenki"
 
@@ -216,10 +219,11 @@ async def test_launch_provisions_and_bridges(tmp_path):
 
     assert await prov.poll() is None  # still running
 
+    prefix = prov._local_prefix
     await prov.cleanup()
     assert sandbox.closed is True
     assert prov.has_process is False
-    assert not os.path.exists(f"{prov._local_prefix}-1")  # sockets cleaned up
+    assert not os.path.exists(f"{prefix}-1")  # sockets cleaned up
 
 
 async def test_signals_forwarded(tmp_path):
@@ -256,8 +260,11 @@ async def test_launch_failure_tears_down_sandbox(tmp_path):
     assert prov.has_process is False
 
 
-async def test_teardown_failure_retains_handle_for_retry(tmp_path):
-    """A failed terminate is not reported as success; the handle is kept."""
+async def test_teardown_failure_raises_and_retains_handle(tmp_path, monkeypatch):
+    """A failed terminate is raised (observable), not reported as success."""
+    import tenki_provisioner.provisioner as prov_mod
+
+    monkeypatch.setattr(prov_mod.time, "sleep", lambda _s: None)  # no retry delay
     sandbox = FakeSandbox()
     fail = {"on": True}
 
@@ -271,8 +278,9 @@ async def test_teardown_failure_retains_handle_for_retry(tmp_path):
     kw = await prov.pre_launch(env={})
     await prov.launch_kernel(kw.pop("cmd"), **kw)
 
-    # First cleanup: teardown fails -> handle retained, no exception raised.
-    await prov.cleanup()
+    # First cleanup: teardown fails -> raises, handle retained for a retry.
+    with pytest.raises(RuntimeError, match="terminate failed"):
+        await prov.cleanup()
     assert prov._sandbox is sandbox
 
     # Recover and retry: teardown now succeeds and the handle is cleared.
@@ -280,6 +288,60 @@ async def test_teardown_failure_retains_handle_for_retry(tmp_path):
     await prov.cleanup()
     assert prov._sandbox is None
     assert sandbox.closed is True
+
+
+async def test_restart_preserves_connection(tmp_path):
+    """A restart reuses the same prefix/ports/connection file (comment #3)."""
+    sandbox = FakeSandbox()
+    prov, km = make_provisioner(tmp_path, sandbox)
+
+    kw = await prov.pre_launch(env={})
+    await prov.launch_kernel(kw.pop("cmd"), **kw)
+    prefix, info = prov._local_prefix, dict(prov.connection_info)
+    write_calls_after_first = km.write_connection_file_calls
+
+    # Restart: manager tears down with restart=True, then pre_launch/launch again.
+    await prov.cleanup(restart=True)
+    assert prov._local_prefix == prefix  # prefix preserved across restart
+    assert os.path.isdir(prov._tmpdir)
+
+    kw2 = await prov.pre_launch(env={})
+    # No new connection file / prefix churn on restart.
+    assert km.write_connection_file_calls == write_calls_after_first
+    assert prov._local_prefix == prefix
+    assert prov.connection_info == info
+    await prov.launch_kernel(kw2.pop("cmd"), **kw2)
+    assert await prov.poll() is None  # fresh process, not the stale return code
+    await prov.cleanup()
+
+
+async def test_env_is_forwarded_to_guest(tmp_path):
+    """kernelspec/start_kernel(env=) additions reach the guest (comment #7)."""
+    sandbox = FakeSandbox()
+    prov, km = make_provisioner(tmp_path, sandbox)
+    kw = await prov.pre_launch(env={"SENTINEL": "present", "PATH": os.environ.get("PATH", "")})
+    await prov.launch_kernel(kw.pop("cmd"), **kw)
+
+    ((_argv, start_kw),) = [(a, k) for a, k in sandbox.start_calls]
+    guest_env = start_kw["env"]
+    assert guest_env["SENTINEL"] == "present"  # explicit addition forwarded
+    assert "PATH" not in guest_env  # ambient local var not dumped into the guest
+    await prov.cleanup()
+
+
+def test_reap_late_creation_terminates_orphan(tmp_path):
+    """A sandbox created after cancellation is terminated, not leaked (comment #1)."""
+    import concurrent.futures
+
+    sandbox = FakeSandbox()
+    prov, _km = make_provisioner(tmp_path, sandbox)
+    prov._sandbox = None  # cleanup already ran; awaiter was cancelled
+
+    fut: concurrent.futures.Future = concurrent.futures.Future()
+    prov._reap_late_creation(fut)
+    fut.set_result(sandbox)  # create finishes late, after cancellation
+
+    assert sandbox.closed is True  # the late sandbox was terminated
 
 
 async def test_ipykernel_install_retries_on_pep668(tmp_path):

--- a/examples/tenki_provisioner/tests/test_provisioner.py
+++ b/examples/tenki_provisioner/tests/test_provisioner.py
@@ -7,6 +7,7 @@ loopback socket proxy without needing Tenki credentials.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import signal
@@ -342,6 +343,73 @@ def test_reap_late_creation_terminates_orphan(tmp_path):
     fut.set_result(sandbox)  # create finishes late, after cancellation
 
     assert sandbox.closed is True  # the late sandbox was terminated
+
+
+async def test_real_cancellation_reaps_late_sandbox(tmp_path):
+    """Cancelling the launch task still terminates a sandbox that arrives late."""
+    import tenki_sandbox
+
+    started = threading.Event()
+    release = threading.Event()
+    sandbox = FakeSandbox()
+
+    def slow_create(**_opts):
+        started.set()
+        release.wait(5)  # block until the test lets create() finish
+        return sandbox
+
+    tenki_sandbox.Sandbox.create = staticmethod(slow_create)
+    ks = KernelSpec(argv=["python3"], language="python", env={}, display_name="t")
+    km = FakeKernelManager(str(tmp_path / "c.json"))
+    prov = TenkiProvisioner(parent=km, kernel_id="k1", kernel_spec=ks)
+
+    task = asyncio.ensure_future(prov._provision_sandbox_cancellation_safe())
+    await asyncio.get_running_loop().run_in_executor(None, started.wait, 5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    release.set()  # create() completes after cancellation -> must be reaped
+    for _ in range(100):
+        if sandbox.closed:
+            break
+        await asyncio.sleep(0.02)
+    assert sandbox.closed is True
+    assert prov._sandbox is None
+
+
+async def test_explicit_env_matching_parent_is_forwarded(tmp_path, monkeypatch):
+    """An explicit env value equal to the parent env is still forwarded (issue #4)."""
+    monkeypatch.setenv("SHARED", "parent-value")
+    sandbox = FakeSandbox()
+    prov, km = make_provisioner(tmp_path, sandbox)
+    # Caller sets SHARED to the same value the parent process already has.
+    km._launch_args = {"env": {"SHARED": "parent-value"}}
+    kw = await prov.pre_launch(env={"SHARED": "parent-value"})
+    await prov.launch_kernel(kw.pop("cmd"), **kw)
+
+    ((_argv, start_kw),) = [(a, k) for a, k in sandbox.start_calls]
+    assert start_kw["env"]["SHARED"] == "parent-value"  # explicit key kept
+    await prov.cleanup()
+
+
+async def test_transport_encryption_sets_curve_keys(tmp_path):
+    """transport_encryption=required generates Curve keys over ipc (issue #2)."""
+    import zmq
+
+    sandbox = FakeSandbox()
+    prov, km = make_provisioner(tmp_path, sandbox)
+    km.transport_encryption = "required"
+    km._transport_encryption_policy = lambda raw=None: "required"
+    km._kernel_supports_curve_encryption = lambda: True
+    km.curve_publickey = None
+    km.curve_secretkey = None
+
+    await prov.pre_launch(env={})
+    assert km.curve_publickey is not None
+    assert km.curve_secretkey is not None
+    # sanity: a real Curve keypair round-trips
+    assert len(zmq.curve_keypair()[0]) == len(km.curve_publickey)
 
 
 async def test_ipykernel_install_retries_on_pep668(tmp_path):

--- a/examples/tenki_provisioner/tests/test_provisioner.py
+++ b/examples/tenki_provisioner/tests/test_provisioner.py
@@ -147,14 +147,14 @@ class _NullDial:
 
 
 def make_provisioner(tmp_path, sandbox, **config):
-    import tenki_sandbox
+    import tenki
 
-    # from tenki_sandbox import Sandbox; Sandbox.create(**opts) -> our fake
+    # from tenki import Sandbox; Sandbox.create(**opts) -> our fake
     def _create(**opts):
         sandbox.create_opts = opts
         return sandbox
 
-    tenki_sandbox.Sandbox.create = staticmethod(_create)
+    tenki.Sandbox.create = staticmethod(_create)
 
     ks = KernelSpec(
         argv=["python3", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
@@ -347,7 +347,7 @@ def test_reap_late_creation_terminates_orphan(tmp_path):
 
 async def test_real_cancellation_reaps_late_sandbox(tmp_path):
     """Cancelling the launch task still terminates a sandbox that arrives late."""
-    import tenki_sandbox
+    import tenki
 
     started = threading.Event()
     release = threading.Event()
@@ -358,7 +358,7 @@ async def test_real_cancellation_reaps_late_sandbox(tmp_path):
         release.wait(5)  # block until the test lets create() finish
         return sandbox
 
-    tenki_sandbox.Sandbox.create = staticmethod(slow_create)
+    tenki.Sandbox.create = staticmethod(slow_create)
     ks = KernelSpec(argv=["python3"], language="python", env={}, display_name="t")
     km = FakeKernelManager(str(tmp_path / "c.json"))
     prov = TenkiProvisioner(parent=km, kernel_id="k1", kernel_spec=ks)
@@ -439,7 +439,7 @@ async def test_ipykernel_install_retries_on_pep668(tmp_path):
 
 
 async def test_launch_fails_clearly_when_dial_unavailable(tmp_path):
-    from tenki_sandbox import CapabilityUnavailableError
+    from tenki import CapabilityUnavailableError
 
     sandbox = FakeSandbox()
 

--- a/examples/tenki_provisioner/tests/test_provisioner.py
+++ b/examples/tenki_provisioner/tests/test_provisioner.py
@@ -118,11 +118,25 @@ class FakeSandbox:
         return self.process
 
     def dial(self, path):
-        assert self._dial_factory is not None, "dial not expected in this test"
-        return self._dial_factory(path)
+        if self._dial_factory is not None:
+            return self._dial_factory(path)
+        return _NullDial()
 
     def close(self):
         self.closed = True
+
+
+class _NullDial:
+    """A no-op dial connection used for the preflight probe in unit tests."""
+
+    def write(self, data):
+        return len(data)
+
+    def read(self, n):
+        return b""
+
+    def close(self):
+        pass
 
 
 def make_provisioner(tmp_path, sandbox, **config):
@@ -217,6 +231,22 @@ async def test_signals_forwarded(tmp_path):
     assert "SIGKILL" in sandbox.process.signals
     assert await prov.wait() == -9
 
+    await prov.cleanup()
+
+
+async def test_launch_fails_clearly_when_dial_unavailable(tmp_path):
+    from tenki_sandbox import CapabilityUnavailableError
+
+    sandbox = FakeSandbox()
+
+    def _boom(_path):
+        raise CapabilityUnavailableError("dial")
+
+    sandbox.dial = _boom  # type: ignore[assignment]
+    prov, km = make_provisioner(tmp_path, sandbox)
+    kw = await prov.pre_launch(env={})
+    with pytest.raises(RuntimeError, match="dial"):
+        await prov.launch_kernel(kw.pop("cmd"), **kw)
     await prov.cleanup()
 
 

--- a/examples/tenki_provisioner/tests/test_provisioner.py
+++ b/examples/tenki_provisioner/tests/test_provisioner.py
@@ -123,6 +123,9 @@ class FakeSandbox:
             return self._dial_factory(path)
         return _NullDial()
 
+    def refresh(self):
+        return None
+
     def close(self):
         self.closed = True
 
@@ -233,6 +236,50 @@ async def test_signals_forwarded(tmp_path):
     assert await prov.wait() == -9
 
     await prov.cleanup()
+
+
+async def test_launch_failure_tears_down_sandbox(tmp_path):
+    """A failure after create must not leak the microVM (failure-atomic launch)."""
+    sandbox = FakeSandbox()
+
+    def _boom(*argv, **kw):
+        raise RuntimeError("kernel launch boom")
+
+    sandbox.start = _boom  # type: ignore[assignment]  # fails after provision
+    prov, km = make_provisioner(tmp_path, sandbox)
+    kw = await prov.pre_launch(env={})
+    with pytest.raises(RuntimeError, match="boom"):
+        await prov.launch_kernel(kw.pop("cmd"), **kw)
+
+    assert sandbox.closed is True  # sandbox was terminated on the failure path
+    assert prov._sandbox is None
+    assert prov.has_process is False
+
+
+async def test_teardown_failure_retains_handle_for_retry(tmp_path):
+    """A failed terminate is not reported as success; the handle is kept."""
+    sandbox = FakeSandbox()
+    fail = {"on": True}
+
+    def flaky_close():
+        if fail["on"]:
+            raise RuntimeError("terminate failed")
+        sandbox.closed = True
+
+    sandbox.close = flaky_close  # type: ignore[assignment]
+    prov, km = make_provisioner(tmp_path, sandbox)
+    kw = await prov.pre_launch(env={})
+    await prov.launch_kernel(kw.pop("cmd"), **kw)
+
+    # First cleanup: teardown fails -> handle retained, no exception raised.
+    await prov.cleanup()
+    assert prov._sandbox is sandbox
+
+    # Recover and retry: teardown now succeeds and the handle is cleared.
+    fail["on"] = False
+    await prov.cleanup()
+    assert prov._sandbox is None
+    assert sandbox.closed is True
 
 
 async def test_ipykernel_install_retries_on_pep668(tmp_path):

--- a/examples/tenki_provisioner/tests/test_provisioner.py
+++ b/examples/tenki_provisioner/tests/test_provisioner.py
@@ -59,10 +59,11 @@ class FakeKernelManager(LoggingConfigurable):
 
 
 class FakeResult:
-    def __init__(self, ok=True, exit_code=0, stderr=""):
+    def __init__(self, ok=True, exit_code=0, stderr="", stdout=""):
         self.ok = ok
         self.exit_code = exit_code
         self.stderr_text = stderr
+        self.stdout_text = stdout
 
     def check(self):
         if not self.ok:
@@ -231,6 +232,32 @@ async def test_signals_forwarded(tmp_path):
     assert "SIGKILL" in sandbox.process.signals
     assert await prov.wait() == -9
 
+    await prov.cleanup()
+
+
+async def test_ipykernel_install_retries_on_pep668(tmp_path):
+    """A PEP 668 'externally-managed' failure retries with --break-system-packages."""
+    sandbox = FakeSandbox()
+    pip_calls: list[tuple] = []
+
+    def fake_exec(*argv, **kw):
+        sandbox.exec_calls.append(argv)
+        if argv[:4] == ("python3", "-m", "pip", "install"):
+            pip_calls.append(argv)
+            if "--break-system-packages" not in argv:
+                return FakeResult(ok=False, exit_code=1, stderr="externally-managed-environment")
+            return FakeResult(ok=True)
+        if argv[1:3] == ("-c", "import ipykernel"):
+            return FakeResult(ok=False, exit_code=1)  # not installed -> triggers install
+        return FakeResult(ok=True)
+
+    sandbox.exec = fake_exec  # type: ignore[assignment]
+    prov, km = make_provisioner(tmp_path, sandbox)
+    kw = await prov.pre_launch(env={})
+    await prov.launch_kernel(kw.pop("cmd"), **kw)
+
+    assert len(pip_calls) == 2
+    assert "--break-system-packages" in pip_calls[1]
     await prov.cleanup()
 
 

--- a/jupyter_client/client.py
+++ b/jupyter_client/client.py
@@ -532,14 +532,18 @@ class KernelClient(ConnectionFileMixin):
         if output_hook is None and "IPython" in sys.modules:
             from IPython import get_ipython
 
-            ip = get_ipython()  # type:ignore[no-untyped-call]
+            ip = get_ipython()
             in_kernel = getattr(ip, "kernel", False)
             if in_kernel:
+                # In a kernel, ip.display_pub is a ZMQDisplayPublisher exposing
+                # session/pub_socket/parent_header. Narrow to Any for the type
+                # checker, since ip is typed as InteractiveShell | None here.
+                display_pub: t.Any = ip.display_pub  # type: ignore[union-attr]
                 output_hook = partial(
                     self._output_hook_kernel,
-                    ip.display_pub.session,
-                    ip.display_pub.pub_socket,
-                    ip.display_pub.parent_header,
+                    display_pub.session,
+                    display_pub.pub_socket,
+                    display_pub.parent_header,
                 )
         if output_hook is None:
             # default: redisplay plain-text outputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,7 +294,7 @@ ignore-property-decorators=true
 ignore-nested-functions=true
 ignore-nested-classes=true
 fail-under=90
-exclude = ["docs", "test"]
+exclude = ["docs", "test", "examples"]
 
 [tool.repo-review]
 ignore = ["GH102"]


### PR DESCRIPTION
## Add an example kernel provisioner (Tenki Sandbox microVMs)

This adds `examples/tenki_provisioner/` — a small but complete
`KernelProvisionerBase` implementation that launches each kernel inside a
disposable [Tenki Sandbox](https://tenki.cloud/docs/sandbox) Linux microVM
instead of on the local machine, and references it from `docs/provisioning.rst`
as a worked remote-provisioner example.

The docs currently describe provisioners with YARN/RBAC fragments; this provides
a runnable, tested end-to-end example of the pieces a real *remote* provisioner
needs (off-box launch, connection bridging, full process-control surface,
entry-point registration, kernelspec installer).

### How it works

A kernel exposes five ZeroMQ channels. Because the kernel runs in a microVM, the
provisioner drives it over the ZeroMQ **`ipc` transport**, so each channel is a
Unix-domain socket the kernel *binds* inside the guest. It stages two connection
files that are identical except for the socket-path prefix (client-side temp dir
vs. guest home), so the HMAC key and channel indices line up on both ends, then
bridges each local socket to the matching guest socket over the vendor SDK's
raw byte-stream primitive. No ssh, CLI, or inbound networking is required.

| `KernelProvisionerBase` method | Action |
| --- | --- |
| `pre_launch` | switch to `ipc`; stage local + guest connection files (restart reuses them) |
| `launch_kernel` | create microVM → install `ipykernel` → launch → bridge sockets (failure-atomic) |
| `poll` / `wait` | track the guest process handle |
| `send_signal` / `kill` / `terminate` | forward signals to the guest process |
| `cleanup` | close the bridge and terminate the microVM (retried; raised on failure) |

### What's included

- `tenki_provisioner/` — the provisioner, the socket bridge, and a
  `python -m tenki_provisioner.kernelspec install` helper
- `pyproject.toml` registering the `jupyter_client.kernel_provisioners`
  entry point, with a nested Ruff config that inherits the repo config
- unit tests (the remote backend is mocked) and a live end-to-end script
- a reference to the example from `docs/provisioning.rst`
- `examples/` added to the `interrogate` exclude list and a scoped CI workflow,
  since the example is not part of the shipped library

### Notes / scope

- The `ipc` transport uses Unix-domain sockets, so the machine running
  `jupyter_client` must be Linux/macOS (documented); the kernel is always Linux
  inside the microVM.
- Restart provisions a fresh microVM (guest state is not preserved). Kernel
  lifecycle is failure-atomic and has a configurable hard-duration backstop so a
  cancelled or crashed launch cannot leak a running VM.
- Cross-process reattach is intentionally not implemented.

### Testing

- Unit tests (SDK mocked): 11/11. `jupyter kernelspec provisioners` lists the
  provisioner.
- Live end-to-end against real infrastructure: a kernel starts in a microVM,
  executes code remotely (verified the hostname differs from the client and that
  `start_kernel(env=...)` values reach the guest), and the microVM is confirmed
  `TERMINATED` on shutdown.
